### PR TITLE
Bump jj2000 version

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -181,7 +181,7 @@ libraries["visad"] = "edu.wisc.ssec:visad:2.0-20130124"
 libraries["commons-lang3"] = "org.apache.commons:commons-lang3:3.4"
 
 //// GRIB
-libraries["jj2000"] = "edu.ucar:jj2000:5.3"
+libraries["jj2000"] = "edu.ucar:jj2000:5.4"
 
 // The easy HTTP client for Groovy (and Java). Used in buildSrc.
 libraries["http-builder-ng-okhttp"] = "io.github.http-builder-ng:http-builder-ng-okhttp:1.0.3"


### PR DESCRIPTION
This fixes an issue encountered when using netCDF-Java in a codebase utilizing Java modules. See Unidata/jj2000#10.