### PR TITLE
last doc changes

### DIFF
--- a/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
+++ b/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
@@ -271,5 +271,5 @@ entries:
       output: web, pdf
 
     - title: 5.0 Changes
-      url: /upgrade_to_5.html
+      url: /upgrade_to_50.html
       output: web, pdf

--- a/docs/src/public/userguide/_data/topnav.yml
+++ b/docs/src/public/userguide/_data/topnav.yml
@@ -14,23 +14,22 @@ topnav_dropdowns:
       folderitems:
         - title: netCDF-Java Github Repo
           external_url: https://github.com/Unidata/netcdf-java
-        - title: netCDF-Java Github Repo
+        - title: THREDDS Data Server Github Repo
           external_url: https://github.com/Unidata/tds
         - title: Rosetta Github Repo
           external_url: https://github.com/Unidata/Rosetta
         - title: Siphon Github Repo
           external_url: https://github.com/Unidata/siphon
-    - title: Tutorial
+
+    - title: Javadocs
       folderitems:
-        - title: THREDDS Data Server Tutorial
-          external_url: https://docs.unidata.ucar.edu/thredds/tds/5.0/userguide/tds_tutorial_index.html
-        - title: netCDF-Java Tutorial
-          url: /netcdf_java_tutorial_index.html
+        - title: netCDF-Java Public Javadocs
+          external_url: https://docs.unidata.ucar.edu/thredds/netcdf-java/5.0/javadoc/
 
     - title: External Docs
       folderitems:
-        - title: netCDF-Java public javadocs
-          external_url: https://docs.unidata.ucar.edu/thredds/netcdf-java/5.0/javadoc/
+        - title: THREDDS Data Server
+          external_url: https://docs.unidata.ucar.edu/thredds/tds/5.0/userguide/index.html
         - title: Rosetta
           external_url: https://www.unidata.ucar.edu/software/rosetta/docs/
         - title: Siphon

--- a/docs/src/public/userguide/pages/netcdfJava/CoverageFeatures.md
+++ b/docs/src/public/userguide/pages/netcdfJava/CoverageFeatures.md
@@ -1,7 +1,7 @@
 ---
 title: Coverage Datasets
 last_updated: 2018-04-02
-sidebar: tdsTutorial_sidebar
+sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: coverage_feature.html
 ---

--- a/docs/src/public/userguide/pages/netcdfJava/GribTablesCdm.md
+++ b/docs/src/public/userguide/pages/netcdfJava/GribTablesCdm.md
@@ -1,6 +1,6 @@
 ---
 title: GRIB Tables in CDM
-last_updated: 2019-07-10
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: grib_tables.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava/NcmlOverview.md
+++ b/docs/src/public/userguide/pages/netcdfJava/NcmlOverview.md
@@ -1,6 +1,6 @@
 ---
 title: NcML Overview
-last_updated: 2018-04-02
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: ncml_overview.html

--- a/docs/src/public/userguide/pages/netcdfJava/bufrtables.md
+++ b/docs/src/public/userguide/pages/netcdfJava/bufrtables.md
@@ -1,6 +1,6 @@
 ---
 title: The Common Data Model
-last_updated: 2019-06-27
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: bufr_tables.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava/cdmobjectnames.md
+++ b/docs/src/public/userguide/pages/netcdfJava/cdmobjectnames.md
@@ -1,6 +1,6 @@
 ---
 title: CDM Object Names
-last_updated: 2019-07-17
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: cdm_objectnames.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava/coordattributeconvention.md
+++ b/docs/src/public/userguide/pages/netcdfJava/coordattributeconvention.md
@@ -1,6 +1,6 @@
 ---
 title: _Coordinate Attribute Convention Reference 
-last_updated: 2019-06-27
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: coord_attr_conv.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava/developer/CdmRemote.md
+++ b/docs/src/public/userguide/pages/netcdfJava/developer/CdmRemote.md
@@ -1,6 +1,6 @@
 ---
 title: CDMRemote
-last_updated: 2018-10-10
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: cdmremote.html

--- a/docs/src/public/userguide/pages/netcdfJava/developer/CdmRemoteFeatureDatasets.md
+++ b/docs/src/public/userguide/pages/netcdfJava/developer/CdmRemoteFeatureDatasets.md
@@ -1,6 +1,6 @@
 ---
 title: CDMRemote Feature Datasets
-last_updated: 2018-10-10
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: cdmremote_feature_datasets.html

--- a/docs/src/public/userguide/pages/netcdfJava/developer/DocGuide.md
+++ b/docs/src/public/userguide/pages/netcdfJava/developer/DocGuide.md
@@ -1,6 +1,6 @@
 ---
 title: Documentation Guide
-last_updated: 2018-04-02
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: doc_guide.html

--- a/docs/src/public/userguide/pages/netcdfJava/developer/DocGuide.md
+++ b/docs/src/public/userguide/pages/netcdfJava/developer/DocGuide.md
@@ -46,7 +46,7 @@ Regenerating: 1 file(s) changed at 2018-10-08 17:10:10 ...done in 5.132 seconds.
 If there is an error in the markdown syntax, a message will appear on the command line, like so:
 
 ~~~bash
-{%raw%}Regenerating: 1 file(s) changed at 2018-10-08 17:14:34   Liquid Exception: Liquid error (line 2): Invalid syntax for include tag: ~~~ ## General Kramdown Syntax Jekyll uses kramdown, which is a superset of Markdown. General kramdown syntax can be found here: <https://kramdown.gettalong.org/syntax.html>){:target="_blank"} ## Documentation Theme for Jekyll We use the Documentation Theme for Jekyll. Information on how the theme works can be found here: <http://idratherbewriting.com/documentation-theme-jekyll/index.html>){:target="_blank"} ## Front Matter Each markdown file needs to start with some front matter: ~~~md title: Documentation Guide last_updated: 2016-09-27 sidebar: tdsTutorial_sidebar toc: false permalink: doc_guide.html ~~~ ## Headers All headings start off as level 2. The `title` set in the front matter will be displayed at the top of the rendered html page and uses the level 1 heading. Headings, and their level number, are denoted by the number of hashtags on a line: # level 1 ## level 2 ### level 3 ~~~md # level 1 ## level 2 ### level 3 ~~~ ## netCDF-Java, TDS jargon italicize TDS specific jargon on first use: _catalog roots_ _client catalog_ _configuration catalog_ ~~~md _catalog roots_ _client catalog_ _configuration catalog_ ~~~ inline text html, xml elements, properties, code variables, snippits, file paths, surround in back ticks, like this: `<catalog>` ~~~md `<catalog>` ~~~ ## Keeping git diffs clean One line of text per line in file blank line needed for new paragraph, so no formatting issue in doing this. this keeps git diff clean ~~~md One line of text per line in file blank line needed for new paragraph, so no formatting issue in doing this. this keeps git diff clean ~~~ ## links General format is: ~~~md [text of link](url){:target="_blank"} ~~~ When linking between markdown files, the `url` will be the permalink defined in the front matter of the markdown file you wish to link to. ## highlight blocks These templates under the top level `_includes/` directory. Here is what we have right now: {%include troubleshooting.html content=" Troubleshooting block. " Valid syntax: {% include file.ext param='value' param2='value' %} in pages/netcdfJava/developer/DocGuide.md block. "{%endraw%}
+{%raw%}Regenerating: 1 file(s) changed at 2018-10-08 17:14:34   Liquid Exception: Liquid error (line 2): Invalid syntax for include tag: ~~~ ## General Kramdown Syntax Jekyll uses kramdown, which is a superset of Markdown. General kramdown syntax can be found here: <https://kramdown.gettalong.org/syntax.html>){:target="_blank"} ## Documentation Theme for Jekyll We use the Documentation Theme for Jekyll. Information on how the theme works can be found here: <http://idratherbewriting.com/documentation-theme-jekyll/index.html>){:target="_blank"} ## Front Matter Each markdown file needs to start with some front matter: ~~~md title: Documentation Guide last_updated: 2016-09-27 sidebar: netcdfJavaTutorial_sidebar toc: false permalink: doc_guide.html ~~~ ## Headers All headings start off as level 2. The `title` set in the front matter will be displayed at the top of the rendered html page and uses the level 1 heading. Headings, and their level number, are denoted by the number of hashtags on a line: # level 1 ## level 2 ### level 3 ~~~md # level 1 ## level 2 ### level 3 ~~~ ## netCDF-Java, TDS jargon italicize TDS specific jargon on first use: _catalog roots_ _client catalog_ _configuration catalog_ ~~~md _catalog roots_ _client catalog_ _configuration catalog_ ~~~ inline text html, xml elements, properties, code variables, snippits, file paths, surround in back ticks, like this: `<catalog>` ~~~md `<catalog>` ~~~ ## Keeping git diffs clean One line of text per line in file blank line needed for new paragraph, so no formatting issue in doing this. this keeps git diff clean ~~~md One line of text per line in file blank line needed for new paragraph, so no formatting issue in doing this. this keeps git diff clean ~~~ ## links General format is: ~~~md [text of link](url){:target="_blank"} ~~~ When linking between markdown files, the `url` will be the permalink defined in the front matter of the markdown file you wish to link to. ## highlight blocks These templates under the top level `_includes/` directory. Here is what we have right now: {%include troubleshooting.html content=" Troubleshooting block. " Valid syntax: {% include file.ext param='value' param2='value' %} in pages/netcdfJava/developer/DocGuide.md block. "{%endraw%}
 ~~~
 
 Note that these errors are often cryptic, so it is a good idea to save and force Jekyll to regenerate often.
@@ -72,7 +72,7 @@ Each markdown file needs to start with some front matter:
 ~~~md
 title: Documentation Guide
 last_updated: 2016-09-27
-sidebar: tdsTutorial_sidebar
+sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: doc_guide.html
 ~~~
@@ -316,7 +316,7 @@ For example, `pages/tds_tutorial/developer/DocGuide.md`
 ---
 title: Documentation Guide
 last_updated: 2017-02-17
-sidebar: tdsTutorial_sidebar
+sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: tds_doc_guide.html
 ---

--- a/docs/src/public/userguide/pages/netcdfJava/developer/FeatureDatasets.md
+++ b/docs/src/public/userguide/pages/netcdfJava/developer/FeatureDatasets.md
@@ -1,6 +1,6 @@
 ---
 title: CDM Feature Datasets
-last_updated: 2018-10-10
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: feature_datasets.html

--- a/docs/src/public/userguide/pages/netcdfJava/faq.md
+++ b/docs/src/public/userguide/pages/netcdfJava/faq.md
@@ -1,6 +1,6 @@
 ---
 title: Frequently Asked Questions
-last_updated: 2019-07-10
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: faq.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava/horizcoordtranforms.md
+++ b/docs/src/public/userguide/pages/netcdfJava/horizcoordtranforms.md
@@ -1,6 +1,6 @@
 ---
 title: Standard Horizontal Coordinate Transforms 
-last_updated: 2019-06-27
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: std_horizonal_coord_transforms.html
 toc: false
@@ -51,7 +51,7 @@ where the x,y values in this equation are the ones that you put into the x and y
 
 #### Resources
 
-* Standard vertical transforms are documented on this page. You can also [implement your own](coord_system_builder.html).
+* Standard horizontal transforms are documented on this page. You can also [implement your own](coord_system_builder.html).
 * You may also be interested in [Standard Vertical Coordinate Transforms](std_vertical_coord_transforms.html).
 * The [CDM _Coordinate Conventions](coord_attr_conv.html)
 

--- a/docs/src/public/userguide/pages/netcdfJava/ncmlschema.md
+++ b/docs/src/public/userguide/pages/netcdfJava/ncmlschema.md
@@ -1,6 +1,6 @@
 ---
 title: Annotated Schema for NcML
-last_updated: 2019-07-11
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: annotated_ncml_schema.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava/vertcoordtransforms.md
+++ b/docs/src/public/userguide/pages/netcdfJava/vertcoordtransforms.md
@@ -1,8 +1,257 @@
 ---
 title: Standard Vertical Coordinate Transforms
-last_updated: 2019-06-27
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: std_vertical_coord_transforms.html
 toc: false
 ---
-## THe current one is a duplicate of the horiontal one......?????
+
+
+This page documents the vertical coordinate transforms that are standard in CDM. 
+These follow the [CF-1.0 Convention](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.6/build/cf-conventions.html#appendix-grid-mappings){:target="_blank"}, where they are called Dimensionless Vertical Coordinates.
+The purpose of a vertical transform is to define a function to calculate the pressure or height coordinate of each grid point in a data variable.
+This typically creates a 3D vertical coordinate, one which varies at each grid point.
+The dimensionless vertical coordinate in contrast, is 1 dimensional, and thus easier to work with and smaller to store in the file.
+
+To follow CF, typically one adds transform information to the vertical coordinate, for example:
+
+~~~
+double s_rho(s_rho=20);
+  :long_name = "S-coordinate at RHO-points";
+  :valid_min = -1.0; // double
+  :valid_max = 0.0; // double
+
+  :standard_name = "ocean_s_coordinate";
+  :positive = "up";
+  :formula_terms = "s: s_rho eta: zeta depth: h a: theta_s b: theta_b depth_c: hc";
+~~~
+
+This example is a CF `ocean_s_coordinate` vertical coordinate.
+The formula terms, explained in the CF doc, point to variables in the same file, which the calculation needs:
+
+~~~
+Definition:
+  z(n,k,j,i) = eta(n,j,i)*(1+s(k)) + depth_c*s(k) +  (depth(j,i)-depth_c)*C(k)  
+~~~
+
+So in this example, anywhere you see `s(k)` in the definition, one uses the variable `s_rho` in the calculation.
+Similarly for the rest:
+
+~~~
+Definition term		actual variable name
+---------------		-------------------
+s 					s_rho 
+eta 					zeta 
+depth 				h 
+a 					theta_s 
+b 					theta_b 
+depth_c 				hc
+~~~
+
+All of these variables must exist in your file, and be the proper dimension etc, as spelled out in the CF doc.
+Note that the file writer must construct the `formula_terms` attribute with the correct variable names.
+The CDM, as well as other software that implements this part of the CF spec, will use the above information to calculate the 3D vertical coordinate.
+
+This 3D vertical coordinate can be obtained in the CDM library by opening the file as a `NetcdfDataset`, and examining the `CoordinateSystem` attached to each `VariableDS`.
+Look through the transforms from `CoordinateSystem.getCoordinateTransforms()` for the vertical transform (class `ucar.nc2.dataset.VerticalCT`).
+For performance, the actual work is not done until you call `VerticalTransform vy = VerticalCT.makeVerticalTransform()`, and then `VerticalTransform.getCoordinateArray()` to get the 3D coordinate array.
+
+To summarize, in order for CF Vertical transforms to work in the CDM, you must:
+
+* Add the `standard_name`, `positive`, and `formula_terms` attributes to the vertical ccoordinate.
+* Add to your file all the variables required by the transform definition.
+* If you are writing your own software that needs the 3D pressure/height values, follow the above steps to retrieve the 3D vertical coordinate.
+
+### Resources
+
+* Standard vertical transforms are documented on this page. You can also [implement your own](coord_transform.html#implementing-a-verticaltransform).
+* You may also be interested in [Standard Horizontal Coordinate Transforms](std_horizonal_coord_transforms.html).
+* The CDM [_Coordinate Conventions](coord_attr_conv.html)
+
+## Standard Vertical Transforms
+
+Attribute names follow the CF Conventions Appendix D ([Vertical Transforms](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.6/build/cf-conventions.html#dimensionless-v-coord){:target="_blank"})) and Appendix F ([Grid Mappings](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.6/build/cf-conventions.html#appendix-grid-mappings){:target="_blank"}).
+See that document for details on the meanings of the formula terms.
+
+These are examples of placing the Coordinate Transform parameters on the corresponding vertical coordinate (required by CF).
+If you are using CF Conventions, you do not have to add the _Coordinate attributes, as they will be added automatically in the CoordSysBuilder.
+
+### atmosphere_ln_pressure_coordinate
+
+~~~
+double levCoord(levCoord=26);
+    :long_name = "log pressure levels";
+    :units = "";
+    :positive = "down";
+    :standard_name = "atmosphere_ln_pressure_coordinate";
+    :formula_terms = "p0: P0 lev: levCoord";
+~~~
+  
+atmosphere_ln_pressure_coordinate transform only works in CF Conventions.
+Required attributes: `standard_name`, `formula_terms`
+
+### atmosphere_hybrid_height_coordinate
+
+~~~
+double lev(lev=26);
+    :long_name = "hybrid hybrid height coordinate";
+    :units = "m";
+    :positive = "up";
+    :standard_name = "atmosphere_hybrid_height_coordinate";
+    :formula_terms = "a: varA b: varB orog: orography";
+    :_CoordinateAxisType = "GeoZ";
+    :_CoordinateZisPositive = "up;
+    :_CoordinateTransformType = "Vertical";
+    :_CoordinateAxes = "lev";
+~~~
+
+Required attributes: `standard_name`, `formula_terms`, `_CoordinateTransformType`, `_CoordinateAxes`
+
+### atmosphere_hybrid_sigma_pressure_coordinate
+
+~~~
+double lev(lev=26);
+    :long_name = "hybrid level at midpoints (1000*(A+B))";
+    :units = "";
+    :positive = "down";
+    :standard_name = "atmosphere_hybrid_sigma_pressure_coordinate";
+    :formula_terms = "a: hyam b: hybm p0: P0 ps: PS";
+    :_CoordinateAxisType = "GeoZ";
+    :_CoordinateZisPositive = "down;
+    :_CoordinateTransformType = "Vertical";
+    :_CoordinateAxes = "lev";
+~~~
+
+Required attributes: `standard_name`, `formula_terms`, `_CoordinateTransformType`, `_CoordinateAxes`
+
+or
+
+~~~
+double lev(lev=26);
+    :long_name = "hybrid level at midpoints (1000*(A+B))";
+    :units = "";
+    :positive = "down";
+    :standard_name = "atmosphere_hybrid_sigma_pressure_coordinate";
+    :formula_terms = "ap: hyam b: hybm p0: P0";
+    :_CoordinateAxisType = "GeoZ";
+    :_CoordinateZisPositive = "down;
+    :_CoordinateTransformType = "Vertical";
+    :_CoordinateAxes = "lev";
+~~~
+
+Required attributes: `standard_name`, `formula_terms`, `_CoordinateTransformType`, `_CoordinateAxes`
+
+### atmosphere_sigma_coordinate
+
+~~~
+float level(level=2);
+    :units = "";
+    :long_name = "sigma at layer midpoints";
+    :positive = "down";
+    :standard_name = "atmosphere_sigma_coordinate";
+    :formula_terms = "sigma: level ps: PS ptop: PTOP";
+    :_CoordinateAxisType = "GeoZ";
+    :_CoordinateZisPositive = "down";
+    :_CoordinateTransformType = "Vertical";
+    :_CoordinateAxes = "level";
+~~~
+
+Required attributes: `standard_name`, `formula_terms`, `_CoordinateTransformType`, `_CoordinateAxes`
+
+### ocean_s_coordinate
+
+~~~ 
+double s_rho(s_rho=20);
+    :long_name = "S-coordinate at RHO-points";
+    :units = "";
+    :positive = "up";
+    :standard_name = "ocean_s_coordinate";
+    :formula_terms = "s: s_rho eta: zeta depth: h a: theta_s b: theta_b depth_c: hc";
+    :_CoordinateAxisType = "GeoZ";
+    :_CoordinateZisPositive = "up"; 
+    :_CoordinateTransformType = "Vertical";
+    :_CoordinateAxes = "s_rho";
+~~~
+
+Required attributes: `standard_name`, `formula_terms`, `_CoordinateTransformType`, `_CoordinateAxes`
+
+### ocean_s_coordinate_g1
+
+~~~
+char OceanSG1_Transform_s_rho;
+    :standard_name = "ocean_s_coordinate_g1";
+    :formula_terms = "s: s_rho C: Cs_r eta: zeta depth: h depth_c: hc";
+    :height_formula = "height(x,y,z) =  depth_c*s(z) + (depth([n],x,y)-depth_c)*C(z) + eta(x,y)*(1+(depth_c*s(z) + (depth([n],x,y)-depth_c)*C(z))/depth([n],x,y))";
+    :Eta_variableName = "zeta";
+    :S_variableName = "s_rho";
+    :Depth_variableName = "h";
+    :Depth_c_variableName = "hc";
+    :c_variableName = "Cs_r";
+~~~
+
+Required attributes: `standard_name`, `formula_terms`
+The other are added for extra readability.
+
+### ocean_s_coordinate_g2
+
+~~~
+char OceanSG2_Transform_s_rho;
+    :standard_name = "ocean_s_coordinate_g2";
+    :formula_terms = "s: s_rho C: Cs_r eta: zeta depth: h depth_c: hc";
+    :height_formula = "height(x,y,z) = eta(x,y) + (eta(x,y) + depth([n],x,y)) * ((depth_c*s(z) + depth([n],x,y)*C(z))/(depth_c+depth([n],x,y)))";
+    :Eta_variableName = "zeta";
+    :S_variableName = "s_rho";
+    :Depth_variableName = "h";
+    :Depth_c_variableName = "hc";
+    :c_variableName = "Cs_r";
+~~~
+Required attributes: `standard_name`, `formula_terms`.
+The other are added for extra readability.
+
+### ocean_sigma_coordinate
+
+~~~
+float zpos(zpos=22);
+    :long_name = "Sigma Layer";
+    :units = "";
+    :positive = "up";
+    :standard_name = "ocean_sigma_coordinate";
+    :formula_terms = "sigma: zpos eta: elev depth: depth";
+    :_CoordinateAxisType = "GeoZ";
+    :_CoordinateZisPositive = "up";
+    :_CoordinateTransformType = "Vertical";
+    :_CoordinateAxes = "zpos";
+~~~
+
+Required attributes: `standard_name`, `formula_terms`, `_CoordinateTransformType`, `_CoordinateAxes`
+
+### explicit_field
+
+~~~
+char ExplicitField;
+    :standard_name = "explicit_field";  // canonical transform name
+    :existingDataField = "ght_hybr";  // must be a 3 or 4D pressure / height / geopotential height field
+    :_CoordinateTransformType = "vertical"; // unambiguouly identifies it as vertical transform
+    :_CoordinateAxes = "hybr"; // attach transform to any coord sys with the "hbyr" axis.
+~~~
+
+Required attributes: `standard_name`, `existingDataField`,  `_CoordinateTransformType`, `_CoordinateAxes`
+This is not part of CF, but a way to mark an existing 3D (4D if time dependent) field as the vertical coordinate.
+
+## Using Vertical Transforms
+
+~~~java
+public void testAtmHybrid() throws java.io.IOException, InvalidRangeException {
+  GridDataset gds = ucar.nc2.dt.grid.GridDataset.open( TestAll.cdmUnitTestDir + "conventions/cf/ccsm2.nc"); 
+  GridDatatype grid = gds.findGridDatatype("T");
+  GridCoordSystem gcs = grid.getCoordinateSystem();
+
+  VerticalTransform vt = gcs.getVerticalTransform();
+  CoordinateAxis1DTime taxis = gcs.getTimeAxis1D();
+  for (int t=0; t<taxis.getSize(); t++) {
+    System.out.printf("vert coord for time = %s%n", taxis.getTimeDate(t));
+    ArrayDouble.D3 ca = vt.getCoordinateArray(t);
+    doSomething(ca);
+  }
+}
+~~~

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/cdmdatasets/netcdfdataset.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/cdmdatasets/netcdfdataset.md
@@ -1,6 +1,6 @@
 ---
-title: The Common Data Model
-last_updated: 2019-06-27
+title: NetcdfDataset
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: netcdf_dataset.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/cdmdatasets/readingcdm.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/cdmdatasets/readingcdm.md
@@ -1,6 +1,6 @@
 ---
-title: The Common Data Model
-last_updated: 2019-06-27
+title: NetcdfFile
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: reading_cdm.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/cdmdatasets/writing_netcdf.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/cdmdatasets/writing_netcdf.md
@@ -1,6 +1,6 @@
 ---
-title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+title: Writing netCDF
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: writing_netcdf.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/coordsystems/coord_system_builder.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/coordsystems/coord_system_builder.md
@@ -1,6 +1,6 @@
 ---
-title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+title: Coordinate System Builder
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 permalink: coord_system_builder.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/coordsystems/coord_transform.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/coordsystems/coord_transform.md
@@ -1,6 +1,6 @@
 ---
-title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+title: Coordinate Transforms
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: coord_transform.html
 toc: false
@@ -14,7 +14,7 @@ A <b>_Coordinate Transform_</b> represents a mathematical function that transfor
 
 A <b>_Coordinate System_</b> may have 0 or more <b>_Coordinate Transforms_</b>, each of which is either a <b>_ProjectionCT_</b> containing a <b>_ucar.unidata.geoloc.Projection_</b> or a <b>_VerticalCT_</b> containing a <b>_ucar.unidata.geoloc.vertical.VerticalTransform_</b>:
 
-{% include image.html file="netcdf-java/tutorial/CoordSys.png" alt="Coord Sys Object Model" caption="" %}
+{% include image.html file="netcdf-java/tutorial/coordsystems/CoordSys.png" alt="Coord Sys Object Model" caption="" %}
 
 The Netcdf-Java library implements a standard set of <b>_ucar.unidata.geoloc.Projection_</b> and <b>_ucar.unidata.geoloc.vertical.VerticalTransform_</b> classes, following the specifications of the <a href="http://cfconventions.org/" target="_blank">CF-1.0 Conventions</a>.
 

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/coordsystems/coordattribute.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/coordsystems/coordattribute.md
@@ -1,6 +1,6 @@
 ---
 title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 permalink: coord_attribute_ex.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/featuretypes/GridDatasets.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/featuretypes/GridDatasets.md
@@ -1,6 +1,6 @@
 ---
 title: Grid Datasets
-last_updated: 2019-06-28
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: grid_datasets.html

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/featuretypes/feat_types.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/featuretypes/feat_types.md
@@ -1,6 +1,6 @@
 ---
 title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 permalink: feature_types.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/overview/BuildingFromSource.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/overview/BuildingFromSource.md
@@ -1,6 +1,6 @@
 ---
 title: Building From Source
-last_updated: 2018-04-02
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: building_from_source.html
 toc: false
@@ -8,28 +8,30 @@ toc: false
 
 ## Assembly
 
-THREDDS source code is hosted on GitHub, and—as of v4.6.1—we use Gradle to build it.
+The netCDF-Java source code is hosted on GitHub, and — as of v4.6.1 — we use Gradle to build it.
 Ant and Maven builds are no longer supported.
-THREDDS includes the NetCDF-Java client libraries, the TDS server, the TDM indexer, and other related packages.
 To build, you need Git and JDK 8 installed (building with JDK > 8 is not yet supported, but is being addressed).
 
-First, clone the THREDDS repository from Github:
+First, clone the netCDF-Java repository from Github:
 
 ~~~bash
-git clone git://github.com/Unidata/thredds.git thredds
+git clone -o unidata https://github.com/Unidata/netcdf-java.git netcdf-java
 ~~~
 
-You’ll have a new folder named thredds in your working directory. Change into it:
+You’ll have a new folder named netcdf-java in your working directory.
+The default name of a remote repository is `origin`.
+We used the `-o` flag to rename it to `unidata` to keep things clear.
+Change into the netcdf-java directory:
 
 ~~~bash
-cd thredds
+cd netcdf-java
 ~~~
 
-By default, the current branch head is set to 5.0, which is our main development branch.
-If you’d like to build a released version instead—v4.6.2, for example, you’ll need to checkout that version:
+By default, the current branch head is set to master, which is our main development branch.
+If you’d like to build a released version instead — v5.0.0, for example, you’ll need to checkout that version:
 
 ~~~bash
-git checkout v4.6.2
+git checkout v5.0.0
 ~~~
 
 Next, use the Gradle wrapper to execute the assemble task:
@@ -39,15 +41,16 @@ Next, use the Gradle wrapper to execute the assemble task:
 ~~~
 
 There will be various artifacts within the `<subproject>/build/libs/` subdirectories.
-For example, the TDS WAR file will be in tds/build/libs/.
+For example, the `cdm.jar` file will be in `cdm/build/libs/`.
 The uber jars, such as `toolsUI.jar` and `netcdfAll.jar`, will be found in `build/libs/`.
 
 ## Publishing
 
-NetCDF-Java is comprised of several modules, many of which you can use within your own projects, as described here.
+NetCDF-Java is comprised of several modules, many of which you can use within your own projects, as described [here](using_netcdf_java_artifacts.html).
 At Unidata, we publish the artifacts that those modules generate to our Nexus repository.
 
-However, it may happen that you need artifacts for the in-development version of THREDDS, which we usually don’t upload to Nexus. 
+However, it may happen that you need artifacts for the in-development version of netCDF-Java in your local branch, which we usually don’t upload to Nexus.
+We do publish nightly SNAPSHOTS, but those may not have the develoment changes you are currently working on. 
 Never fear: you can build them yourself and publish them to your local Maven repository!
 
 ~~~
@@ -57,5 +60,5 @@ git checkout master
 
 You will find the artifacts in `~/.m2/repository/edu/ucar/`.
 If you’re building your projects using Maven, artifacts in your local repo will be preferred over remote ones by default; you don’t have to do any additional configuration in order for them to be picked up.
-If you’re building with Gradle, you’ll need to do [a little more work](https://docs.gradle.org/current/userguide/dependency_management.html#sub:maven_local){:target="_blank"}.
+If you’re building with Gradle, you’ll need to do [a little more work](https://docs.gradle.org/current/userguide/repository_types.html#sub:maven_local){:target="_blank"}.
 

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/overview/CommonDataModel.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/overview/CommonDataModel.md
@@ -1,6 +1,6 @@
 ---
 title: The Common Data Model
-last_updated: 2019-06-27
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar 
 permalink: common_data_model_overview.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/overview/UsingNetcdfJava.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/overview/UsingNetcdfJava.md
@@ -1,6 +1,6 @@
 ---
 title: Using netCDF-Java Maven Artifacts
-last_updated: 2019-07-22
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: using_netcdf_java_artifacts.html
 toc: false
@@ -8,7 +8,7 @@ toc: false
 
 ## Using netCDF-Java Maven Artifacts
 
-We make the NetCDF-Java library available as Maven artifacts.
+We make the netCDF-Java library available as Maven artifacts.
 To use them in your build, you need to add the Unidata Releases repository:
 
 ~~~xml
@@ -20,6 +20,9 @@ To use them in your build, you need to add the Unidata Releases repository:
         <url>https://artifacts.unidata.ucar.edu/repository/unidata-all/</url>
     </repository>
 </repositories>
+~~~
+
+~~~groovy
 // In Gradle
 repositories {
     maven {

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/runtime/runtimeloading.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/runtime/runtimeloading.md
@@ -1,6 +1,6 @@
 ---
 title: Runtime Loading
-last_updated: 2019-06-27
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 permalink: runtime_loading.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/dmsp_example.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/dmsp_example.md
@@ -1,6 +1,6 @@
 ---
 title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+last_updated: 2019-07-22
 sidebar: netcdfJavaTutorial_sidebar
 permalink: dmsp_example.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/iospdetails.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/iospdetails.md
@@ -1,6 +1,6 @@
 ---
-title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+title: Writing an IOSP - Details
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: iosp_details.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/lightning_example.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/lightning_example.md
@@ -1,6 +1,6 @@
 ---
-title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+title: Writing an IOSP - Example
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: lightning_example.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/otherclasses.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/otherclasses.md
@@ -1,6 +1,6 @@
 ---
-title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+title: Writing an IOSP - Other Classes
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: other_classes.html
 toc: false

--- a/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/overview_iosp.md
+++ b/docs/src/public/userguide/pages/netcdfJava_tutorial/writingiosp/overview_iosp.md
@@ -1,6 +1,6 @@
 ---
-title: Coordinate Attribute Examples
-last_updated: 2019-06-27
+title: Writing an IOSP - Overview
+last_updated: 2019-07-23
 sidebar: netcdfJavaTutorial_sidebar
 permalink: writing_iosp.html
 toc: false


### PR DESCRIPTION
Last round of doc changes before release. Note that the netcdf-java docs have been moved from a collection of Dreamweaver generated HTML to markdown managed by Jekyll using the documentation theme. There will be more issues, I'm sure, but the major lifting should be done.