### PR TITLE
A temporary change troubleshooting a Jenkins test hang, seeing an infinite loop.

### DIFF
--- a/cdm/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFile.java
@@ -681,9 +681,15 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
             break;
 
           } catch (OverlappingFileLockException oe) { // not sure why lock() doesnt block
+            //hvandam2
+            System.out.println("NetcdfFile.java Line 684, OFLE msg: " + oe.getMessage());
+            oe.printStackTrace(System.out);
             try {
               Thread.sleep(100); // msecs
             } catch (InterruptedException e1) {
+              //hvandam2
+              System.out.println("NetcdfFile.java Line 688, IE msg: " + oe.getMessage());
+              e1.printStackTrace(System.out);
               break;
             }
           }
@@ -715,9 +721,15 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
           break;
 
         } catch (OverlappingFileLockException oe) { // not sure why lock() doesnt block
+          //hvandam2
+          System.out.println("NetcdfFile.java Line 720, OFLE msg: " + oe.getMessage() + oe);
+          oe.printStackTrace(System.out);
           try {
             Thread.sleep(100); // msecs
           } catch (InterruptedException e1) {
+            //hvandam2
+            System.out.println("NetcdfFile.java Line 724, IE msg: " + oe.getMessage());
+            e1.printStackTrace(System.out);
           }
         }
       }


### PR DESCRIPTION
A temporary change troubleshooting a Jenkins test hang, seeing an infinite loop
after "InterruptedException=sleep interrupted" during TestNetcdfFileCache > testPeriodicClear.
Adding some output statements to dump stacktraces to the console.