### PR TITLE
Change elements with both nav and affix CSS classes to position:unset…

### DIFF
--- a/docs/src/public/userguide/css/customstyles.css
+++ b/docs/src/public/userguide/css/customstyles.css
@@ -459,6 +459,11 @@ ul#mysidebar {
   padding-left: 10px;
 }
 
+.nav.affix {
+  /* DD note: bootstrap.css sets this to fixed, which causes the menu to extend below the footer */
+  position:unset;
+}
+
 
 /* end sidebar */
 


### PR DESCRIPTION
Unset positioning for elements with css classes 'nav' and 'affix'; overrides 'affix' class setting in bootstrap.css for navgoco menu, so the menu no longer extends below the footer.