### PR TITLE
remove unneeded throws Exceptions

### DIFF
--- a/cdm/src/main/java/thredds/client/catalog/CatalogRef.java
+++ b/cdm/src/main/java/thredds/client/catalog/CatalogRef.java
@@ -98,20 +98,15 @@ public class CatalogRef extends Dataset {
 
   @Override
   public List<Dataset> getDatasetsLogical() {
-    try {
-      ucar.nc2.util.Optional<DatasetNode> opt = readCatref();
-      if (!opt.isPresent())
-        throw new RuntimeException(opt.getErrorMessage());
+    ucar.nc2.util.Optional<DatasetNode> opt = readCatref();
+    if (!opt.isPresent())
+      throw new RuntimeException(opt.getErrorMessage());
 
-      DatasetNode proxy = opt.get();
-      return proxy.getDatasets();
-
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    DatasetNode proxy = opt.get();
+    return proxy.getDatasets();
   }
 
-  public synchronized ucar.nc2.util.Optional<DatasetNode> readCatref() throws IOException {
+  public synchronized ucar.nc2.util.Optional<DatasetNode> readCatref() {
     if (proxy != null)
       return ucar.nc2.util.Optional.of(proxy);
 

--- a/cdm/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
+++ b/cdm/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
@@ -45,7 +45,7 @@ public class CatalogBuilder {
   protected Formatter errlog = new Formatter();
   protected boolean fatalError = false;
 
-  public Catalog buildFromLocation(String location, URI baseURI) throws IOException {
+  public Catalog buildFromLocation(String location, URI baseURI) {
     location = StringUtil2.replace(location, "\\", "/");
 
     if (baseURI == null) {
@@ -65,13 +65,13 @@ public class CatalogBuilder {
     return fatalError ? null : makeCatalog();
   }
 
-  public Catalog buildFromURI(URI uri) throws IOException {
+  public Catalog buildFromURI(URI uri) {
     this.baseURI = uri;
     readXML(uri);
     return fatalError ? null : makeCatalog();
   }
 
-  public Catalog buildFromCatref(CatalogRef catref) throws IOException {
+  public Catalog buildFromCatref(CatalogRef catref) {
     URI catrefURI = catref.getURI();
     if (catrefURI == null) {
       errlog.format("Catref doesnt have valid UrlPath=%s%n", catref.getUrlPath());
@@ -85,13 +85,13 @@ public class CatalogBuilder {
     return fatalError ? null : result;
   }
 
-  public Catalog buildFromString(String catalogAsString, URI docBaseUri) throws IOException {
+  public Catalog buildFromString(String catalogAsString, URI docBaseUri) {
     this.baseURI = docBaseUri;
     readXMLfromString(catalogAsString);
     return fatalError ? null : makeCatalog();
   }
 
-  public Catalog buildFromStream(InputStream stream, URI docBaseUri) throws IOException {
+  public Catalog buildFromStream(InputStream stream, URI docBaseUri) {
     this.baseURI = docBaseUri;
     readXML(stream);
     return fatalError ? null : makeCatalog();

--- a/cdm/src/main/java/thredds/client/catalog/tools/CatalogCrawler.java
+++ b/cdm/src/main/java/thredds/client/catalog/tools/CatalogCrawler.java
@@ -233,19 +233,13 @@ public class CatalogCrawler {
 
   private Catalog readCatref(CatalogRef catref, PrintWriter out, Indent indent) {
     CatalogBuilder builder = new CatalogBuilder();
-    try {
-      Catalog cat = builder.buildFromCatref(catref);
-      if (builder.hasFatalError() || cat == null) {
-        if (out != null) out.printf("%sError reading catref %s err=%s%n", indent, catref.getName(), builder.getErrorMessage());
-        return null;
-      }
-      return cat;
-    } catch (IOException e) {
-      if (out != null) out.printf("%sError reading catref %s err=%s%n", indent, catref.getName(), e.getMessage());
+    Catalog cat = builder.buildFromCatref(catref);
+    if (builder.hasFatalError() || cat == null) {
+      if (out != null) out.printf("%sError reading catref %s err=%s%n", indent, catref.getName(), builder.getErrorMessage());
+      return null;
     }
-    return null;
+    return cat;
   }
-
 
   private Dataset chooseRandom(List datasets) {
     int index = random.nextInt(datasets.size());

--- a/cdm/src/main/java/thredds/client/catalog/tools/DataFactory.java
+++ b/cdm/src/main/java/thredds/client/catalog/tools/DataFactory.java
@@ -137,7 +137,7 @@ public class DataFactory {
     return openFeatureDataset(wantFeatureType, ds, task, result);
   }
 
-  private Dataset openCatalogFromLocation(String location, ucar.nc2.util.CancelTask task, Result result) throws IOException {
+  private Dataset openCatalogFromLocation(String location, ucar.nc2.util.CancelTask task, Result result) {
     location = location.trim();
     location = StringUtil2.replace(location, '\\', "/");
 
@@ -572,7 +572,7 @@ public class DataFactory {
     return access;
   }
 
-  private Dataset openResolver(String urlString, ucar.nc2.util.CancelTask task, Result result) throws IOException {
+  private Dataset openResolver(String urlString, ucar.nc2.util.CancelTask task, Result result) {
     CatalogBuilder catFactory = new CatalogBuilder();
     Catalog catalog = catFactory.buildFromLocation(urlString, null);
     if (catalog == null) {
@@ -637,7 +637,7 @@ public class DataFactory {
 
 // look for an access method for an image datatype
 
-  private Access getImageAccess(Dataset ds, ucar.nc2.util.CancelTask task, Result result) throws IOException {
+  private Access getImageAccess(Dataset ds, ucar.nc2.util.CancelTask task, Result result) {
 
     List<Access> accessList = new ArrayList<>(ds.getAccess()); // a list of all the accesses
     while (accessList.size() > 0) {

--- a/cdm/src/main/java/thredds/inventory/CollectionManagerAbstract.java
+++ b/cdm/src/main/java/thredds/inventory/CollectionManagerAbstract.java
@@ -21,7 +21,7 @@ import java.util.*;
 public abstract class CollectionManagerAbstract extends CollectionAbstract implements CollectionManager  {
 
     // called from Aggregation, Fmrc, FeatureDatasetFactoryManager
-  static public CollectionManager open(String collectionName, String collectionSpec, String olderThan, Formatter errlog) throws IOException {
+  static public CollectionManager open(String collectionName, String collectionSpec, String olderThan, Formatter errlog) {
     if (collectionSpec.startsWith(CATALOG))
       return new CollectionManagerCatalog(collectionName, collectionSpec, olderThan, errlog);
     else

--- a/cdm/src/main/java/thredds/inventory/partition/DirectoryPartition.java
+++ b/cdm/src/main/java/thredds/inventory/partition/DirectoryPartition.java
@@ -104,7 +104,7 @@ public class DirectoryPartition extends CollectionAbstract implements PartitionM
   }
 
   @Override
-  public CloseableIterator<MFile> getFileIterator() throws IOException {
+  public CloseableIterator<MFile> getFileIterator() {
     return new MFileIterator( getFilesSorted().iterator(), null);
   }
 

--- a/cdm/src/main/java/ucar/atd/dorade/DoradeDescriptor.java
+++ b/cdm/src/main/java/ucar/atd/dorade/DoradeDescriptor.java
@@ -285,7 +285,7 @@ abstract class DoradeDescriptor {
   protected static long findNextWithName(String expectedName,
                                          RandomAccessFile file,
                                          boolean littleEndianData)
-          throws DescriptorException, java.io.IOException {
+          throws DescriptorException {
 
     //
     // Skip forward through the file until we find a descriptor with
@@ -307,7 +307,7 @@ abstract class DoradeDescriptor {
   }
 
   protected long findNext(RandomAccessFile file)
-          throws DescriptorException, java.io.IOException {
+          throws DescriptorException {
     return findNextWithName(expectedName, file, littleEndianData);
   }
 

--- a/cdm/src/main/java/ucar/atd/dorade/DoradeRDAT.java
+++ b/cdm/src/main/java/ucar/atd/dorade/DoradeRDAT.java
@@ -46,7 +46,7 @@ class DoradeRDAT extends DoradeDescriptor {
     return paramData;
   }
 
-  public static DoradeRDAT getNextOf(DoradePARM parm, RandomAccessFile file, boolean littleEndianData) throws DescriptorException, java.io.IOException {
+  public static DoradeRDAT getNextOf(DoradePARM parm, RandomAccessFile file, boolean littleEndianData) throws DescriptorException {
     while (true) {
       long pos = findNextWithName("RDAT", file, littleEndianData);
       if (peekParamName(file).equals(parm.getName()))

--- a/cdm/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFile.java
@@ -616,7 +616,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
     return raf;
   }
 
-  private static String makeUncompressed(String filename) throws Exception {
+  private static String makeUncompressed(String filename) throws IOException {
     // see if its a compressed file
     int pos = filename.lastIndexOf('.');
     if (pos < 0) return null;
@@ -729,11 +729,6 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
           if (debugCompress) log.info("ungzipped {} to {}", filename, uncompressedFile);
         }
       }  catch (Exception e) {
-
-        // appears we have to close before we can delete   LOOK
-        //fout.close();
-        //fout = null;
-
         // dont leave bad files around
         if (uncompressedFile.exists()) {
           if (!uncompressedFile.delete())

--- a/cdm/src/main/java/ucar/nc2/dataset/conv/HdfEosOmiConvention.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/conv/HdfEosOmiConvention.java
@@ -13,8 +13,6 @@ import ucar.nc2.dataset.CoordinateAxis1D;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.util.CancelTask;
 
-import java.io.IOException;
-
 /**
  * HDF5-EOS AURA OMI
  *
@@ -129,7 +127,7 @@ public class HdfEosOmiConvention extends ucar.nc2.dataset.CoordSysBuilder {
     }
   }
    */
-    public void augmentDataset(NetcdfDataset ds, CancelTask cancelTask) throws IOException {
+    public void augmentDataset(NetcdfDataset ds, CancelTask cancelTask) {
         final Attribute levelAtt = ds.findAttribute("/HDFEOS/ADDITIONAL/FILE_ATTRIBUTES/@ProcessLevel");
         if (levelAtt == null)  { return; }
         final int level = levelAtt.getStringValue().startsWith("2") ? 2 : 3;

--- a/cdm/src/main/java/ucar/nc2/dataset/conv/NsslRadarMosaicConvention.java
+++ b/cdm/src/main/java/ucar/nc2/dataset/conv/NsslRadarMosaicConvention.java
@@ -55,7 +55,7 @@ public class NsslRadarMosaicConvention extends CoordSysBuilder {
     this.conventionName = "NSSL National Reflectivity Mosaic";
   }
 
-  public void augmentDataset(NetcdfDataset ds, CancelTask cancelTask) throws IOException {
+  public void augmentDataset(NetcdfDataset ds, CancelTask cancelTask) {
     if (null != ds.findVariable("Lat")) return; // check if its already been done - aggregating enhanced datasets.
     String s = ds.findAttValueIgnoreCase(null, "DataType", null);
     if (s == null) return;
@@ -68,7 +68,7 @@ public class NsslRadarMosaicConvention extends CoordSysBuilder {
     ds.finish();
   }
 
-  private void augment3D(NetcdfDataset ds, CancelTask cancelTask) throws IOException {
+  private void augment3D(NetcdfDataset ds, CancelTask cancelTask) {
     ds.addAttribute(null, new Attribute(CDM.CONVENTIONS, "NSSL National Reflectivity Mosaic"));
 
     addLongName(ds, "mrefl_mosaic", "3-D reflectivity mosaic grid");
@@ -96,7 +96,7 @@ public class NsslRadarMosaicConvention extends CoordSysBuilder {
     var.addAttribute(new Attribute(_Coordinate.Axes, "Height Lat Lon"));
   }
 
-  private void augment2D(NetcdfDataset ds, CancelTask cancelTask) throws IOException {
+  private void augment2D(NetcdfDataset ds, CancelTask cancelTask) {
     ds.addAttribute(null, new Attribute(CDM.CONVENTIONS, "NSSL National Reflectivity Mosaic"));
 
     addLongName(ds, "cref", "composite reflectivity");

--- a/cdm/src/main/java/ucar/nc2/ft/PointFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/PointFeatureCollection.java
@@ -22,10 +22,9 @@ public interface PointFeatureCollection extends DsgFeatureCollection, Iterable<P
    * @param boundingBox only points in this lat/lon bounding box. may be null.
    * @param dateRange only points in this date range. may be null.
    * @return subsetted collection, may be null if empty
-   * @throws IOException on read error
    */
   @Nullable
-  PointFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException;
+  PointFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox, CalendarDateRange dateRange);
 
   //////////////////////////////////////////////////////
   // deprecated, use foreach
@@ -47,7 +46,7 @@ public interface PointFeatureCollection extends DsgFeatureCollection, Iterable<P
    * @see PointFeatureIterator#next
    * @deprecated use foreach
    */
-  PointFeature next();
+  PointFeature next() throws java.io.IOException;
 
   /**
    * Reset the internal iterator for another iteration over the PointFeatures in this Collection.

--- a/cdm/src/main/java/ucar/nc2/ft/ProfileFeature.java
+++ b/cdm/src/main/java/ucar/nc2/ft/ProfileFeature.java
@@ -44,5 +44,5 @@ public interface ProfileFeature extends PointFeatureCollection, Iterable<PointFe
    * @return the actual data of this profile. may be empty, not null.
    */
   @Nonnull
-  StructureData getFeatureData();
+  StructureData getFeatureData() throws java.io.IOException;
 }

--- a/cdm/src/main/java/ucar/nc2/ft/StationProfileFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/StationProfileFeatureCollection.java
@@ -20,15 +20,15 @@ public interface StationProfileFeatureCollection extends PointFeatureCCC, Iterab
 
   List<StationFeature> getStationFeatures();
   List<StationFeature> getStationFeatures( List<String> stnNames);
-  List<StationFeature> getStationFeatures( ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException;
+  List<StationFeature> getStationFeatures( ucar.unidata.geoloc.LatLonRect boundingBox);
 
   StationFeature findStationFeature(String name);
   StationProfileFeature getStationProfileFeature(StationFeature s);
 
   // subsetting
-  StationProfileFeatureCollection subset(List<StationFeature> stations) throws IOException;
-  StationProfileFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException;
-  StationProfileFeatureCollection subset(List<StationFeature> stns, CalendarDateRange dateRange) throws IOException;
+  StationProfileFeatureCollection subset(List<StationFeature> stations);
+  StationProfileFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox);
+  StationProfileFeatureCollection subset(List<StationFeature> stns, CalendarDateRange dateRange);
   StationProfileFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException;
 
 

--- a/cdm/src/main/java/ucar/nc2/ft/StationTimeSeriesFeatureCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/StationTimeSeriesFeatureCollection.java
@@ -21,13 +21,13 @@ public interface StationTimeSeriesFeatureCollection extends PointFeatureCC, Iter
 
   List<StationFeature> getStationFeatures();
   List<StationFeature> getStationFeatures( List<String> stnNames);
-  List<StationFeature> getStationFeatures( ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException;
+  List<StationFeature> getStationFeatures( ucar.unidata.geoloc.LatLonRect boundingBox);
 
   StationFeature findStationFeature(String name);
   StationTimeSeriesFeature getStationTimeSeriesFeature(StationFeature s);
 
   // subsetting
-  StationTimeSeriesFeatureCollection subset(List<StationFeature> stations) throws IOException;
+  StationTimeSeriesFeatureCollection subset(List<StationFeature> stations);
   StationTimeSeriesFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException;
   StationTimeSeriesFeatureCollection subset(List<StationFeature> stns, CalendarDateRange dateRange) throws IOException;
   StationTimeSeriesFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException;
@@ -39,9 +39,8 @@ public interface StationTimeSeriesFeatureCollection extends PointFeatureCC, Iter
    * @param dateRange only points in this date range. may be null.
    * @param varList only these member variables. may be null. currently ignored
    * @return a PointFeatureCollection, may be null if its empty.
-   * @throws IOException on read error
    */
-  PointFeatureCollection flatten(List<String> stations, CalendarDateRange dateRange, List<VariableSimpleIF> varList) throws IOException;
+  PointFeatureCollection flatten(List<String> stations, CalendarDateRange dateRange, List<VariableSimpleIF> varList);
   PointFeatureCollection flatten(LatLonRect llbbox, CalendarDateRange dateRange) throws IOException;
   StationFeature getStationFeature(PointFeature flatPointFeature); // for flattened point only
 
@@ -79,10 +78,9 @@ public interface StationTimeSeriesFeatureCollection extends PointFeatureCC, Iter
 
   /**
    * Reset the internal iterator for another iteration over the StationTimeSeriesFeatures in this Collection.
-   * @throws java.io.IOException on read error
    * @deprecated use foreach
    */
-  void resetIteration() throws IOException;
+  void resetIteration();
 
   /**
    * @deprecated use foreach

--- a/cdm/src/main/java/ucar/nc2/ft/TrajectoryFeature.java
+++ b/cdm/src/main/java/ucar/nc2/ft/TrajectoryFeature.java
@@ -42,6 +42,6 @@ public interface TrajectoryFeature extends PointFeatureCollection {
    * @return the actual data of this Trajectory, may not be null but may be empty.
    */
   @Nonnull
-  StructureData getFeatureData();
+  StructureData getFeatureData() throws java.io.IOException;
 
 }

--- a/cdm/src/main/java/ucar/nc2/ft/TrajectoryProfileFeature.java
+++ b/cdm/src/main/java/ucar/nc2/ft/TrajectoryProfileFeature.java
@@ -29,7 +29,7 @@ public interface TrajectoryProfileFeature extends PointFeatureCC, Iterable<Profi
    * @return the actual data of this section. may be empty, not null.
    */
   @Nonnull
-  StructureData getFeatureData();
+  StructureData getFeatureData() throws java.io.IOException;
 
   //////////////////////////////////////////////////////////
   // deprecated use foreach

--- a/cdm/src/main/java/ucar/nc2/ft/fmrc/Fmrc.java
+++ b/cdm/src/main/java/ucar/nc2/ft/fmrc/Fmrc.java
@@ -107,7 +107,7 @@ public class Fmrc implements Closeable {
   private volatile long lastInvChanged;
   private volatile long lastProtoChanged;
 
-  private Fmrc(String collectionSpec, Formatter errlog) throws IOException {
+  private Fmrc(String collectionSpec, Formatter errlog) {
     this.manager = MFileCollectionManager.open(collectionSpec, collectionSpec, null, errlog);  // LOOK no name
     this.config = new FeatureCollectionConfig();
     this.config.spec = collectionSpec;
@@ -140,7 +140,7 @@ public class Fmrc implements Closeable {
     return manager;
   }
 
-  public FmrcInv getFmrcInv(Formatter debug) throws IOException {
+  public FmrcInv getFmrcInv(Formatter debug) {
     return makeFmrcInv( debug);
   }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/PointCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/PointCollectionImpl.java
@@ -35,7 +35,7 @@ public abstract class PointCollectionImpl extends DsgCollectionImpl implements P
   }
 
   @Override
-  public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+  public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) {
     return new PointCollectionSubset(this, boundingBox, dateRange);
   }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationHelper.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationHelper.java
@@ -8,7 +8,6 @@ import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.Station;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -156,7 +155,7 @@ public class StationHelper {
     return result;
   }
 
-  public StationHelper subset(LatLonRect bb) throws IOException {
+  public StationHelper subset(LatLonRect bb) {
     StationHelper result = new StationHelper();
     result.setStations( getStationFeatures(bb));
     return result;

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationProfileCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationProfileCollectionImpl.java
@@ -72,7 +72,7 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl i
   }
 
   @Override
-  public List<StationFeature> getStationFeatures(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException {
+  public List<StationFeature> getStationFeatures(ucar.unidata.geoloc.LatLonRect boundingBox) {
     return getStationHelper().getStationFeatures(boundingBox);
   }
 
@@ -87,23 +87,23 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl i
   }
 
   @Override
-  public StationProfileCollectionImpl subset(List<StationFeature> stations) throws IOException {
+  public StationProfileCollectionImpl subset(List<StationFeature> stations) {
     if (stations == null) return this;
     return new StationProfileFeatureCollectionSubset(this, stations);
   }
 
   @Override
-  public StationProfileCollectionImpl subset(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException {
+  public StationProfileCollectionImpl subset(ucar.unidata.geoloc.LatLonRect boundingBox) {
     return subset(getStationFeatures(boundingBox));
   }
 
   @Override
-  public StationProfileFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+  public StationProfileFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) {
     return subset(getStationFeatures(boundingBox), dateRange);
   }
 
   @Override
-  public StationProfileCollectionImpl subset(List<StationFeature> stnsWanted, CalendarDateRange dateRange) throws IOException {
+  public StationProfileCollectionImpl subset(List<StationFeature> stnsWanted, CalendarDateRange dateRange) {
     if (dateRange == null)
       return subset(stnsWanted);
 
@@ -133,7 +133,7 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl i
     }
 
     @Override
-    protected StationHelper createStationHelper() throws IOException {
+    protected StationHelper createStationHelper() {
       return from.getStationHelper().subset(stations);
     }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionFlattened.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionFlattened.java
@@ -5,7 +5,6 @@
 
 package ucar.nc2.ft.point;
 
-import java.io.IOException;
 import javax.annotation.Nonnull;
 
 import ucar.nc2.ft.PointFeatureIterator;
@@ -31,7 +30,7 @@ public class StationTimeSeriesCollectionFlattened extends PointCollectionImpl {
 
   @Override
   @Nonnull
-  public PointFeatureIterator getPointFeatureIterator() throws IOException {
+  public PointFeatureIterator getPointFeatureIterator() {
     return new PointIteratorFlatten( from.getPointFeatureCollectionIterator(), null, this.getCalendarDateRange());
   }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionImpl.java
@@ -74,7 +74,7 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
   }
 
   @Override
-  public List<StationFeature> getStationFeatures(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException {
+  public List<StationFeature> getStationFeatures(ucar.unidata.geoloc.LatLonRect boundingBox) {
     return getStationHelper().getStationFeatures(boundingBox);
   }
 
@@ -92,22 +92,22 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
   // subset
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) {
     return subset( getStationFeatures(boundingBox));
   }
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) {
     return subset(getStationFeatures(boundingBox), dateRange);
   }
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stations) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stations) {
     return new StationSubset(this, stations);
   }
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stnsWanted, CalendarDateRange dateRange) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stnsWanted, CalendarDateRange dateRange) {
     if (dateRange == null)
       return subset(stnsWanted);
 
@@ -152,7 +152,7 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
 
   // might need to override for efficiency
   @Override
-  public PointFeatureCollection flatten(List<String> stationNames, CalendarDateRange dateRange, List<VariableSimpleIF> varList) throws IOException {
+  public PointFeatureCollection flatten(List<String> stationNames, CalendarDateRange dateRange, List<VariableSimpleIF> varList) {
     if ((stationNames == null) || (stationNames.size() == 0))
       return new StationTimeSeriesCollectionFlattened(this, dateRange);
 
@@ -252,7 +252,7 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
   }
 
   @Override
-  public void resetIteration() throws IOException {
+  public void resetIteration() {
     localIterator = getPointFeatureCollectionIterator();
   }
 }

--- a/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositePointCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositePointCollection.java
@@ -71,7 +71,7 @@ public class CompositePointCollection extends PointCollectionImpl implements Upd
 
   @Override
   @Nonnull
-  public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+  public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) {
     if ((dateRange == null) && (boundingBox == null))
       return this;
     else if (dateRange == null)

--- a/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositeStationCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/collection/CompositeStationCollection.java
@@ -103,7 +103,7 @@ public class CompositeStationCollection extends StationTimeSeriesCollectionImpl 
   // StationTimeSeriesFeatureCollection
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stations) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stations) {
     if (stations == null) {
       return this;
     } else {
@@ -113,7 +113,7 @@ public class CompositeStationCollection extends StationTimeSeriesCollectionImpl 
   }
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) {
     if (boundingBox == null) {
       return this;
     } else {
@@ -129,7 +129,7 @@ public class CompositeStationCollection extends StationTimeSeriesCollectionImpl 
   } */
 
   @Override
-  public PointFeatureCollection flatten(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+  public PointFeatureCollection flatten(LatLonRect boundingBox, CalendarDateRange dateRange) {
     TimedCollection subsetCollection = (dateRange != null) ? dataCollection.subset(dateRange) : dataCollection;
     return new CompositeStationCollectionFlattened(getName(), getTimeUnit(), getAltUnits(), boundingBox, dateRange, subsetCollection);
 
@@ -137,7 +137,7 @@ public class CompositeStationCollection extends StationTimeSeriesCollectionImpl 
   }
 
   @Override
-  public PointFeatureCollection flatten(List<String> stations, CalendarDateRange dateRange, List<VariableSimpleIF> varList) throws IOException {
+  public PointFeatureCollection flatten(List<String> stations, CalendarDateRange dateRange, List<VariableSimpleIF> varList) {
     TimedCollection subsetCollection = (dateRange != null) ? dataCollection.subset(dateRange) : dataCollection;
     return new CompositeStationCollectionFlattened(getName(), getTimeUnit(), getAltUnits(), stations, dateRange, varList, subsetCollection);
   }
@@ -147,8 +147,7 @@ public class CompositeStationCollection extends StationTimeSeriesCollectionImpl 
     private final CompositeStationCollection from;
     private final List<StationFeature> stationFeats;
 
-    private CompositeStationCollectionSubset(CompositeStationCollection from, List<StationFeature> stationFeats)
-            throws IOException {
+    private CompositeStationCollectionSubset(CompositeStationCollection from, List<StationFeature> stationFeats) {
       super(from.getName(), from.getTimeUnit(), from.getAltUnits(), from.dataCollection);
       this.from = Preconditions.checkNotNull(from, "from == null");
 
@@ -271,7 +270,7 @@ public class CompositeStationCollection extends StationTimeSeriesCollectionImpl 
 
     @Override
     @Nullable
-    public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+    public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) {
       if (boundingBox != null) {
         if (!boundingBox.contains(s.getLatLon())) return null;
         if (dateRange == null) return this;

--- a/cdm/src/main/java/ucar/nc2/ft/point/remote/PointCollectionStreamRemote.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/remote/PointCollectionStreamRemote.java
@@ -40,7 +40,7 @@ public class PointCollectionStreamRemote extends PointCollectionStreamAbstract i
     // Must override default subsetting implementation for efficiency.
 
     @Override
-    public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+    public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) {
         return new Subset(this, boundingBox, dateRange);
     }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/remote/PointStream.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/remote/PointStream.java
@@ -240,7 +240,7 @@ public class PointStream {
 
       @Nonnull
       @Override
-      public StructureData getDataAll() throws IOException {
+      public StructureData getDataAll() {
         return getFeatureData();
       }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/remote/StationCollectionStream.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/remote/StationCollectionStream.java
@@ -84,21 +84,21 @@ public class StationCollectionStream extends StationTimeSeriesCollectionImpl {
   // StationTimeSeriesFeatureCollection
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stations) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(List<StationFeature> stations) {
     if (stations == null) return this;
 //    List<StationFeature> subset = getStationHelper().getStationFeatures(stations);
     return new Subset(this, null, null); // LOOK WRONG
   }
 
   @Override
-  public StationTimeSeriesFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) throws IOException {
+  public StationTimeSeriesFeatureCollection subset(ucar.unidata.geoloc.LatLonRect boundingBox) {
     if (boundingBox == null) return this;
     return new Subset(this, boundingBox, null);
   }
 
   // NestedPointFeatureCollection
   @Override
-  public PointFeatureCollection flatten(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+  public PointFeatureCollection flatten(LatLonRect boundingBox, CalendarDateRange dateRange) {
     //boolean restrictedList = false;
     //QueryMaker queryMaker = restrictedList ? new QueryByStationList() : null;
     PointFeatureCollection pfc = new PointCollectionStreamRemote(uri, getTimeUnit(), getAltUnits(), null);
@@ -140,7 +140,7 @@ public class StationCollectionStream extends StationTimeSeriesCollectionImpl {
     }
 
     @Override
-    protected StationHelper createStationHelper() throws IOException {
+    protected StationHelper createStationHelper() {
       List<ucar.nc2.ft.point.StationFeature> stations = from.getStationHelper().getStationFeatures(boundingBoxSubset);
       StationHelper stationHelper = new StationHelper();
       stationHelper.setStations(stations);
@@ -183,7 +183,7 @@ public class StationCollectionStream extends StationTimeSeriesCollectionImpl {
     // PointCollection
     @Override
     @Nullable
-    public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) throws IOException {
+    public PointFeatureCollection subset(LatLonRect boundingBox, CalendarDateRange dateRange) {
       if (boundingBox != null) {
         if (!boundingBox.contains(s.getLatLon())) return null;
         if (dateRange == null) return this;

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/NestedTable.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/NestedTable.java
@@ -626,7 +626,7 @@ public class NestedTable {
   }  */
 
   // add table join to this cursor level
-  void addParentJoin(Cursor cursor) throws IOException {
+  void addParentJoin(Cursor cursor) {
     int level = cursor.currentIndex;
     Table t = getTable(level);
     if (t.extraJoins != null) {

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/PointDatasetStandardFactory.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/PointDatasetStandardFactory.java
@@ -51,7 +51,7 @@ public class PointDatasetStandardFactory implements FeatureDatasetFactory {
    * @return if successful, return non-null. This object is then passed back into open(), so analysis can be reused.
    */
   @Override
-  public Object isMine(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) throws IOException {
+  public Object isMine(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) {
     if (wantFeatureType == null) wantFeatureType = FeatureType.ANY_POINT;
     if (wantFeatureType != FeatureType.ANY_POINT) {
       if (!wantFeatureType.isPointFeatureType())
@@ -118,7 +118,7 @@ public class PointDatasetStandardFactory implements FeatureDatasetFactory {
     private TableAnalyzer analyser;
     //private DateUnit timeUnit;
 
-    PointDatasetStandard(FeatureType wantFeatureType, TableAnalyzer analyser, NetcdfDataset ds, Formatter errlog) throws IOException {
+    PointDatasetStandard(FeatureType wantFeatureType, TableAnalyzer analyser, NetcdfDataset ds, Formatter errlog) {
       super(ds, null);
       parseInfo.format(" PointFeatureDatasetImpl=%s%n", getClass().getName());
       this.analyser = analyser;

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardPointFeatureIterator.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardPointFeatureIterator.java
@@ -31,7 +31,7 @@ public class StandardPointFeatureIterator extends PointIteratorFromStructureData
   protected CalendarDateUnit timeUnit;
   protected Cursor cursor;
 
-  StandardPointFeatureIterator(PointCollectionImpl dsg, NestedTable ft, CalendarDateUnit timeUnit, ucar.ma2.StructureDataIterator structIter, Cursor cursor) throws IOException {
+  StandardPointFeatureIterator(PointCollectionImpl dsg, NestedTable ft, CalendarDateUnit timeUnit, ucar.ma2.StructureDataIterator structIter, Cursor cursor) {
     super(structIter, null);
     this.collectionDsg = dsg;
     this.ft = ft;

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardProfileCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardProfileCollectionImpl.java
@@ -110,7 +110,7 @@ public class StandardProfileCollectionImpl extends PointFeatureCCImpl implements
 
     private class StandardProfileFeatureIterator extends StandardPointFeatureIterator {
 
-      StandardProfileFeatureIterator(NestedTable ft, CalendarDateUnit timeUnit, StructureDataIterator structIter, Cursor cursor) throws IOException {
+      StandardProfileFeatureIterator(NestedTable ft, CalendarDateUnit timeUnit, StructureDataIterator structIter, Cursor cursor) {
         super(StandardProfileFeature.this, ft, timeUnit, structIter, cursor);
       }
 
@@ -203,7 +203,7 @@ public class StandardProfileCollectionImpl extends PointFeatureCCImpl implements
     }
 
     @Override
-    public ProfileFeature next() throws IOException {
+    public ProfileFeature next() {
       Cursor cursor = new Cursor(ft.getNumberOfLevels());
       cursor.tableData[1] = nextProfileData;
       cursor.recnum[1] = structIter.getCurrentRecno();
@@ -268,7 +268,7 @@ public class StandardProfileCollectionImpl extends PointFeatureCCImpl implements
 
   // need covariant return to allow superclass to implement
   @Override
-  public ProfileFeature next() throws IOException {
+  public ProfileFeature next() {
     return localIterator.next();
   }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardSectionCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardSectionCollectionImpl.java
@@ -97,7 +97,7 @@ public class StandardSectionCollectionImpl extends SectionCollectionImpl {
     }
 
     @Override
-    public TrajectoryProfileFeature next() throws IOException {
+    public TrajectoryProfileFeature next() {
       Cursor cursor = new Cursor(ft.getNumberOfLevels());
       cursor.recnum[2] = sdataIter.getCurrentRecno();
       cursor.tableData[2] = sectionData; // obs(leaf) = 0, profile=1, section(root)=2
@@ -241,7 +241,7 @@ public class StandardSectionCollectionImpl extends SectionCollectionImpl {
 
     private class PointIterator extends StandardPointFeatureIterator {
 
-      PointIterator(NestedTable ft, CalendarDateUnit timeUnit, StructureDataIterator structIter, Cursor cursor) throws IOException {
+      PointIterator(NestedTable ft, CalendarDateUnit timeUnit, StructureDataIterator structIter, Cursor cursor) {
         super(StandardSectionProfileFeature.this, ft, timeUnit, structIter, cursor);
       }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardStationProfileCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardStationProfileCollectionImpl.java
@@ -107,7 +107,7 @@ public class StandardStationProfileCollectionImpl extends StationProfileCollecti
     }
 
     @Override
-    public StationProfileFeature next() throws IOException {
+    public StationProfileFeature next() {
       Cursor cursor = new Cursor(ft.getNumberOfLevels());
       cursor.recnum[2] = sdataIter.getCurrentRecno();
       cursor.tableData[2] = stationProfileData; // obs(leaf) = 0, profile=1, section(root)=2
@@ -132,7 +132,7 @@ public class StandardStationProfileCollectionImpl extends StationProfileCollecti
     //int recnum;
     Cursor cursor;
 
-    StandardStationProfileFeature(Station s, Cursor cursor, StructureData stationProfileData, int recnum) throws IOException {
+    StandardStationProfileFeature(Station s, Cursor cursor, StructureData stationProfileData, int recnum) {
       super(s, StandardStationProfileCollectionImpl.this.getTimeUnit(), StandardStationProfileCollectionImpl.this.getAltUnits(), -1);
       this.cursor = cursor;
       //this.recnum = recnum;
@@ -219,7 +219,7 @@ public class StandardStationProfileCollectionImpl extends StationProfileCollecti
       }
 
       @Override
-      public PointFeatureCollection next() throws IOException {
+      public PointFeatureCollection next() {
         count++;
         PointFeatureCollection result = new StandardProfileFeature(station, getTimeUnit(), getAltUnits(), ft.getObsTime(cursor), cursor.copy(), profileData);
         prev = (DsgCollectionImpl) result;
@@ -282,7 +282,7 @@ public class StandardStationProfileCollectionImpl extends StationProfileCollecti
 
     private class StandardProfileFeatureIterator extends StandardPointFeatureIterator {
 
-      StandardProfileFeatureIterator(NestedTable ft, CalendarDateUnit timeUnit, StructureDataIterator structIter, Cursor cursor) throws IOException {
+      StandardProfileFeatureIterator(NestedTable ft, CalendarDateUnit timeUnit, StructureDataIterator structIter, Cursor cursor) {
         super(StandardProfileFeature.this, ft, timeUnit, structIter, cursor);
       }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardTrajectoryCollectionImpl.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/StandardTrajectoryCollectionImpl.java
@@ -155,7 +155,7 @@ public class StandardTrajectoryCollectionImpl extends PointFeatureCCImpl impleme
     }
 
     @Override
-    public TrajectoryFeature next() throws IOException {
+    public TrajectoryFeature next() {
       Cursor cursor = new Cursor(ft.getNumberOfLevels());
       cursor.recnum[1] = structIter.getCurrentRecno();
       cursor.tableData[1] = nextTraj;
@@ -185,7 +185,7 @@ public class StandardTrajectoryCollectionImpl extends PointFeatureCCImpl impleme
 
   // need covariant return to allow superclass to implement
   @Override
-  public TrajectoryFeature next() throws IOException {
+  public TrajectoryFeature next() {
     return localIterator.next();
   }
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/Table.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/Table.java
@@ -487,7 +487,7 @@ public abstract class Table {
     }
 
     @Override
-    public StructureDataIterator getStructureDataIterator(Cursor cursor) throws IOException {
+    public StructureDataIterator getStructureDataIterator(Cursor cursor) {
       if (!isInit) init();
 
       int firstRecno, numrecs;
@@ -554,7 +554,7 @@ public abstract class Table {
     }
 
     @Override
-    public StructureDataIterator getStructureDataIterator(Cursor cursor) throws IOException {
+    public StructureDataIterator getStructureDataIterator(Cursor cursor) {
       int parentIndex = cursor.getParentRecnum();
       List<Integer> index = indexMap.get(parentIndex);
       if (index == null) index = new ArrayList<>();
@@ -660,7 +660,7 @@ public abstract class Table {
     }
 
     @Override
-    public StructureDataIterator getStructureDataIterator(Cursor cursor) throws IOException {
+    public StructureDataIterator getStructureDataIterator(Cursor cursor) {
       int parentIndex = cursor.getParentRecnum();
       ParentInfo info = indexMap[parentIndex];
       List<Integer> index = (info == null) ? new ArrayList<>() : info.recnumList;
@@ -696,7 +696,7 @@ public abstract class Table {
     }
 
     @Override
-    public StructureDataIterator getStructureDataIterator(Cursor cursor) throws IOException {
+    public StructureDataIterator getStructureDataIterator(Cursor cursor) {
       StructureData parentStruct = cursor.getParentStructure();
       int firstRecno = parentStruct.getScalarInt(start);
       return new StructureDataIteratorLinked(struct, firstRecno, -1, next);

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/TableAnalyzer.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/TableAnalyzer.java
@@ -312,11 +312,7 @@ public class TableAnalyzer {
     for (NestedTable nt : leaves) {
       if (!nt.hasCoords()) {
         errlog.format("Table %s featureType %s: lat/lon/time coord not found%n", nt.getName(), nt.getFeatureType());
-        try {
-          writeConfigXML(errlog);
-        } catch (IOException e) {
-         log.error("featuretypeOk", e);
-        }
+        writeConfigXML(errlog);
       }
 
       if (!FeatureDatasetFactoryManager.featureTypeOk(ftype, nt.getFeatureType()))
@@ -621,11 +617,7 @@ public class TableAnalyzer {
     if (userAdviceS.length() > 0)
       sf.format("%n userAdvice=%n%s%n",userAdviceS);
 
-    try {
-      writeConfigXML(sf);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    writeConfigXML(sf);
   }
 
   private void writeConfigXML(java.util.Formatter sf) {

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/TableAnalyzer.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/TableAnalyzer.java
@@ -628,7 +628,7 @@ public class TableAnalyzer {
     }
   }
 
-  private void writeConfigXML(java.util.Formatter sf) throws IOException {
+  private void writeConfigXML(java.util.Formatter sf) {
     if (configResult != null) {
         PointConfigXML tcx = new PointConfigXML();
         tcx.writeConfigXML(configResult, getName(), sf);

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/plug/CFpointObs.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/plug/CFpointObs.java
@@ -59,7 +59,7 @@ public class CFpointObs extends TableConfigurerImpl {
     return false;
   }
 
-  public TableConfig getConfig(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) throws IOException {
+  public TableConfig getConfig(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) {
     EncodingInfo info = new EncodingInfo();
 
     // figure out the actual feature type of the dataset
@@ -126,7 +126,7 @@ public class CFpointObs extends TableConfigurerImpl {
   /////////////////////////////////////////////////////////////////////////////////
 
 
-  protected TableConfig getPointConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) throws IOException {
+  protected TableConfig getPointConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) {
     if (info.time.getRank() != 1) {
       errlog.format("CFpointObs type=point: coord time must have rank 1, coord var= %s %n", info.time.getNameAndDimensions());
       return null;
@@ -140,7 +140,7 @@ public class CFpointObs extends TableConfigurerImpl {
 
   //////////////////////////////////////////////////////////////////////////////////
 
-  protected TableConfig getStationConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) throws IOException {
+  protected TableConfig getStationConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) {
     if (!identifyEncodingStation(ds, info, CF.FeatureType.timeSeries, errlog))
       return null;
 
@@ -197,7 +197,7 @@ public class CFpointObs extends TableConfigurerImpl {
 
   ////
 
-  protected TableConfig getProfileConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) throws IOException {
+  protected TableConfig getProfileConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) {
     if (!identifyEncodingProfile(ds, info, errlog)) return null;
 
     TableConfig profileTable = makeStructTable(ds, FeatureType.PROFILE, info, errlog);
@@ -248,7 +248,7 @@ public class CFpointObs extends TableConfigurerImpl {
 
   ////
 
-  protected TableConfig getTrajectoryConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) throws IOException {
+  protected TableConfig getTrajectoryConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) {
     if (!identifyEncodingTraj(ds, info, errlog)) return null;
 
     TableConfig trajTable = makeStructTable(ds, FeatureType.TRAJECTORY, info, errlog);
@@ -291,7 +291,7 @@ public class CFpointObs extends TableConfigurerImpl {
 
   ////
 
-  protected TableConfig getTimeSeriesProfileConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) throws IOException {
+  protected TableConfig getTimeSeriesProfileConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) {
     if (!identifyEncodingTimeSeriesProfile(ds, info, CF.FeatureType.timeSeriesProfile, errlog)) return null;
 
     VariableDS time = CoordSysEvaluator.findCoordByType(ds, AxisType.Time);
@@ -454,7 +454,7 @@ public class CFpointObs extends TableConfigurerImpl {
     return stationTable;
   }
 
-  protected TableConfig getSectionConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) throws IOException {
+  protected TableConfig getSectionConfig(NetcdfDataset ds, EncodingInfo info, Formatter errlog) {
     if (!identifyEncodingSection(ds, info, CF.FeatureType.trajectoryProfile, errlog)) return null;
 
     TableConfig parentTable = makeStructTable(ds, FeatureType.TRAJECTORY_PROFILE, info, errlog);

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/plug/CdmDirect.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/plug/CdmDirect.java
@@ -47,7 +47,7 @@ public class CdmDirect extends TableConfigurerImpl {
     return (ftype == CF.FeatureType.timeSeries) || (ftype == CF.FeatureType.timeSeriesProfile);
   }
 
-  public TableConfig getConfig(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) throws IOException {
+  public TableConfig getConfig(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) {
 
     CF.FeatureType ftype = CF.FeatureType.getFeatureTypeFromGlobalAttribute(ds);
     if (ftype == null) ftype = CF.FeatureType.point;
@@ -138,7 +138,7 @@ public class CdmDirect extends TableConfigurerImpl {
     return stnTable;
   }
 
-  protected TableConfig getStationProfileConfig(NetcdfDataset ds, Formatter errlog) throws IOException {
+  protected TableConfig getStationProfileConfig(NetcdfDataset ds, Formatter errlog) {
     TableConfig stnTable = getStationConfig(ds, errlog);
     if (stnTable == null) return null;
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/standard/plug/GempakCdm.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/standard/plug/GempakCdm.java
@@ -50,7 +50,7 @@ public class GempakCdm extends TableConfigurerImpl {
     return (ftype == CF.FeatureType.timeSeries) || (ftype == CF.FeatureType.timeSeriesProfile);
   }
 
-  public TableConfig getConfig(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) throws IOException {
+  public TableConfig getConfig(FeatureType wantFeatureType, NetcdfDataset ds, Formatter errlog) {
 
     CF.FeatureType ftype = CF.FeatureType.getFeatureTypeFromGlobalAttribute(ds);
     if (ftype == null) ftype = CF.FeatureType.point;
@@ -271,7 +271,7 @@ public class GempakCdm extends TableConfigurerImpl {
     return obs;
   }
 
-  protected TableConfig getStationProfileConfig(NetcdfDataset ds, Formatter errlog) throws IOException {
+  protected TableConfig getStationProfileConfig(NetcdfDataset ds, Formatter errlog) {
     TableConfig stnTable = makeStationTable(ds, errlog);
     if (stnTable == null) return null;
     Dimension stationDim = ds.findDimension( stnTable.dimName);

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
@@ -430,8 +430,8 @@ public abstract class CFPointWriter implements Closeable {
     }
   }
 
-  protected abstract void makeFeatureVariables(StructureData featureData, boolean isExtended) throws IOException;
-  protected void makeMiddleVariables(StructureData middleData, boolean isExtended) throws IOException {
+  protected abstract void makeFeatureVariables(StructureData featureData, boolean isExtended);
+  protected void makeMiddleVariables(StructureData middleData, boolean isExtended) {
     // NOOP
   }
 
@@ -483,7 +483,7 @@ public abstract class CFPointWriter implements Closeable {
     writeExtraVariables();
   }
 
-  protected void addExtraVariables() throws IOException {
+  protected void addExtraVariables() {
     if (extra == null) return;
     if (extraMap == null) extraMap = new HashMap<>();
 
@@ -513,7 +513,7 @@ public abstract class CFPointWriter implements Closeable {
   }
 
    // added as variables with the unlimited (record) dimension
-  protected void addCoordinatesClassic(Dimension recordDim, List<VariableSimpleIF> coords, Map<String, Variable> varMap) throws IOException {
+  protected void addCoordinatesClassic(Dimension recordDim, List<VariableSimpleIF> coords, Map<String, Variable> varMap) {
     addDimensionsClassic(coords, dimMap);
 
     for (VariableSimpleIF oldVar : coords) {
@@ -558,7 +558,7 @@ public abstract class CFPointWriter implements Closeable {
   }
 
    // added as variables with the unlimited (record) dimension
-  protected void addDataVariablesClassic(Dimension recordDim, StructureData stnData, Map<String, Variable> varMap, String coordVars) throws IOException {
+  protected void addDataVariablesClassic(Dimension recordDim, StructureData stnData, Map<String, Variable> varMap, String coordVars) {
     addDimensionsClassic(dataVars, dimMap);
 
     for (StructureMembers.Member m : stnData.getMembers()) {

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/FeatureDatasetCapabilitiesWriter.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/FeatureDatasetCapabilitiesWriter.java
@@ -68,9 +68,8 @@ public class FeatureDatasetCapabilitiesWriter {
    * @param bb    restrict stations to this bounding box, may be null
    * @param names restrict stations to these names, may be null
    * @return XML document for the stations
-   * @throws IOException on read error
    */
-  public Document makeStationCollectionDocument(LatLonRect bb, String[] names) throws IOException {
+  public Document makeStationCollectionDocument(LatLonRect bb, String[] names) {
 
     List<DsgFeatureCollection> list = fdp.getPointFeatureCollectionList();
     DsgFeatureCollection fc = list.get(0); // LOOK maybe should pass in the dsg?

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFProfileCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFProfileCollection.java
@@ -77,7 +77,7 @@ public class WriterCFProfileCollection extends CFPointWriter {
     super.writeHeader(coords, profile.getFeatureData(), obs.getFeatureData(), coordNames.toString());
   }
 
-  protected void makeFeatureVariables(StructureData featureData, boolean isExtended) throws IOException {
+  protected void makeFeatureVariables(StructureData featureData, boolean isExtended) {
 
     // LOOK why not unlimited here ?
     Dimension profileDim = writer.addDimension(null, profileDimName, nfeatures);

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationCollection.java
@@ -103,7 +103,7 @@ public class WriterCFStationCollection extends CFPointWriter {
 
   }
 
-  protected void makeFeatureVariables(StructureData featureData, boolean isExtended) throws IOException {
+  protected void makeFeatureVariables(StructureData featureData, boolean isExtended) {
 
     // add the dimensions : extendded model can use an unlimited dimension
     //Dimension stationDim = isExtended ? writer.addDimension(null, stationDimName, 0, true, true, false) : writer.addDimension(null, stationDimName, nstns);

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationProfileCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationProfileCollection.java
@@ -145,7 +145,7 @@ public class WriterCFStationProfileCollection extends CFPointWriter {
 
   }
 
-  protected void makeFeatureVariables(StructureData stnData, boolean isExtended) throws IOException {
+  protected void makeFeatureVariables(StructureData stnData, boolean isExtended) {
 
     // add the dimensions : extended model can use an unlimited dimension
     //Dimension stationDim = isExtended ? writer.addDimension(null, stationDimName, 0, true, true, false) : writer.addDimension(null, stationDimName, nstns);
@@ -203,7 +203,7 @@ public class WriterCFStationProfileCollection extends CFPointWriter {
   }
 
   @Override
-  protected void makeMiddleVariables(StructureData profileData, boolean isExtended) throws IOException {
+  protected void makeMiddleVariables(StructureData profileData, boolean isExtended) {
 
     Dimension profileDim = writer.addDimension(null, profileDimName, nfeatures);
 

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryCollection.java
@@ -74,7 +74,7 @@ public class WriterCFTrajectoryCollection extends CFPointWriter {
     super.writeHeader(coords, feature.getFeatureData(), obs.getFeatureData(), coordNames.toString());
   }
 
-  protected void makeFeatureVariables(StructureData featureData, boolean isExtended) throws IOException {
+  protected void makeFeatureVariables(StructureData featureData, boolean isExtended) {
 
     // LOOK why not unlimited here fro extended model ?
     Dimension profileDim = writer.addDimension(null, trajDimName, nfeatures);

--- a/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryProfileCollection.java
+++ b/cdm/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryProfileCollection.java
@@ -92,7 +92,7 @@ public class WriterCFTrajectoryProfileCollection extends CFPointWriter {
     super.writeHeader2(obsCoords, sectionData, profileData, obsData, coordNames.toString());
   }
 
-  protected void makeFeatureVariables(StructureData trajData, boolean isExtended) throws IOException {
+  protected void makeFeatureVariables(StructureData trajData, boolean isExtended) {
 
     // add the dimensions : extended model can use an unlimited dimension
     Dimension trajDim = writer.addDimension(null, trajDimName, ntraj);
@@ -131,7 +131,7 @@ public class WriterCFTrajectoryProfileCollection extends CFPointWriter {
   }
 
   @Override
-  protected void makeMiddleVariables(StructureData profileData, boolean isExtended) throws IOException {
+  protected void makeMiddleVariables(StructureData profileData, boolean isExtended) {
 
     Dimension profileDim = writer.addDimension(null, profileDimName, nfeatures);
 

--- a/cdm/src/main/java/ucar/nc2/ft/radial/RadialSweepFeature.java
+++ b/cdm/src/main/java/ucar/nc2/ft/radial/RadialSweepFeature.java
@@ -63,24 +63,24 @@ public interface RadialSweepFeature {
   /**
    * @return all the sweep data, of length getNumRadials() by getNumGates()
    */
-  float[] readData();
+  float[] readData() throws java.io.IOException;
 
   /**
    * @param radial which radial, must in interval [0,getRadialNumber())
    * @return the actual data, of length getNumGates()
    */
-  float[] readData(int radial);
+  float[] readData(int radial) throws java.io.IOException;
 
   /**
    * @param radial which radial, must in interval [0,getRadialNumber())
    * @return the elevation of the ith radial, in degrees
    */
-  float getElevation(int radial);
+  float getElevation(int radial) throws java.io.IOException;
 
   /**
    * @return all elevation in the sweep
    */
-  float[] getElevation();
+  float[] getElevation() throws java.io.IOException;
 
   /**
    * @return the average elevation of all the radials in the sweep, in degrees.
@@ -92,12 +92,12 @@ public interface RadialSweepFeature {
    * @param radial which radial, must in interval [0,getRadialNumber())
    * @return the azimuth of the ith radial, in degrees
    */
-  float getAzimuth(int radial);
+  float getAzimuth(int radial) throws java.io.IOException;
 
   /**
    * @return all azimuth in the sweep
    */
-  float[] getAzimuth();
+  float[] getAzimuth() throws java.io.IOException;
 
   /**
    * @return the average azimuth of all the radials in the sweep, in degrees.
@@ -115,7 +115,7 @@ public interface RadialSweepFeature {
    * @param radial which radial, must in interval [0,getRadialNumber())
    * @return the time of the ith radial, in units of getTimeUnits().
    */
-  float getTime(int radial);
+  float getTime(int radial) throws java.io.IOException;
 
   /**
    * @return the starting time of the sweep, in units of getTimeUnits().

--- a/cdm/src/main/java/ucar/nc2/ft/radial/StationRadialDataset.java
+++ b/cdm/src/main/java/ucar/nc2/ft/radial/StationRadialDataset.java
@@ -19,7 +19,7 @@ import java.util.Date;
 public interface StationRadialDataset extends StationCollection, FeatureDataset {
 
   // LOOK - should return RadialSweepFeature ??
-  RadialDatasetSweep getRadarDataset(String stationName, Date date);
+  RadialDatasetSweep getRadarDataset(String stationName, Date date) throws java.io.IOException;
 
   /*
    * Get a subsetted StationCollection

--- a/cdm/src/main/java/ucar/nc2/ft/radial/StationRadialDataset.java
+++ b/cdm/src/main/java/ucar/nc2/ft/radial/StationRadialDataset.java
@@ -19,7 +19,7 @@ import java.util.Date;
 public interface StationRadialDataset extends StationCollection, FeatureDataset {
 
   // LOOK - should return RadialSweepFeature ??
-  RadialDatasetSweep getRadarDataset(String stationName, Date date) throws java.io.IOException;
+  RadialDatasetSweep getRadarDataset(String stationName, Date date);
 
   /*
    * Get a subsetted StationCollection

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -277,7 +277,7 @@ public class HorizCoordSys {
   }
 
   // here's where to deal with crossing seam
-  private Optional<CoverageCoordAxis> subsetLon(LatLonRect llbb, int stride) throws InvalidRangeException {
+  private Optional<CoverageCoordAxis> subsetLon(LatLonRect llbb, int stride) {
     double wantMin = LatLonPointImpl.lonNormalFrom(llbb.getLonMin(), lonAxis.getStartValue());
     double wantMax = LatLonPointImpl.lonNormalFrom(llbb.getLonMax(), lonAxis.getStartValue());
     double start = lonAxis.getStartValue();

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/SubsetParams.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/SubsetParams.java
@@ -157,7 +157,7 @@ public class SubsetParams {
   public Integer getInteger(String key) {
     Object val = req.get(key);
     if (val == null) return null;
-    Integer dval;
+    int dval;
     if (val instanceof Number) dval = ((Number) val).intValue();
     else dval = Integer.parseInt((String) val);
     return dval;

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageDatasetCapabilities.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageDatasetCapabilities.java
@@ -74,7 +74,7 @@ public class CoverageDatasetCapabilities {
    *
    * @return a JDOM Document
    */
-  public Document makeDatasetDescription() throws IOException {
+  public Document makeDatasetDescription() {
     Element rootElem = new Element("gridDataset");
     Document doc = new Document(rootElem);
     rootElem.setAttribute("location", gcd.getName());

--- a/cdm/src/main/java/ucar/nc2/iosp/BitReader.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/BitReader.java
@@ -76,7 +76,7 @@ public class BitReader {
     }
   }
 
-  public long getPos() throws IOException {
+  public long getPos() {
     if (raf != null) {
       return raf.getFilePointer();
     } else {

--- a/cdm/src/main/java/ucar/nc2/iosp/IospHelper.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/IospHelper.java
@@ -253,9 +253,8 @@ public class IospHelper {
    * @param dataType  dataType of the variable
    * @param fillValue must be Number if dataType.isNumeric(), or String for STRING, byte[] for Structure, or null for none
    * @return primitive array with data read in
-   * @throws java.io.IOException on read error
    */
-  static public Object readDataFill(LayoutBB layout, DataType dataType, Object fillValue) throws java.io.IOException {
+  static public Object readDataFill(LayoutBB layout, DataType dataType, Object fillValue) {
     long size = layout.getTotalNelems();
     if (dataType == DataType.STRUCTURE) size *= layout.getElemSize();
     Object arr = (fillValue == null) ? makePrimitiveArray((int) size, dataType) :
@@ -271,9 +270,8 @@ public class IospHelper {
    * @param dataType dataType of the variable
    * @param arr      primitive array to read data into
    * @return the primitive array with data read in
-   * @throws java.io.IOException on read error
    */
-  static public Object readData(LayoutBB layout, DataType dataType, Object arr) throws java.io.IOException {
+  static public Object readData(LayoutBB layout, DataType dataType, Object arr) {
     if (showLayoutTypes) System.out.println("***BB LayoutType=" + layout.getClass().getName());
 
     if (dataType.getPrimitiveClassType() == byte.class || (dataType == DataType.CHAR)) {

--- a/cdm/src/main/java/ucar/nc2/iosp/Layout.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/Layout.java
@@ -4,8 +4,6 @@
  */
 package ucar.nc2.iosp;
 
-import java.io.IOException;
-
 /**
  * Iterator to read/write subsets of a multidimensional array, finding the contiguous chunks.
  * The iteration is monotonic in both src and dest positions.
@@ -74,9 +72,8 @@ public interface Layout {
    * Get the next chunk
    *
    * @return next chunk, or null if !hasNext()
-   * @throws java.io.IOException on i/o error
    */
-  Chunk next() throws IOException;
+  Chunk next();
 
   /**
    * A chunk of data that is contiguous in both the source and destination.

--- a/cdm/src/main/java/ucar/nc2/iosp/LayoutBB.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/LayoutBB.java
@@ -4,7 +4,6 @@
  */
 package ucar.nc2.iosp;
 
-import java.io.IOException;
 import java.nio.*;
 
 /**
@@ -62,9 +61,8 @@ public interface LayoutBB extends Layout {
    * Get the next chunk
    *
    * @return next chunk, or null if !hasNext()
-   * @throws java.io.IOException on i/o error
    */
-  Chunk next() throws IOException;
+  Chunk next();
 
   /**
    * A chunk of data that is contiguous in both the source and destination.

--- a/cdm/src/main/java/ucar/nc2/iosp/dorade/Doradeheader.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/dorade/Doradeheader.java
@@ -37,7 +37,7 @@ public class Doradeheader {
     return true;
   }
 
-  void read(DoradeSweep mySweep, ucar.nc2.NetcdfFile ncfile, PrintStream out) throws IOException {
+  void read(DoradeSweep mySweep, ucar.nc2.NetcdfFile ncfile, PrintStream out) {
 
     this.ncfile = ncfile;
     DoradePARM[] parms = mySweep.getParamList();
@@ -308,7 +308,7 @@ public class Doradeheader {
   }
 
 
-  void addNCAttributes(NetcdfFile nc, DoradeSweep mySweep) throws DoradeSweep.DoradeSweepException {
+  void addNCAttributes(NetcdfFile nc, DoradeSweep mySweep) {
     nc.addAttribute(null, new Attribute("summary", "Dorade radar data " +
             "from radar " + mySweep.getSensorName(0) + " in the project " + mySweep.getProjectName()));
     nc.addAttribute(null, new Attribute("radar_name", mySweep.getSensorName(0)));

--- a/cdm/src/main/java/ucar/nc2/iosp/grads/GradsBinaryGridServiceProvider.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/grads/GradsBinaryGridServiceProvider.java
@@ -271,9 +271,8 @@ public class GradsBinaryGridServiceProvider extends AbstractIOServiceProvider {
   /**
    * Build the netCDF file
    *
-   * @throws IOException problem reading the file
    */
-  protected void buildNCFile() throws IOException {
+  protected void buildNCFile() {
     ncFile.empty();
     fillNCFile();
     ncFile.finish();

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf4/H4header.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf4/H4header.java
@@ -652,7 +652,7 @@ public class H4header extends NCheader
     return ncfile.addDimension(null, new Dimension(dimName, len));
   }
 
-  private Variable makeVariable(TagVH vh) throws IOException {
+  private Variable makeVariable(TagVH vh) {
     Vinfo vinfo = new Vinfo(vh.refno);
     vinfo.tags.add(vh);
     vh.vinfo = vinfo;

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf4/HdfEos.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf4/HdfEos.java
@@ -146,9 +146,8 @@ public class HdfEos {
      *
      * @param ncfile         Amend this file
      * @param structMetadata structMetadata as String
-     * @throws IOException on read error
      */
-    private void amendFromODL(NetcdfFile ncfile, String structMetadata) throws IOException {
+    private void amendFromODL(NetcdfFile ncfile, String structMetadata) {
         Group rootg = ncfile.getRootGroup();
 
         ODLparser parser = new ODLparser();

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf4/ODLparser.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf4/ODLparser.java
@@ -65,7 +65,7 @@ public class ODLparser {
     parseFromString(text);
   }
 
-  public Element parseFromString(String text) throws IOException {
+  public Element parseFromString(String text) {
     if (showRaw) System.out.println("Raw ODL=\n"+text);
     
     Element rootElem = new Element("odl");

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
@@ -209,7 +209,7 @@ Where startingBlockSize is from the header, ie the same for all indirect blocks.
   }
 
 
-  DHeapId getFractalHeapId(byte[] heapId) throws IOException {
+  DHeapId getFractalHeapId(byte[] heapId) {
     return new DHeapId(heapId);
   }
 

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
@@ -1750,9 +1750,8 @@ public class H5header extends NCheader
      * Constructor
      *
      * @param facade DataObjectFacade: always has an mdt and an msl
-     * @throws java.io.IOException on read error
      */
-    Vinfo(DataObjectFacade facade) throws IOException {
+    Vinfo(DataObjectFacade facade) {
       this.facade = facade;
       // LOOK if compact, do not use fileOffset
       this.dataPos = (facade.dobj.msl.type == 0) ? facade.dobj.msl.dataAddress : getFileOffset(facade.dobj.msl.dataAddress);

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayout.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayout.java
@@ -4,7 +4,6 @@
  */
 package ucar.nc2.iosp.hdf5;
 
-import ucar.ma2.InvalidRangeException;
 import ucar.ma2.DataType;
 import ucar.ma2.Section;
 import ucar.nc2.iosp.LayoutTiled;
@@ -36,10 +35,9 @@ class H5tiledLayout implements Layout {
    * @param vinfo       the vinfo object for this variable
    * @param dtype       type of data. may be different from v2.
    * @param wantSection the wanted section of data, contains a List of Range objects, must be complete
-   * @throws InvalidRangeException if section invalid for this variable
    * @throws java.io.IOException on io error
    */
-  H5tiledLayout(H5header.Vinfo vinfo, DataType dtype, Section wantSection) throws InvalidRangeException, IOException {
+  H5tiledLayout(H5header.Vinfo vinfo, DataType dtype, Section wantSection) throws IOException {
     assert vinfo.isChunked;
     assert vinfo.btree != null;
 
@@ -84,7 +82,7 @@ class H5tiledLayout implements Layout {
     return delegate.hasNext();
   }
 
-  public Chunk next() throws IOException {
+  public Chunk next() {
     return delegate.next();
   }
 

--- a/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
@@ -124,7 +124,7 @@ class H5tiledLayoutBB implements LayoutBB {
     return delegate.hasNext();
   }
 
-  public Chunk next() throws IOException {
+  public Chunk next() {
     return delegate.next();
   }
 

--- a/cdm/src/main/java/ucar/nc2/iosp/misc/NmcObsLegacy.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/misc/NmcObsLegacy.java
@@ -109,7 +109,7 @@ public class NmcObsLegacy extends AbstractIOServiceProvider {
     }
   }
 
-  public Array readData(Variable v, Section section) throws IOException, InvalidRangeException {
+  public Array readData(Variable v, Section section) throws IOException {
     switch (v.getShortName()) {
       case "station":
         return readStation(v, section);
@@ -307,7 +307,7 @@ public class NmcObsLegacy extends AbstractIOServiceProvider {
     return abb;
   }
 
-  public Array readReportIndex(Variable v, Section section) throws IOException {
+  public Array readReportIndex(Variable v, Section section) {
       //coverity[FB.BC_UNCONFIRMED_CAST]
     Structure s = (Structure) v;
     StructureMembers members = s.makeStructureMembers();
@@ -705,7 +705,7 @@ public class NmcObsLegacy extends AbstractIOServiceProvider {
     int code, next, nlevels, nbytes;
     Entry[] entries;
 
-    int read(byte[] b, int offset) throws IOException {
+    int read(byte[] b, int offset) {
 
       code = Integer.parseInt(new String(b, offset, 2, CDM.utf8Charset));
       next = Integer.parseInt(new String(b, offset + 2, 3, CDM.utf8Charset));

--- a/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
@@ -168,7 +168,7 @@ public class Nexrad2IOServiceProvider extends AbstractIOServiceProvider {
     ncfile.finish();
   }
 
-  public void makeVariable2(NetcdfFile ncfile, int datatype, String shortName, String longName, String abbrev, Level2VolumeScan vScan) throws IOException {
+  public void makeVariable2(NetcdfFile ncfile, int datatype, String shortName, String longName, String abbrev, Level2VolumeScan vScan) {
       List<List<Level2Record>> groups = null;
 
       if( shortName.startsWith("Reflectivity"))
@@ -226,7 +226,7 @@ public class Nexrad2IOServiceProvider extends AbstractIOServiceProvider {
 
   public Variable makeVariable(NetcdfFile ncfile, int datatype, String shortName,
                                String longName, String abbrev, List<List<Level2Record>> groups,
-                               int rd) throws IOException {
+                               int rd) {
       return makeVariable(ncfile, datatype, shortName, longName, abbrev, groups, rd, null);
   }
 

--- a/cdm/src/main/java/ucar/nc2/iosp/nids/Nidsiosp.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/nids/Nidsiosp.java
@@ -73,7 +73,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * Read nested structure data
    */
   public ucar.ma2.Array readNestedData(ucar.nc2.Variable v2, Section section)
-          throws java.io.IOException, ucar.ma2.InvalidRangeException {
+          throws ucar.ma2.InvalidRangeException {
 
     Variable vp = v2.getParentStructure();
     Object data;
@@ -112,7 +112,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
   /**
    * Read the data for each variable passed in
    */
-  public Array readData(Variable v2, Section section) throws IOException, InvalidRangeException {
+  public Array readData(Variable v2, Section section) throws InvalidRangeException {
     // subset
     Object data;
     Array outputData;
@@ -222,7 +222,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * @return the array  of member variable data
    */
   public Array readNestedGraphicSymbolData(String name, StructureMembers.Member m, ByteBuffer bos, Nidsheader.Vinfo vinfo,
-                                           java.util.List section) throws IOException, InvalidRangeException {
+                                           java.util.List section) throws InvalidRangeException {
     int[] pos = vinfo.pos;
     int size = pos.length;
     Structure pdata = (Structure) ncfile.findVariable(name);
@@ -300,7 +300,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * @return the array  of member variable data
    */
   public Array readNestedLinkedVectorData(String name, String memberName, ByteBuffer bos, Nidsheader.Vinfo vinfo,
-                                          java.util.List section) throws IOException, InvalidRangeException {
+                                          java.util.List section) throws InvalidRangeException {
 
     Structure pdata = (Structure) ncfile.findVariable(name);
     ArrayStructure ma = readLinkedVectorData(name, bos, vinfo);
@@ -403,7 +403,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * @return the array  of member variable data
    */
   public Array readNestedCircleStructData(String name, String memberName, ByteBuffer bos, Nidsheader.Vinfo vinfo,
-                                          java.util.List section) throws IOException, InvalidRangeException {
+                                          java.util.List section) throws InvalidRangeException {
 
     Structure pdata = (Structure) ncfile.findVariable(name);
     ArrayStructure ma = readCircleStructData(name, bos, vinfo);
@@ -496,7 +496,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
      * @return the data object of scan data
      */
     // all the work is here, so can be called recursively
-    public Object readOneScanGenericData(ByteBuffer bos, Nidsheader.Vinfo vinfo, String vName) throws IOException {
+    public Object readOneScanGenericData(ByteBuffer bos, Nidsheader.Vinfo vinfo, String vName) {
         int npixel = 0;
         short [] pdata = null;
 
@@ -554,7 +554,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * @return the data object of scan data
    */
   // all the work is here, so can be called recursively
-  public Object readOneScanData(ByteBuffer bos, Nidsheader.Vinfo vinfo, String vName) throws IOException, InvalidRangeException {
+  public Object readOneScanData(ByteBuffer bos, Nidsheader.Vinfo vinfo, String vName) {
     int doff = 0;
     int npixel = vinfo.yt * vinfo.xt;
     byte[] odata = new byte[vinfo.xt];
@@ -865,7 +865,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * @return the array  of member variable data
    */
   public Array readNestedWindBarbData(String name, String memberName, ByteBuffer bos, Nidsheader.Vinfo vinfo,
-                                      java.util.List section) throws IOException, InvalidRangeException {
+                                      java.util.List section) throws InvalidRangeException {
 
     Structure pdata = (Structure) ncfile.findVariable(name);
     ArrayStructure ma = readWindBarbData(name, bos, vinfo, null);
@@ -893,7 +893,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * @param vinfo variable info,
    * @return the arraystructure of wind barb data
    */
-  public ArrayStructure readWindBarbData(String name, ByteBuffer bos, Nidsheader.Vinfo vinfo, List sList) throws InvalidRangeException {
+  public ArrayStructure readWindBarbData(String name, ByteBuffer bos, Nidsheader.Vinfo vinfo, List sList) {
     int[] pos = vinfo.pos;
     int size = pos.length;
 
@@ -939,7 +939,7 @@ public class Nidsiosp extends AbstractIOServiceProvider {
    * @return the array  of member variable data
    */
   public Array readNestedVectorArrowData(String name, String memberName, ByteBuffer bos, Nidsheader.Vinfo vinfo,
-                                         java.util.List section) throws IOException, InvalidRangeException {
+                                         java.util.List section) throws InvalidRangeException {
 
     Structure pdata = (Structure) ncfile.findVariable(name);
     ArrayStructure ma = readVectorArrowData(name, bos, vinfo);
@@ -1072,7 +1072,7 @@ short arrowHeadValue = 0;    */
    * @return the array  of member variable data
    */
   public Array readNestedTextStringData(String name, String memberName, ByteBuffer bos, Nidsheader.Vinfo vinfo,
-                                        java.util.List section) throws IOException, InvalidRangeException {
+                                        java.util.List section) throws InvalidRangeException {
 
     Structure pdata = (Structure) ncfile.findVariable(name);
     ArrayStructure ma = readTextStringData(name, bos, vinfo);
@@ -1240,7 +1240,7 @@ short arrowHeadValue = 0;    */
    * @return the array  of member variable data
    */
   public Array readNestedDataUnlinkVector(String name, String memberName, ByteBuffer bos, Nidsheader.Vinfo vinfo,
-                                          java.util.List section) throws java.io.IOException, ucar.ma2.InvalidRangeException {
+                                          java.util.List section) throws ucar.ma2.InvalidRangeException {
 
     Structure pdata = (Structure) ncfile.findVariable(name);
     ArrayStructure ma = readUnlinkedVectorData(name, bos, vinfo);
@@ -1332,7 +1332,7 @@ short arrowHeadValue = 0;    */
 
 
   // all the work is here, so can be called recursively
-  public Object readOneArrayData(ByteBuffer bos, Nidsheader.Vinfo vinfo, String vName) throws IOException, InvalidRangeException {
+  public Object readOneArrayData(ByteBuffer bos, Nidsheader.Vinfo vinfo, String vName) {
     int doff = 0;
     int offset = 0;
     //byte[] odata = new byte[ vinfo.xt];
@@ -1402,7 +1402,7 @@ short arrowHeadValue = 0;    */
    * @param vinfo is variable info
    * @return the data object
    */
-  public Object readOneArrayData1(ByteBuffer bos, Nidsheader.Vinfo vinfo) throws IOException, InvalidRangeException {
+  public Object readOneArrayData1(ByteBuffer bos, Nidsheader.Vinfo vinfo) {
     int doff = 0;
     //byte[] odata = new byte[ vinfo.xt];
 

--- a/cdm/src/main/java/ucar/nc2/iosp/noaa/IgraPor.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/noaa/IgraPor.java
@@ -430,7 +430,7 @@ public class IgraPor extends AbstractIOServiceProvider {
     }
 
     @Override
-    public boolean hasNext() throws IOException {
+    public boolean hasNext() {
       if (!exists) return false;
       if (timeSeriesRaf == null) init();
       assert timeSeriesRaf != null;
@@ -523,7 +523,7 @@ public class IgraPor extends AbstractIOServiceProvider {
         }
 
         @Override
-        public StructureData next() throws IOException {
+        public StructureData next() {
           if (!hasNext()) return null;
           Matcher matcher = profileVinfo.p.matcher(lines.get(countRead));
           StructureData sd;

--- a/cdm/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
+++ b/cdm/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
@@ -861,7 +861,7 @@ channel.close();
    * @return the number of bytes written, possibly zero.
    */
   public long readToByteChannel11(ucar.nc2.Variable v2, Section section, WritableByteChannel channel)
-          throws java.io.IOException, ucar.ma2.InvalidRangeException {
+          throws java.io.IOException {
     Array data = readData(v2, section);
     float[] ftdata = new float[(int) data.getSize()];
     byte[] bytedata = new byte[(int) data.getSize() * 4];

--- a/cdm/src/main/java/ucar/nc2/ncml/Aggregation.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/Aggregation.java
@@ -214,7 +214,7 @@ public abstract class Aggregation {
  }
 
   // experimental
-  public void addCollection(String spec, String olderThan) throws IOException {
+  public void addCollection(String spec, String olderThan) {
     datasetManager = MFileCollectionManager.open(spec, spec, olderThan, new Formatter());
  }
 

--- a/cdm/src/main/java/ucar/nc2/ncml/NcMLReader.java
+++ b/cdm/src/main/java/ucar/nc2/ncml/NcMLReader.java
@@ -181,9 +181,8 @@ public class NcMLReader {
    * @param targetDS   referenced dataset
    * @param parentElem parent element - usually the aggregation element of the ncml
    * @return new dataset with the merged info
-   * @throws IOException on read error
    */
-  static public NetcdfDataset mergeNcMLdirect(NetcdfDataset targetDS, Element parentElem) throws IOException {
+  static public NetcdfDataset mergeNcMLdirect(NetcdfDataset targetDS, Element parentElem) {
 
     NcMLReader reader = new NcMLReader();
     reader.readGroup(targetDS, targetDS, null, null, parentElem);
@@ -801,7 +800,7 @@ public class NcMLReader {
    * @param refParent parent Group in referenced dataset
    * @param groupElem ncml group element
    */
-  private void readGroup(NetcdfDataset newds, NetcdfFile refds, Group parent, Group refParent, Element groupElem) throws IOException {
+  private void readGroup(NetcdfDataset newds, NetcdfFile refds, Group parent, Group refParent, Element groupElem) {
 
     Group g, refg = null;
     if (parent == null) { // this is the <netcdf> element
@@ -1376,7 +1375,7 @@ public class NcMLReader {
 
   /////////////////////////////////////////////////////////////////////////////////////////
 
-  private Aggregation readAgg(Element aggElem, String ncmlLocation, NetcdfDataset newds, CancelTask cancelTask) throws IOException {
+  private Aggregation readAgg(Element aggElem, String ncmlLocation, NetcdfDataset newds, CancelTask cancelTask) {
     String dimName = aggElem.getAttributeValue("dimName");
     String type = aggElem.getAttributeValue("type");
     String recheck = aggElem.getAttributeValue("recheckEvery");

--- a/cdm/src/main/java/ucar/nc2/stream/NcStreamReader.java
+++ b/cdm/src/main/java/ucar/nc2/stream/NcStreamReader.java
@@ -19,7 +19,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.zip.InflaterInputStream;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import ucar.nc2.constants.CDM;
 
 /**
@@ -311,7 +310,7 @@ public class NcStreamReader {
 
   /////////////////////////////////////////////////////////////////////
 
-  private NetcdfFile proto2nc(NcStreamProto.Header proto, NetcdfFile ncfile) throws InvalidProtocolBufferException {
+  private NetcdfFile proto2nc(NcStreamProto.Header proto, NetcdfFile ncfile) {
     if (ncfile == null)
       ncfile = new NetcdfFileSubclass(); // not used i think
     ncfile.setLocation(proto.getLocation());

--- a/cdm/src/main/java/ucar/nc2/time/CalendarDuration.java
+++ b/cdm/src/main/java/ucar/nc2/time/CalendarDuration.java
@@ -313,7 +313,7 @@ static private void test(String unit, String result) {
   assert jp.toString().equals(result) : jp.toString()+" != "+ result;
 }
 
-static public void main(String args[]) throws Exception {
+static public void main(String args[]) {
   test("sec", "PT1S");
   test("secs", "PT1S");
   test("minute", "PT1M");

--- a/cdm/src/main/java/ucar/nc2/util/cache/FileCacheGuava.java
+++ b/cdm/src/main/java/ucar/nc2/util/cache/FileCacheGuava.java
@@ -12,7 +12,6 @@ import com.google.common.cache.LoadingCache;
 import ucar.nc2.dataset.DatasetUrl;
 import ucar.nc2.util.CancelTask;
 
-import java.io.IOException;
 import java.util.Formatter;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -55,7 +54,7 @@ public class FileCacheGuava implements FileCacheIF {
   }
 
   @Override
-  public FileCacheable acquire(FileFactory factory, DatasetUrl durl) throws IOException {
+  public FileCacheable acquire(FileFactory factory, DatasetUrl durl) {
     return acquire(factory, durl.trueurl, durl, -1, null, null);
   }
 

--- a/uicdm/src/main/java/thredds/ui/catalog/CatalogTreeView.java
+++ b/uicdm/src/main/java/thredds/ui/catalog/CatalogTreeView.java
@@ -20,7 +20,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -444,17 +443,12 @@ public class CatalogTreeView extends JPanel {
       if (debugRef) System.out.println("readCatref on ="+ds.getName()+" "+isReading);
       if (!isReading) {
         isReading = true;
-        try {
-          Optional<DatasetNode> opt = catref.readCatref();
-          if (!opt.isPresent()) {
-            javax.swing.JOptionPane.showMessageDialog(CatalogTreeView.this, opt.getErrorMessage());
-            return;
-          }
-          setCatalog(opt.get());
-
-        } catch (IOException e) {
-          javax.swing.JOptionPane.showMessageDialog(CatalogTreeView.this, "Error reading catref " + catref.getName()+" err="+e.getMessage());
+        Optional<DatasetNode> opt = catref.readCatref();
+        if (!opt.isPresent()) {
+          javax.swing.JOptionPane.showMessageDialog(CatalogTreeView.this, opt.getErrorMessage());
+          return;
         }
+        setCatalog(opt.get());
       }
     }
 

--- a/uicdm/src/main/java/ucar/nc2/ui/widget/TextGetPutPane.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/widget/TextGetPutPane.java
@@ -35,8 +35,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 
-//import thredds.catalog.query.*;
-
 /**
  * A text widget that does get and put to a web URL.
  *
@@ -190,7 +188,6 @@ public class TextGetPutPane extends TextHistoryPane {
       ta.setText(os.toString(CDM.UTF8));
     }
 
-   //private DqcFactory dqcFactory = null;
     void validate(String urlString) {
       if (urlString == null) return;
       URI uri;
@@ -203,23 +200,14 @@ public class TextGetPutPane extends TextHistoryPane {
         return;
       }
       String contents = getText();
-      //boolean isCatalog = contents.indexOf("queryCapability") < 0;
-
       ByteArrayInputStream is = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
 
-      try {
-        CatalogBuilder catFactory = new CatalogBuilder();
-        Catalog cat = catFactory.buildFromLocation(urlString, null);
-        boolean isValid = !catFactory.hasFatalError();
+      CatalogBuilder catFactory = new CatalogBuilder();
+      Catalog cat = catFactory.buildFromLocation(urlString, null);
+      boolean isValid = !catFactory.hasFatalError();
 
-       javax.swing.JOptionPane.showMessageDialog(this,
-          "Catalog Validation = " + isValid + "\n" +  catFactory.getErrorMessage());
-
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-
-
+     javax.swing.JOptionPane.showMessageDialog(this,
+        "Catalog Validation = " + isValid + "\n" +  catFactory.getErrorMessage());
     }
 
     void putURL(String uriString) throws IOException {


### PR DESCRIPTION
This is part 2 of intellij cleanup.
Finish removing unneeded checked Exceptions, except leave them on top-level interfaces (even restore a few that had been removed).  This should also cut down on the affects on library users.

Probably more to think about when checked Exceptions should be used.