### PR TITLE
Refactor NEXRAD level2 format checking

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dt/radial/Nexrad2RadialAdapter.java
+++ b/cdm/core/src/main/java/ucar/nc2/dt/radial/Nexrad2RadialAdapter.java
@@ -36,9 +36,7 @@ public class Nexrad2RadialAdapter extends AbstractRadialAdapter {
     String convention = ncd.findAttValueIgnoreCase(null, "Conventions", null);
     if (_Coordinate.Convention.equals(convention)) {
       String format = ncd.findAttValueIgnoreCase(null, "Format", null);
-      if (format != null && (format.equals("ARCHIVE2") || format.equals("AR2V0001") || format.equals("CINRAD-SA")
-          || format.equals("AR2V0003") || format.equals("AR2V0002") || format.equals("AR2V0004")
-          || format.equals("AR2V0006") || format.equals("AR2V0007")))
+      if (format != null && (Nexrad2IOServiceProvider.isNEXRAD2Format(format) || format.equals("CINRAD-SA"))
         return this;
     }
     return null;

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Level2VolumeScan.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Level2VolumeScan.java
@@ -126,9 +126,10 @@ public class Level2VolumeScan {
       }
     }
 
-    // see if we have to uncompress
-    if (dataFormat.equals(AR2V0001) || dataFormat.equals(AR2V0003) || dataFormat.equals(AR2V0004)
-        || dataFormat.equals(AR2V0006) || dataFormat.equals(AR2V0007)) {
+    // see if we have to uncompress--basically looking for anything but the original Level2 format
+    // technically speaking, this BZ2 compression is a detail of transmission--there's no requirement in the
+    // ICDs that this BZ2 block compression is actually applied on disk.
+    if (dataFormat.startsWith("AR2V")) {
       raf.skipBytes(4);
       String BZ = raf.readString(2);
       if (BZ.equals("BZ")) {

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
@@ -35,15 +35,19 @@ public class Nexrad2IOServiceProvider extends AbstractIOServiceProvider {
   private static final int MISSING_INT = -9999;
   private static final float MISSING_FLOAT = Float.NaN;
 
+  static public boolean isNEXRAD2Format(String format) {
+    if (format != null && (format.equals("ARCHIVE2") || format.startsWith("AR2V"))) {
+      if (Integer.parseInt(format.substring(4)) > 8)
+        logger.warn("Trying to handle unknown but valid-looking format: " + format);
+      return true;
+    }
+    return false;
+  }
 
   public boolean isValidFile(RandomAccessFile raf) {
     try {
       raf.seek(0);
-      String test = raf.readString(8);
-      return test.equals(Level2VolumeScan.ARCHIVE2) || test.equals(Level2VolumeScan.AR2V0001)
-          || test.equals(Level2VolumeScan.AR2V0003) || test.equals(Level2VolumeScan.AR2V0004)
-          || test.equals(Level2VolumeScan.AR2V0002) || test.equals(Level2VolumeScan.AR2V0006)
-          || test.equals(Level2VolumeScan.AR2V0007);
+      return isNEXRAD2Format(raf.readString(8));
     } catch (IOException ioe) {
       return false;
     }


### PR DESCRIPTION
Don't try to enumerate all the possible values. Instead, just look for AR2V and a number--and log a warning is this number is bigger than the most recent we are aware of. Also refactor to eliminate duplicated code.

This is motivated by NWS ROC testing data declaring a format of AR2V0008.

@lesserwhirls I'm not having a lot of luck building locally at the moment. Can you double check my work here against the test file?