### PR TITLE
TdsMonitor fixes and improvement

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -219,6 +219,9 @@ libraries["jfreechart"] = "org.jfree:jfreechart:1.0.19"
 // http://www.jgoodies.com/. Latest version is 1.9.0, but there is breakage when we try to upgrade.
 libraries["jgoodies-forms"] = "com.jgoodies:jgoodies-forms:1.6.0"
 
+// LGoodDatePicker - swing calendar widget used in TdsMonitor
+libraries["lgooddatepicker"] = "com.github.lgooddatepicker:LGoodDatePicker:10.3.1"
+
 /////////////////////////////// Servlets to run tests against ////////////////////////////////
 
 // used by :dap4 test

--- a/uicdm/build.gradle
+++ b/uicdm/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile libraries["httpcore"]
     compile libraries["bounce"]
     compile libraries["re2j"]
+    compile libraries["lgooddatepicker"]
 
     compile libraries["slf4j-api"]
     runtime libraries["logback-classic"]

--- a/uicdm/src/main/java/thredds/ui/monitor/AccessLogTable.java
+++ b/uicdm/src/main/java/thredds/ui/monitor/AccessLogTable.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2019 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
 package thredds.ui.monitor;
 
-// import net.sf.ehcache.Cache;
-// import net.sf.ehcache.Element;
+import com.github.lgooddatepicker.components.DateTimePicker;
+import java.time.ZoneId;
 import org.jfree.data.time.Minute;
 import org.jfree.data.time.TimeSeries;
 import thredds.logs.AccessLogParser;
@@ -57,11 +57,12 @@ public class AccessLogTable extends JPanel {
   private TextHistoryPane infoTA;
   private IndependentWindow infoWindow;
 
-  private JTextArea startDateField, endDateField;
+  private DateTimePicker dateTimePickerStart, dateTimePickerEnd;
 
-  public AccessLogTable(JTextArea startDateField, JTextArea endDateField, PreferencesExt prefs, DnsLookup dnsLookup) {
-    this.startDateField = startDateField;
-    this.endDateField = endDateField;
+  public AccessLogTable(DateTimePicker dateTimePickerStart, DateTimePicker dateTimePickerEnd, PreferencesExt prefs,
+      DnsLookup dnsLookup) {
+    this.dateTimePickerStart = dateTimePickerStart;
+    this.dateTimePickerEnd = dateTimePickerEnd;
     this.prefs = prefs;
     this.dnsLookup = dnsLookup;
     PopupMenu varPopup;
@@ -257,26 +258,14 @@ public class AccessLogTable extends JPanel {
   public void setLocalManager(LogLocalManager manager) {
     this.manager = manager;
 
-    Date startDate = manager.getStartDate();
-    Date endDate = manager.getEndDate();
-    if (startDate != null)
-      startDateField.setText(df.format(startDate));
-    else
-      startDateField.setText(df.format(new Date()));
-
-    if (endDate != null)
-      endDateField.setText(df.format(endDate));
-    else
-      endDateField.setText(df.format(new Date()));
-
     LogCategorizer.setRoots(manager.getRoots());
   }
 
   void showLogs(LogReader.LogFilter filter) {
     Date start = null, end = null;
     try {
-      start = df.parse(startDateField.getText());
-      end = df.parse(endDateField.getText());
+      start = Date.from(dateTimePickerStart.getDateTimeStrict().atZone(ZoneId.systemDefault()).toInstant());
+      end = Date.from(dateTimePickerEnd.getDateTimeStrict().atZone(ZoneId.systemDefault()).toInstant());
       accessLogFiles = manager.getLocalFiles(start, end);
     } catch (Exception e) {
       e.printStackTrace();

--- a/uicdm/src/main/java/thredds/ui/monitor/AccessLogTable.java
+++ b/uicdm/src/main/java/thredds/ui/monitor/AccessLogTable.java
@@ -671,7 +671,7 @@ public class AccessLogTable extends JPanel {
     total_count += count;
     System.out.printf("showTimeSeriesAll: total_count = %d logs = %d%n", total_count, logs.size());
 
-    MultipleAxisChart mc = new MultipleAxisChart("Access Logs", intervalS + " average", "Mbytes Sent", bytesSentData);
+    MultipleAxisChart mc = new MultipleAxisChart("Access Logs", intervalS + " window", "Mbytes Sent", bytesSentData);
     mc.addSeries("Number of Requests", nreqData);
     mc.addSeries("Average Latency (secs)", timeTookData);
     mc.finish(new java.awt.Dimension(1000, 1000));

--- a/uicdm/src/main/java/thredds/ui/monitor/MultipleAxisChart.java
+++ b/uicdm/src/main/java/thredds/ui/monitor/MultipleAxisChart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2019 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -47,7 +47,6 @@ public class MultipleAxisChart extends JPanel {
     // chart.addSubtitle(new TextTitle("Four datasets and four range axes."));
     XYPlot plot = (XYPlot) chart.getPlot();
     plot.setOrientation(PlotOrientation.VERTICAL);
-    plot.getRangeAxis().setFixedDimension(15.0);
 
     this.setLayout(new BorderLayout());
     this.add(new ChartPanel(chart), BorderLayout.CENTER);
@@ -57,7 +56,6 @@ public class MultipleAxisChart extends JPanel {
 
   public void addSeries(String yaxisName, TimeSeries series) {
     NumberAxis axis2 = new NumberAxis(yaxisName);
-    axis2.setFixedDimension(10.0);
     axis2.setAutoRangeIncludesZero(false);
 
     XYPlot plot = (XYPlot) chart.getPlot();

--- a/uicdm/src/main/java/thredds/ui/monitor/TdsMonitor.java
+++ b/uicdm/src/main/java/thredds/ui/monitor/TdsMonitor.java
@@ -308,6 +308,18 @@ public class TdsMonitor extends JPanel {
       manager = new LogLocalManager(server, isAccess);
       manager.getLocalFiles(null, null);
       setLocalManager(manager);
+
+      // if there are log files associated with this server,
+      // make sure the server is in the list of choices
+      // in the combo box (and if not, add it)
+      if (manager.getStartDate() != null) {
+        DefaultComboBoxModel cbm = (DefaultComboBoxModel) serverCB.getModel();
+        if (cbm.getIndexOf(server) == -1) {
+          // add server to combo box
+          serverCB.addItem(server);
+        }
+      }
+
       initDateTimeWidget();
     }
 


### PR DESCRIPTION
This PR fixes a few bugs, namely:

1. Y-Axis labels on the AccessLogs panel's TimeSeries chart:

   **Before:**
   ![before_chart](https://user-images.githubusercontent.com/67096/71487727-237d7600-27da-11ea-9f92-d0d3d8935f0c.png)

   **After:**
   ![after_chart](https://user-images.githubusercontent.com/67096/71487740-309a6500-27da-11ea-92e3-65867a6588e0.png)

1. Minor clarification of the TimeSeries chart's x-axis label.

1. Allow logs that exists on disk, but have not been downloaded by TdsMonitor directly, to be analyzed (initilized by typing the name of the server into the `server` text box in the ManageLogs panel).

This PR also introduces an improvement, specifically by allowing users to choose date/time limits on the access and servlet logs via a [LGoodDatePicker](https://github.com/LGoodDatePicker/LGoodDatePicker/) DateTimePicker widget rather than editing an ISO time string by hand.

* **Before:**
   ![before_dateTime](https://user-images.githubusercontent.com/67096/71487748-37c17300-27da-11ea-8870-5a84bb26b0a3.png)

* **After:**
   ![after_dateTime](https://user-images.githubusercontent.com/67096/71487751-3abc6380-27da-11ea-97c3-b23a89530502.png)

