### PR TITLE
Grib2Pds throw UnsupportedOperation rather than return null

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Pds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Pds.java
@@ -68,7 +68,7 @@ public abstract class Grib2Pds {
         return new Grib2Pds61(input);
       default:
         log.warn("Missing template " + template);
-        return null;
+        throw new UnsupportedOperationException ("Product Definition " + template + " not yet implemented.");
     }
   }
 


### PR DESCRIPTION
Grib2Pds returns a null if product template is not recognized. Higher up the chain, this results in an unhelpful NullPointerException being thrown. Better to throw an UnsupportedOperation exception with a useful message. Note that the latter way is how Grib2Gds handles an unrecognized grid template.