### PR TITLE
Account for calendar when performing a joinExisting aggregation and units change

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/WRFConvention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/WRFConvention.java
@@ -777,27 +777,30 @@ public class WRFConvention extends CoordSystemBuilder {
       return CONVENTION_NAME;
     }
 
-    @Override
-    public boolean isMine(NetcdfFile ncfile) {
-      if (null == ncfile.findDimension("south_north"))
-        return false;
-
-      // ARW only
-      Attribute att = ncfile.findGlobalAttribute("DYN_OPT");
-      if (att != null) {
-        if (att.getNumericValue().intValue() != 2)
-          return false;
-      } else {
-        att = ncfile.findGlobalAttribute("GRIDTYPE");
-        if (att != null) {
-          if (!att.getStringValue().equalsIgnoreCase("C") && !att.getStringValue().equalsIgnoreCase("E"))
-            return false;
-        }
-      }
-
-      att = ncfile.findGlobalAttribute("MAP_PROJ");
-      return att != null;
-    }
+    // not ready
+    /*
+     * @Override
+     * public boolean isMine(NetcdfFile ncfile) {
+     * if (null == ncfile.findDimension("south_north"))
+     * return false;
+     * 
+     * // ARW only
+     * Attribute att = ncfile.findGlobalAttribute("DYN_OPT");
+     * if (att != null) {
+     * if (att.getNumericValue().intValue() != 2)
+     * return false;
+     * } else {
+     * att = ncfile.findGlobalAttribute("GRIDTYPE");
+     * if (att != null) {
+     * if (!att.getStringValue().equalsIgnoreCase("C") && !att.getStringValue().equalsIgnoreCase("E"))
+     * return false;
+     * }
+     * }
+     * 
+     * att = ncfile.findGlobalAttribute("MAP_PROJ");
+     * return att != null;
+     * }
+     */
 
     @Override
     public CoordSystemBuilder open(NetcdfDataset.Builder datasetBuilder) {

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingAllLeapCal.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingAllLeapCal.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!--1950 -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="366" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2016-01-01 00:00:00" />
+        <attribute name="calendar" value="all_leap" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!--1951 -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="366" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2017-01-01 00:00:00" />
+        <attribute name="calendar" value="all_leap" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!--1950 uniform30day calendar-->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="360" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2019-01-01 00:00:00" />
+        <attribute name="calendar" value="uniform30day" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!--1951 360_day calendar -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="360" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2020-01-01 00:00:00" />
+        <attribute name="calendar" value="uniform30day" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingGregorianCal.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingGregorianCal.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!-- On the gregorian calendar, 4 October 1582 was followed by 15 October 1582. -->
+    <!-- Therefore, this year should have 365 - 10 = 355 days -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="355" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 1582-01-01 00:00:00" />
+        <attribute name="calendar" value="gregorian" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!--1583: first full year of the gregorian calendar -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 1583-01-01 00:00:00" />
+        <attribute name="calendar" value="gregorian" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingInequivalentCals.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingInequivalentCals.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!-- 360_day calendar -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="360" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2017-01-01 00:00:00" />
+        <attribute name="calendar" value="360_day" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!-- gregorian calendar -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2018-01-01 00:00:00" />
+        <attribute name="calendar" value="gregorian" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingJulienCal.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingJulienCal.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!-- On the Julian calendar, 4 October 1582 was followed by 5 October 1582.
+         which is unlike the gregorian calendar, 4 October 1582 was followed by 15 October 1582.
+         Therefore, this year should still have 365 days -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 1582-01-01 00:00:00" />
+        <attribute name="calendar" value="julian" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!--1583: first full year of the gregorian calendar, but we're staying old school here (e.g. using Julian calendar). -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 1583-01-01 00:00:00" />
+        <attribute name="calendar" value="julian" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingNoCal.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingNoCal.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <!-- no calendar attributes defined - should default to proleptic_gregorian -->
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2017-01-01 00:00:00" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2018-01-01 00:00:00" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingNoLeapCal.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingNoLeapCal.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!--1950 -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2016-01-01 00:00:00" />
+        <attribute name="calendar" value="noleap" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!--1951 -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2017-01-01 00:00:00" />
+        <attribute name="calendar" value="noleap" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingProlepticGregorianCal.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingProlepticGregorianCal.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!-- On the gregorian calendar, 4 October 1582 was followed by 15 October 1582.
+         However, the proleptic_gregorian calendar pretends that didn't happen and
+         applies itself retroactively. Therefore, on the proleptic_gregorian calendar
+         this year should have 365 days, not 355 days -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 1582-01-01 00:00:00" />
+        <attribute name="calendar" value="proleptic_gregorian" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!--1583: actual first full year of the gregorian calendar -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="365" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 1583-01-01 00:00:00" />
+        <attribute name="calendar" value="proleptic_gregorian" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingUniform30DayCal.xml
+++ b/cdm/core/src/test/data/ncml/agg_with_calendar/aggExistingUniform30DayCal.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" timeUnitsChange="true">
+    <!--1950 -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="360" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2019-01-01 00:00:00" />
+        <attribute name="calendar" value="uniform30day" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="100" increment="10" />
+      </variable>
+    </netcdf>
+    <!--1951 -->
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <dimension name="time" length="360" />
+      <variable name="time" shape="time" type="int">
+        <attribute name="units" value="days since 2020-01-01 00:00:00" />
+        <attribute name="calendar" value="uniform30day" />
+        <values start="0" increment="1" />
+      </variable>
+      <variable name="some_var" shape="time" type="int">
+        <values start="200" increment="10" />
+      </variable>
+    </netcdf>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExisting.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExisting.java
@@ -1,18 +1,31 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.ncml;
 
+import static com.google.common.truth.Truth.assertThat;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
-import ucar.nc2.*;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.constants.CF;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.time.Calendar;
+import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.CalendarDateUnit;
+import ucar.nc2.time.CalendarPeriod.Field;
 import ucar.unidata.util.test.Assert2;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 
 /** Test TestNcml - AggExisting in the JUnit framework. */
 
@@ -195,6 +208,347 @@ public class TestAggExisting {
       if (ncd != null)
         ncd.close();
     }
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testNcmlAggInequivalentCals() throws IOException {
+    // Tests that an aggregation with inequivalent calendars across the individual datasets will fail
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
+    NcMLReader.readNcML(filename, null);
+  }
+
+  @Test
+  public void testNcmlAggExistingNoCal() throws IOException {
+    // no calendar attribute in the aggregation, which should default to using proleptic_gregorian
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
+
+    NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(365 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2017-01-01T00:00:00";
+    String expectedEnd = "2018-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    // If anyone ever decides to change the default calendar, this should give them pause
+    Attribute calAttr = timeVar.findAttributeIgnoreCase(CF.CALENDAR);
+    assertThat(calAttr).isNotNull();
+    String calName = calAttr.getStringValue();
+    assertThat(calName).ignoringCase().isEqualTo("proleptic_gregorian");
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingNoLeapCal() throws IOException {
+    // with calendar = noleap, each year should have 365 days, even in a leap years
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
+
+    NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(365 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2016-01-01T00:00:00";
+    String expectedEnd = "2017-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingAllLeapCal() throws IOException {
+    // with calendar = all_leap, each year should have 366 days, even in non-leap years
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
+
+    NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(366 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2016-01-01T00:00:00";
+    String expectedEnd = "2017-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingUniform30DayCal() throws IOException {
+    // with calendar = uniform30day, each year should have 360 days (12 months, each with 30 days)
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
+    testNcmlAggExisting30DayCals(filename);
+  }
+
+  @Test
+  public void testNcmlAggExistingEquivalentUniform30DayCals() throws IOException {
+    // in this NcML agg, one file uses uniform30day calendar, the other uses 360_day calendar, but
+    // those are equivalent, so we let it slide. Otherwise, identical to the ncml agg used in
+    // testNcmlAggExistingUniform30DayCal()
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
+    testNcmlAggExisting30DayCals(filename);
+  }
+
+  private void testNcmlAggExisting30DayCals(String filename) throws IOException {
+    NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(360 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2019-01-01T00:00:00";
+    String expectedEnd = "2020-12-30T00:00:00"; // every month has 30 days
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingJulienCal() throws IOException {
+    // with calendar = Julian, 4 October 1582 was followed by 5 October 1582 (unlike gregorian, where 4 October
+    // was followed by 15 October).
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
+
+    NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    // 1582 -> 365 days (because we stay on Julian calendar)
+    // 1583 -> 365 days
+    // expected is 365 days + 365 days = 730 days
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(730 - 1);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    // Check the crossover for Gregorian, just to be sure we have it right for Julian
+    // 4 October 1582 would be:
+    //
+    // 31 days Jan
+    // 28 days Feb
+    // 31 days March
+    // 30 days April
+    // 31 days May
+    // 30 days June
+    // 31 days July
+    // 31 days August
+    // 30 days September
+    // 4 days October
+    // --------------
+    // 277 days would be 4 October 1582
+    // 278 days would be 5 October 1582
+    //
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    int indexOct4 = 277 - 1;
+    CalendarDate calendarDateBefore = calendarDateUnit.makeCalendarDate(indexOct4);
+    CalendarDate expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-4T0:0:0");
+    assertThat(calendarDateBefore).isEqualTo(expected);
+
+    // 278 days -> 5 October 1582
+    CalendarDate calendarDateAfter = calendarDateUnit.makeCalendarDate(indexOct4 + 1);
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-5T0:0:0");
+    assertThat(calendarDateAfter).isEqualTo(expected);
+
+    // check start and end dates of aggregation
+    String expectedStart = "1582-01-01T00:00:00";
+    String expectedEnd = "1583-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingGregorianCal() throws IOException {
+    // with calendar = gregorian, 4 October 1582 was followed by 15 October 1582
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
+
+    NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    // 1582 -> 365 - 10 = 355 days
+    // 1583 -> 365 days
+    // expected is 355 days + 365 days = 720
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(720 - 1);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    // Check the crossover for Gregorian, just to be sure we have it right for Julian
+    // 4 October 1582 would be:
+    //
+    // 31 days Jan
+    // 28 days Feb
+    // 31 days March
+    // 30 days April
+    // 31 days May
+    // 30 days June
+    // 31 days July
+    // 31 days August
+    // 30 days September
+    // 4 days October
+    // --------------
+    // 277 days would be 4 October 1582
+    // 278 days would be 15 October 1582
+    //
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    int indexOct4 = 277 - 1;
+    CalendarDate calendarDateBefore = calendarDateUnit.makeCalendarDate(indexOct4);
+    CalendarDate expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-4T0:0:0");
+    assertThat(calendarDateBefore).isEqualTo(expected);
+
+    // 278 days -> 15 October 1582
+    CalendarDate calendarDateAfter = calendarDateUnit.makeCalendarDate(indexOct4 + 1);
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-15T0:0:0");
+    assertThat(calendarDateAfter).isEqualTo(expected);
+
+    // 355 days + 365 days = 720 days in aggregation
+    int indexLastDate = 720 - 1;
+    CalendarDate lastCalendarDate = calendarDateUnit.makeCalendarDate(indexLastDate);
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1583-12-31T0:0:0");
+    assertThat(lastCalendarDate).isEqualTo(expected);
+
+    // check start and end dates of aggregation
+    String expectedStart = "1582-01-01T00:00:00";
+    String expectedEnd = "1583-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingProlepticGregorianCal() throws IOException {
+    // with calendar = proleptic_gregorian, 1582 and 1583 should each have 365 days
+    // (for a gregorian calendar, 1852 would only have 355
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
+
+    NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(365 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "1582-01-01T00:00:00";
+    String expectedEnd = "1583-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+    ncfile.close();
+  }
+
+  private class TimeDelta {
+
+    private final Number value;
+    private final Field unit;
+
+    TimeDelta(Number value, Field unit) {
+      this.value = value;
+      this.unit = unit;
+    }
+
+    Number getValue() {
+      return value;
+    }
+
+    Field getUnit() {
+      return unit;
+    }
+  }
+
+  private CalendarDateUnit getCalendarDateUnit(Variable timeVar) {
+    Attribute calAttr = timeVar.findAttributeIgnoreCase(CF.CALENDAR);
+    assertThat(calAttr).isNotNull();
+    Calendar cal = Calendar.get(calAttr.getStringValue());
+    return CalendarDateUnit.withCalendar(cal, timeVar.getUnitsString());
+  }
+
+  private void testTimeDelta(Variable timeVar, TimeDelta expectedDiff) throws IOException {
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    int[] shape = timeVar.getShape();
+    Array vals = timeVar.read();
+    for (int val = 1; val < shape[0]; val++) {
+      CalendarDate today = calendarDateUnit.makeCalendarDate(vals.getInt(val));
+      CalendarDate yesterday = calendarDateUnit.makeCalendarDate(vals.getInt(val - 1));
+      long diff = today.getDifference(yesterday, expectedDiff.getUnit());
+      assertThat(diff).isEqualTo(expectedDiff.getValue());
+    }
+  }
+
+  private void testStartAndEnd(Variable timeVar, String start, String end) throws IOException {
+    Array vals = timeVar.read();
+    int[] shape = vals.getShape();
+
+    // check start date of aggregation
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    CalendarDate calendarDate = calendarDateUnit.makeCalendarDate(vals.getInt(0));
+    CalendarDate expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), start);
+    assertThat(calendarDate).isEqualTo(expected);
+
+    // check end date of aggregation
+    calendarDate = calendarDateUnit.makeCalendarDate(vals.getInt(shape[0] - 1));
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), end);
+    assertThat(calendarDate).isEqualTo(expected);
   }
 
   public void testDimensions(NetcdfFile ncfile) {

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingNew.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingNew.java
@@ -1,0 +1,716 @@
+/*
+ * Copyright (c) 1998-2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.nc2.ncml;
+
+import static com.google.common.truth.Truth.assertThat;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.TestNetcdfFileBuilder;
+import ucar.nc2.Variable;
+import ucar.nc2.constants.CF;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDataset.Builder;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.internal.ncml.NcMLReaderNew;
+import ucar.nc2.time.Calendar;
+import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.CalendarDateUnit;
+import ucar.nc2.time.CalendarPeriod.Field;
+import ucar.unidata.util.test.Assert2;
+
+/** Test TestNcml - AggExisting in the JUnit framework. */
+
+public class TestAggExistingNew {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Test
+  public void testNcmlDirect() throws IOException, InvalidRangeException {
+    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+
+    NetcdfFile ncfile = NcMLReaderNew.readNcML(filename, null, null).build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+  }
+
+
+  @Test
+  public void testNcmlDataset() throws IOException, InvalidRangeException {
+    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+
+    NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlDatasetNoProtocolInFilename() throws IOException, InvalidRangeException {
+    String filename = "./" + TestNcMLRead.topDir + "aggExisting.xml";
+
+    NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+  }
+
+  @Test(expected = IOException.class)
+  public void testNcmlDatasetNoProtocolInNcmlAbsPath() throws IOException, InvalidRangeException {
+    // if using an absolute path in the NcML file location attr of the element netcdf, then
+    // you must prepend file:
+    // this should fail with an IOException
+    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+
+    NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+  }
+
+  @Test(expected = IOException.class)
+  public void testNcmlDatasetNoProtocolInFilenameOrNcmlAbsPath() throws IOException, InvalidRangeException {
+    // if using an absolute path in the NcML file location attr of the element netcdf, then
+    // you must prepend file:
+    // this should fail with an IOException
+    String filename = "./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+
+    NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlDatasetNoProtocolInNcmlRelPath() throws IOException, InvalidRangeException {
+    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting7.xml";
+
+    NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlDatasetNoProtocolInFilenameOrNcmlRelPath() throws IOException, InvalidRangeException {
+    String filename = "./" + TestNcMLRead.topDir + "aggExisting7.xml";
+
+    NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlDatasetWcoords() throws IOException, InvalidRangeException {
+    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingWcoords.xml";
+
+    NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
+    logger.debug(" testNcmlDatasetWcoords.open {}", filename);
+
+    testDimensions(ncfile);
+    testCoordVar(ncfile);
+    testAggCoordVar(ncfile);
+    testReadData(ncfile);
+    testReadSlice(ncfile);
+    ncfile.close();
+    logger.debug(" testNcmlDatasetWcoords.closed ");
+  }
+
+  // remove test - now we get a coordinate initialized to missing data, but at least testCoordsAdded works!
+  // @Test
+  public void testNoCoords() throws IOException {
+    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoords.xml";
+    logger.debug("{}", filename);
+    NetcdfDataset ncd = null;
+
+    try {
+      ncd = NetcdfDatasets.openDataset(filename, true, null);
+      Variable time = ncd.findVariable(null, "time");
+      Array data = time.read();
+      // all missing
+      // assert data.getInt(0) ==
+    } finally {
+      if (ncd != null)
+        ncd.close();
+    }
+    // logger.debug("{}", ncd);
+    // assert false;
+  }
+
+  // LOOK this test expects an Exception, but it seems to work. Why isnt this test failing in travis?
+  // @Test
+  public void testNoCoordsDir() throws IOException {
+    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
+
+    try (NetcdfDataset ncd = NetcdfDatasets.openDataset(filename, true, null)) {
+      System.out.printf("testNoCoordsDir supposed to fail = %s", ncd);
+      assert false;
+    } catch (Exception e) {
+      // expect an Exception
+      assert true;
+    }
+  }
+
+  @Test
+  public void testCoordsAdded() throws IOException {
+    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingAddCoord.ncml";
+    logger.debug("{}", filename);
+    NetcdfDataset ncd = null;
+
+    try {
+      ncd = NetcdfDatasets.openDataset(filename, true, null);
+      logger.debug("{}", ncd);
+    } finally {
+      if (ncd != null)
+        ncd.close();
+    }
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testNcmlAggInequivalentCals() throws IOException {
+    // Tests that an aggregation with inequivalent calendars across the individual datasets will fail
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
+    NcMLReaderNew.readNcML(filename, null, null).build();
+  }
+
+  @Test
+  public void testNcmlAggExistingNoCal() throws IOException {
+    // no calendar attribute in the aggregation, which should default to using proleptic_gregorian
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
+
+    Builder netcdfFileBuilder = NcMLReaderNew.readNcML(filename, null, null);
+    NetcdfFile ncfile = netcdfFileBuilder.build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(365 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2017-01-01T00:00:00";
+    String expectedEnd = "2018-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    // If anyone ever decides to change the default calendar, this should give them pause
+    Attribute calAttr = timeVar.attributes().findAttributeIgnoreCase(CF.CALENDAR);
+    assertThat(calAttr).isNotNull();
+    String calName = calAttr.getStringValue();
+    assertThat(calName).ignoringCase().isEqualTo("proleptic_gregorian");
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingNoLeapCal() throws IOException {
+    // with calendar = noleap, each year should have 365 days, even in a leap years
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
+
+    NetcdfFile ncfile = NcMLReaderNew.readNcML(filename, null, null).build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(365 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2016-01-01T00:00:00";
+    String expectedEnd = "2017-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingAllLeapCal() throws IOException {
+    // with calendar = all_leap, each year should have 366 days, even in non-leap years
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
+
+    NetcdfFile ncfile = NcMLReaderNew.readNcML(filename, null, null).build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(366 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2016-01-01T00:00:00";
+    String expectedEnd = "2017-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingUniform30DayCal() throws IOException {
+    // with calendar = uniform30day, each year should have 360 days (12 months, each with 30 days)
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
+    testNcmlAggExisting30DayCals(filename);
+  }
+
+  @Test
+  public void testNcmlAggExistingEquivalentUniform30DayCals() throws IOException {
+    // in this NcML agg, one file uses uniform30day calendar, the other uses 360_day calendar, but
+    // those are equivalent, so we let it slide. Otherwise, identical to the ncml agg used in
+    // testNcmlAggExistingUniform30DayCal()
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
+    testNcmlAggExisting30DayCals(filename);
+  }
+
+  private void testNcmlAggExisting30DayCals(String filename) throws IOException {
+    NetcdfFile ncfile = NcMLReaderNew.readNcML(filename, null, null).build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(360 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "2019-01-01T00:00:00";
+    String expectedEnd = "2020-12-30T00:00:00"; // every month has 30 days
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingJulienCal() throws IOException {
+    // with calendar = Julian, 4 October 1582 was followed by 5 October 1582 (unlike gregorian, where 4 October
+    // was followed by 15 October).
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
+
+    NetcdfFile ncfile = NcMLReaderNew.readNcML(filename, null, null).build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    // 1582 -> 365 days (because we stay on Julian calendar)
+    // 1583 -> 365 days
+    // expected is 365 days + 365 days = 730 days
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(730 - 1);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    // Check the crossover for Gregorian, just to be sure we have it right for Julian
+    // 4 October 1582 would be:
+    //
+    // 31 days Jan
+    // 28 days Feb
+    // 31 days March
+    // 30 days April
+    // 31 days May
+    // 30 days June
+    // 31 days July
+    // 31 days August
+    // 30 days September
+    // 4 days October
+    // --------------
+    // 277 days would be 4 October 1582
+    // 278 days would be 5 October 1582
+    //
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    int indexOct4 = 277 - 1;
+    CalendarDate calendarDateBefore = calendarDateUnit.makeCalendarDate(indexOct4);
+    CalendarDate expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-4T0:0:0");
+    assertThat(calendarDateBefore).isEqualTo(expected);
+
+    // 278 days -> 5 October 1582
+    CalendarDate calendarDateAfter = calendarDateUnit.makeCalendarDate(indexOct4 + 1);
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-5T0:0:0");
+    assertThat(calendarDateAfter).isEqualTo(expected);
+
+    // check start and end dates of aggregation
+    String expectedStart = "1582-01-01T00:00:00";
+    String expectedEnd = "1583-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingGregorianCal() throws IOException {
+    // with calendar = gregorian, 4 October 1582 was followed by 15 October 1582
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
+
+    NetcdfFile ncfile = NcMLReaderNew.readNcML(filename, null, null).build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    // 1582 -> 365 - 10 = 355 days
+    // 1583 -> 365 days
+    // expected is 355 days + 365 days = 720
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(720 - 1);
+
+    // the difference between two sequential CalendarDate objects should be 1 day
+    testTimeDelta(timeVar, new TimeDelta(1, Field.Day));
+
+    // Check the crossover for Gregorian, just to be sure we have it right for Julian
+    // 4 October 1582 would be:
+    //
+    // 31 days Jan
+    // 28 days Feb
+    // 31 days March
+    // 30 days April
+    // 31 days May
+    // 30 days June
+    // 31 days July
+    // 31 days August
+    // 30 days September
+    // 4 days October
+    // --------------
+    // 277 days would be 4 October 1582
+    // 278 days would be 15 October 1582
+    //
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    int indexOct4 = 277 - 1;
+    CalendarDate calendarDateBefore = calendarDateUnit.makeCalendarDate(indexOct4);
+    CalendarDate expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-4T0:0:0");
+    assertThat(calendarDateBefore).isEqualTo(expected);
+
+    // 278 days -> 15 October 1582
+    CalendarDate calendarDateAfter = calendarDateUnit.makeCalendarDate(indexOct4 + 1);
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1582-10-15T0:0:0");
+    assertThat(calendarDateAfter).isEqualTo(expected);
+
+    // 355 days + 365 days = 720 days in aggregation
+    int indexLastDate = 720 - 1;
+    CalendarDate lastCalendarDate = calendarDateUnit.makeCalendarDate(indexLastDate);
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), "1583-12-31T0:0:0");
+    assertThat(lastCalendarDate).isEqualTo(expected);
+
+    // check start and end dates of aggregation
+    String expectedStart = "1582-01-01T00:00:00";
+    String expectedEnd = "1583-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+
+    ncfile.close();
+  }
+
+  @Test
+  public void testNcmlAggExistingProlepticGregorianCal() throws IOException {
+    // with calendar = proleptic_gregorian, 1582 and 1583 should each have 365 days
+    // (for a gregorian calendar, 1852 would only have 355
+    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
+
+    NetcdfFile ncfile = NcMLReaderNew.readNcML(filename, null, null).build();
+    logger.debug(" TestNcmlAggExisting.open {}", filename);
+    Variable timeVar = ncfile.findVariable("time");
+    assert timeVar != null;
+    int[] shape = timeVar.getShape();
+    assertThat(shape.length).isEqualTo(1);
+
+    Array vals = timeVar.read();
+    assertThat(vals.getInt(0)).isEqualTo(0);
+    timeVar.getShape();
+    assertThat(vals.getInt(shape[0] - 1)).isEqualTo(365 * 2 - 1);
+
+    // check start and end dates of aggregation
+    String expectedStart = "1582-01-01T00:00:00";
+    String expectedEnd = "1583-12-31T00:00:00";
+    testStartAndEnd(timeVar, expectedStart, expectedEnd);
+    ncfile.close();
+  }
+
+  private class TimeDelta {
+
+    private final Number value;
+    private final Field unit;
+
+    TimeDelta(Number value, Field unit) {
+      this.value = value;
+      this.unit = unit;
+    }
+
+    Number getValue() {
+      return value;
+    }
+
+    Field getUnit() {
+      return unit;
+    }
+  }
+
+  private CalendarDateUnit getCalendarDateUnit(Variable timeVar) {
+    Attribute calAttr = timeVar.attributes().findAttributeIgnoreCase("calendar");
+    assertThat(calAttr).isNotNull();
+    Calendar cal = Calendar.get(calAttr.getStringValue());
+    return CalendarDateUnit.withCalendar(cal, timeVar.getUnitsString());
+  }
+
+  private void testTimeDelta(Variable timeVar, TimeDelta expectedDiff) throws IOException {
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    int[] shape = timeVar.getShape();
+    Array vals = timeVar.read();
+    for (int val = 1; val < shape[0]; val++) {
+      CalendarDate today = calendarDateUnit.makeCalendarDate(vals.getInt(val));
+      CalendarDate yesterday = calendarDateUnit.makeCalendarDate(vals.getInt(val - 1));
+      long diff = today.getDifference(yesterday, expectedDiff.getUnit());
+      assertThat(diff).isEqualTo(expectedDiff.getValue());
+    }
+  }
+
+  private void testStartAndEnd(Variable timeVar, String start, String end) throws IOException {
+    Array vals = timeVar.read();
+    int[] shape = vals.getShape();
+
+    // check start date of aggregation
+    CalendarDateUnit calendarDateUnit = getCalendarDateUnit(timeVar);
+    CalendarDate calendarDate = calendarDateUnit.makeCalendarDate(vals.getInt(0));
+    CalendarDate expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), start);
+    assertThat(calendarDate).isEqualTo(expected);
+
+    // check end date of aggregation
+    calendarDate = calendarDateUnit.makeCalendarDate(vals.getInt(shape[0] - 1));
+    expected = CalendarDate.parseISOformat(calendarDateUnit.getCalendar().name(), end);
+    assertThat(calendarDate).isEqualTo(expected);
+  }
+
+  public void testDimensions(NetcdfFile ncfile) {
+    Dimension latDim = ncfile.findDimension("lat");
+    assert null != latDim;
+    assert latDim.getShortName().equals("lat");
+    assert latDim.getLength() == 3;
+    assert !latDim.isUnlimited();
+
+    Dimension lonDim = ncfile.findDimension("lon");
+    assert null != lonDim;
+    assert lonDim.getShortName().equals("lon");
+    assert lonDim.getLength() == 4;
+    assert !lonDim.isUnlimited();
+
+    Dimension timeDim = ncfile.findDimension("time");
+    assert null != timeDim;
+    assert timeDim.getShortName().equals("time");
+    assert timeDim.getLength() == 59;
+  }
+
+  public void testCoordVar(NetcdfFile ncfile) throws IOException {
+
+    Variable lat = ncfile.findVariable("lat");
+    assert null != lat;
+    assert lat.getShortName().equals("lat");
+    assert lat.getRank() == 1;
+    assert lat.getSize() == 3;
+    assert lat.getShape()[0] == 3;
+    assert lat.getDataType() == DataType.FLOAT;
+
+    assert !lat.isUnlimited();
+    assert lat.getDimension(0).equals(ncfile.findDimension("lat"));
+
+    Attribute att = lat.findAttribute("units");
+    assert null != att;
+    assert !att.isArray();
+    assert att.isString();
+    assert att.getDataType() == DataType.STRING;
+    assert att.getStringValue().equals("degrees_north");
+    assert att.getNumericValue() == null;
+    assert att.getNumericValue(3) == null;
+
+    Array data = lat.read();
+    assert data.getRank() == 1;
+    assert data.getSize() == 3;
+    assert data.getShape()[0] == 3;
+    assert data.getElementType() == float.class;
+
+    IndexIterator dataI = data.getIndexIterator();
+    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 41.0);
+    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 40.0);
+    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 39.0);
+  }
+
+  public void testAggCoordVar(NetcdfFile ncfile) {
+    Variable time = ncfile.findVariable("time");
+    assert null != time;
+
+    String testAtt = time.findAttValueIgnoreCase("ncmlAdded", null);
+    assert testAtt != null;
+    assert testAtt.equals("timeAtt");
+
+    assert time.getShortName().equals("time");
+    assert time.getRank() == 1;
+    assert time.getSize() == 59;
+    assert time.getShape()[0] == 59;
+    assert time.getDataType() == DataType.INT;
+
+    assert time.getDimension(0) == ncfile.findDimension("time");
+
+    try {
+      Array data = time.read();
+      assert data.getRank() == 1;
+      assert data.getSize() == 59;
+      assert data.getShape()[0] == 59;
+      assert data.getElementType() == int.class;
+
+      int count = 0;
+      IndexIterator dataI = data.getIndexIterator();
+      while (dataI.hasNext())
+        assert dataI.getIntNext() == count++ : dataI.getIntCurrent();
+
+    } catch (IOException io) {
+      io.printStackTrace();
+      assert false;
+    }
+
+  }
+
+  public void testReadData(NetcdfFile ncfile) {
+    Variable v = ncfile.findVariable("T");
+    assert null != v;
+    assert v.getShortName().equals("T");
+    assert v.getRank() == 3;
+    assert v.getSize() == 708 : v.getSize();
+    assert v.getShape()[0] == 59;
+    assert v.getShape()[1] == 3;
+    assert v.getShape()[2] == 4;
+    assert v.getDataType() == DataType.DOUBLE;
+
+    assert !v.isCoordinateVariable();
+
+    assert v.getDimension(0) == ncfile.findDimension("time");
+    assert v.getDimension(1) == ncfile.findDimension("lat");
+    assert v.getDimension(2) == ncfile.findDimension("lon");
+
+    try {
+      Array data = v.read();
+      assert data.getRank() == 3;
+      assert data.getSize() == 708;
+      assert data.getShape()[0] == 59;
+      assert data.getShape()[1] == 3;
+      assert data.getShape()[2] == 4;
+      assert data.getElementType() == double.class;
+
+      int[] shape = data.getShape();
+      Index tIndex = data.getIndex();
+      for (int i = 0; i < shape[0]; i++)
+        for (int j = 0; j < shape[1]; j++)
+          for (int k = 0; k < shape[2]; k++) {
+            double val = data.getDouble(tIndex.set(i, j, k));
+            Assert2.assertNearlyEquals(val, 100 * i + 10 * j + k);
+          }
+
+    } catch (IOException io) {
+      io.printStackTrace();
+      assert false;
+    }
+  }
+
+  public void testReadSlice(NetcdfFile ncfile, int[] origin, int[] shape) throws IOException, InvalidRangeException {
+
+    Variable v = ncfile.findVariable("T");
+
+    Array data = v.read(origin, shape);
+    assert data.getRank() == 3;
+    assert data.getSize() == shape[0] * shape[1] * shape[2];
+    assert data.getShape()[0] == shape[0] : data.getShape()[0] + " " + shape[0];
+    assert data.getShape()[1] == shape[1];
+    assert data.getShape()[2] == shape[2];
+    assert data.getElementType() == double.class;
+
+    Index tIndex = data.getIndex();
+    for (int i = 0; i < shape[0]; i++)
+      for (int j = 0; j < shape[1]; j++)
+        for (int k = 0; k < shape[2]; k++) {
+          double val = data.getDouble(tIndex.set(i, j, k));
+          Assert2.assertNearlyEquals(val, 100 * (i + origin[0]) + 10 * j + k);
+        }
+
+  }
+
+  public void testReadSlice(NetcdfFile ncfile) throws IOException, InvalidRangeException {
+    testReadSlice(ncfile, new int[] {0, 0, 0}, new int[] {59, 3, 4});
+    testReadSlice(ncfile, new int[] {0, 0, 0}, new int[] {2, 3, 2});
+    testReadSlice(ncfile, new int[] {25, 0, 0}, new int[] {10, 3, 4});
+    testReadSlice(ncfile, new int[] {44, 0, 0}, new int[] {10, 2, 3});
+  }
+}

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlReadersCompare.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlReadersCompare.java
@@ -69,6 +69,9 @@ public class TestNcmlReadersCompare {
     @Override
     public boolean accept(File pathname) {
       String name = pathname.getName();
+      // Made to fail, so skip
+      if (name.contains("aggExistingInequivalentCals.xml"))
+        return false;
       // NcMLReader does not change variable to type int, so fails.
       if (name.contains("aggSynthetic.xml"))
         return false;

--- a/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
+++ b/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
@@ -162,6 +162,10 @@ entries:
       url: /file_types.html
       output: web, pdf
 
+    - title: CDM Calendar Date Handling
+      url: /cdm_calendar_date_time_ref.html
+      output: web, pdf
+
     - title: CDM Disk Caching
       url: /disk_caching.html
       output: web, pdf

--- a/docs/src/public/userguide/pages/netcdfJava/CalendarDateTime.md
+++ b/docs/src/public/userguide/pages/netcdfJava/CalendarDateTime.md
@@ -1,0 +1,269 @@
+---
+title: CDM Calendar Date Handling
+last_updated: 2020-01-19
+sidebar: netcdfJavaTutorial_sidebar
+toc: false
+permalink: cdm_calendar_date_time_ref.html
+---
+
+As of CDM version 4.3, dates are no longer handled by the [UDUNITS library](https://www.unidata.ucar.edu/software/udunits/){:target="_blank"}.
+This allows handling [non-standard Calendars](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/cf-conventions.html#calendar){:target="_blank"}.
+This change only affects datetime coordinate handling, called [time coordinates](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/cf-conventions.html#time-coordinate){:target="_blank"} in CF.
+For all [dimensional units](http://en.wikipedia.org/wiki/Dimensional_analysis){:target="_blank"}, the UDUNITS package is still used.
+
+## Definitions and Background
+* **time** is a duration of time (a dimensional unit).
+  UDUNITS handles this using a base unit of `seconds`.
+  All other udunit time units are fixed multiples of a second.
+* **datetime** is an instant of historical time.
+  UDUNITS represents a datetime as a fixed number of seconds since a reference date, eg `12 days since 1990-02-03 12:22`.
+* **calendar date** (e.g. `1990-02-03 12:22`) is a representation of a datetime using calendar fields (`millisec`, `second`, `minute`, `hour`, `day`, `month`, `year`).
+  This allows one to correctly represent the same instant of time that, for example, is printed in a newspaper or is referenced in a history book.
+  We are following the design from the [joda-time library](http://joda-time.sourceforge.net/userguide.html){:target="_blank"}, which has a very good discussion of the issues in datetime handling software.
+
+## CDM datetime coordinates
+The CDM library allows datetime coordinates to be specified in the following forms:
+
+1. [**udunit coordinate**](#cdm-udunit-date-grammar): Variables of any numeric type (`byte`, `short`, `int`, `long`, `float`, `double`) with a `units` attribute that is a udunit date string, e.g. `hours since 1930-01-01`.
+   This is the only form that conforms to the current NetCDF Climate and Forecast (CF) Metadata Conventions specification.
+2. [**calendar field coordinate**](#cdm-calendar_field-unit-grammar): Variables of any integer type (`byte`, `short`, `int`, `long`) with a `units` attribute that is a udunit date string but with `calendar` added, e.g. `calendar months since 1930-01-01`.
+3. [**ISO String coordinate**](#w3c-profile-of-iso-8601): Variables of type `String` or `char` in which the values follow (a slightly extended version of) the W3C profile of ISO 8601.
+
+## Supported Calendars
+CDM 4.3 and above supports the following values of the calendar attribute, which is attached to the datetime coordinate:
+
+* **gregorian** or **standard**: Mixed Gregorian/Julian calendar.
+  Same as UDUNITS except that the dates 1582-10-05 to 1582-10-14 do not exist, and neither does year 0.
+* **proleptic_gregorian** or **ISO8601**: A Gregorian calendar extended to dates before 1582-10-15.
+  This corresponds to the ISO8601 standard.
+  This is the CDM default.
+* **julian**: proleptic Julian calendar system.
+* **noleap** or **365_day**: Gregorian calendar without leap years (all years are 365 days long).
+* **all_leap** or **366_day**: Gregorian calendar with every year being a leap year (all years are 366 days long).
+* **uniform30day** or **360_day**: All years are 360 days long.
+   Each year consists of 12 months, and each month is 30 days long.
+* **none**: Currently ignored by the CDM, but is available to the application to process.
+
+None of these calendars handle leap seconds, but with enough effort one could define a [UTC](http://en.wikipedia.org/wiki/Coordinated_Universal_Time){:target="_blank"} or [TAI](http://en.wikipedia.org/wiki/International_Atomic_Time){:target="_blank"} calendar.
+
+These calendars are implemented in the CDM with classes from Jon Blower's `uk.ac.rdg.resc.edal.time` package.
+## Getting a non-standard CalendarDate
+
+In `CalendarDate` class:
+`public static CalendarDate of(Calendar cal, int year, int monthOfYear, int dayOfMonth, int hourOfDay, int minuteOfHour, int secondOfMinute);`
+
+In CalendarDateFormatter class:
+`public static CalendarDate isoStringToCalendarDate(Calendar calt, String iso) throws IllegalArgumentException;`
+
+## Supported Operations
+* A `ucar.nc2.time.CalendarDate` object is now used instead of a `java.util.Date`.
+* `CalendarDate.getCalendar()` retrieves the calendar being used.
+* `CalendarDate.equals(cdate)`, `CalendarDate.isBefore(cdate)`, `CalendarDate.isAfter(cdate)` allow for comparisons between two `CalendarDates`.
+* `CalendarDate.getDifferenceInMsecs(cdate)` calculates the difference between two `CalendarDate` in `milliseconds`.
+* A `CalendarDate` is obtained from a `ucar.nc2.time.CalendarDateUnit` (instead of a `ucar.units.Unit` or `ucar.nc2.units.DateUnit`), and are created in classes like `ucar.nc2.datset.CoordinateAxis1DTime`.
+
+## CDM udunit date grammar
+The CDM library version 4.3 and after continues to accept UDUNITS for time coordinate units, but it does not use the udunit library to process them.
+
+The udunit date grammar is difficult to understand. Here's an approximate regular expression:
+
+~~~
+period SINCE [-]Y[Y[Y[Y]]]-MM-DD[(T| )hh[:mm[:ss[.sss*]]][ [+|-]hh[[:]mm]]]
+~~~
+
+The following specifies the CDM udunit date grammar:
+
+~~~
+udunitDate     = period SINCE reference_date
+period         = "millisec" | "msec" | "second" | "sec" | "s" | "minute" | "min" | "hour" | "hr" | "day" | 
+                 "week" | "month" | "mon" | "year" | "yr"
+period         = period + "s" (plural form)
+reference_date = iso8601 formatted date as described below
+SINCE          = literal (case insensitive)
+~~~
+
+where
+* msec = millisec = seconds / 1000
+
+UDUNITS defines the periods as _fixed_ multiples of seconds.
+The non-obvious ones are:
+* **day** = 86400.0 seconds
+* **week** = 7 days = 604800.0 seconds
+* **year** = 3.15569259747E7 seconds (365 days of length 86400.0 seconds)
+* **month** = year/12 = 2629743.831225 seconds
+
+The udunit package has some other periods that are no longer supported by CDM udunit date grammar, such as `sidereal day`, `lunar month`, `fortnight`, `eon`, etc.
+Also CDM does not support the full menagerie of udunit prefixes like `nano`, `mega`, `kilo`, and so on.
+Contact us if this is a problem.
+
+CF and CDM agree that one should not use `month` or `year` as the period in a udunit, in order to avoid the following sort of problems:
+
+~~~
+ 0 months since 1930-01-01 == 1930-01-01T00:00:00Z
+ 1 months since 1930-01-01 == 1930-01-31T10:29:03Z
+ 2 months since 1930-01-01 == 1930-03-02T20:58:07Z
+ 3 months since 1930-01-01 == 1930-04-02T07:27:11Z
+ 4 months since 1930-01-01 == 1930-05-02T17:56:15Z
+ 5 months since 1930-01-01 == 1930-06-02T04:25:19Z
+ 6 months since 1930-01-01 == 1930-07-02T14:54:22Z
+ 7 months since 1930-01-01 == 1930-08-02T01:23:26Z
+ 8 months since 1930-01-01 == 1930-09-01T11:52:30Z
+ 9 months since 1930-01-01 == 1930-10-01T22:21:34Z
+10 months since 1930-01-01 == 1930-11-01T08:50:38Z
+11 months since 1930-01-01 == 1930-12-01T19:19:42Z
+~~~
+
+~~~
+ 0 years since 1850-01-01 == 1850-01-01T00:00:00Z
+10 years since 1850-01-01 == 1860-01-01T10:07:39Z
+20 years since 1850-01-01 == 1869-12-31T20:15:19Z
+30 years since 1850-01-01 == 1880-01-01T06:22:59Z
+40 years since 1850-01-01 == 1889-12-31T16:30:38Z
+50 years since 1850-01-01 == 1900-01-01T02:38:18Z
+60 years since 1850-01-01 == 1910-01-01T12:45:58Z
+70 years since 1850-01-01 == 1920-01-01T22:53:38Z
+80 years since 1850-01-01 == 1930-01-01T09:01:17Z
+90 years since 1850-01-01 == 1940-01-01T19:08:57Z
+~~~
+
+## CDM calendar_field unit grammar
+The CDM accepts an extended form of udunit grammar, called a calendar field unit:
+
+~~~
+CALENDAR period SINCE reference_date
+~~~
+
+The presence of `CALENDAR` (case insensitive) means that the CDM library manipulates the calendar field directly, rather than converting the period to a fixed multiple of seconds.
+The actual result depends on the calendar used.
+Note that values of the period must be an integer.
+
+For example:
+~~~
+ 1 calendar months since 1930-01-01 00:00:00Z == 1930-02-01T00:00:00.000Z
+ 2 calendar months since 1930-01-01 00:00:00Z == 1930-03-01T00:00:00.000Z
+ 3 calendar months since 1930-01-01 00:00:00Z == 1930-04-01T00:00:00.000Z
+ 4 calendar months since 1930-01-01 00:00:00Z == 1930-05-01T00:00:00.000Z
+ 5 calendar months since 1930-01-01 00:00:00Z == 1930-06-01T00:00:00.000Z
+ 6 calendar months since 1930-01-01 00:00:00Z == 1930-07-01T00:00:00.000Z
+ 7 calendar months since 1930-01-01 00:00:00Z == 1930-08-01T00:00:00.000Z
+ 8 calendar months since 1930-01-01 00:00:00Z == 1930-09-01T00:00:00.000Z
+ 9 calendar months since 1930-01-01 00:00:00Z == 1930-10-01T00:00:00.000Z
+10 calendar months since 1930-01-01 00:00:00Z == 1930-11-01T00:00:00.000Z
+11 calendar months since 1930-01-01 00:00:00Z == 1930-12-01T00:00:00.000Z
+12 calendar months since 1930-01-01 00:00:00Z == 1931-01-01T00:00:00.000Z
+~~~
+
+~~~
+ 1 calendar years since 1930-01-01 00:00:00Z == 1931-01-01T00:00:00.000Z
+ 2 calendar years since 1930-01-01 00:00:00Z == 1932-01-01T00:00:00.000Z
+ 3 calendar years since 1930-01-01 00:00:00Z == 1933-01-01T00:00:00.000Z
+ 4 calendar years since 1930-01-01 00:00:00Z == 1934-01-01T00:00:00.000Z
+ 5 calendar years since 1930-01-01 00:00:00Z == 1935-01-01T00:00:00.000Z
+ 6 calendar years since 1930-01-01 00:00:00Z == 1936-01-01T00:00:00.000Z
+ 7 calendar years since 1930-01-01 00:00:00Z == 1937-01-01T00:00:00.000Z
+ 8 calendar years since 1930-01-01 00:00:00Z == 1938-01-01T00:00:00.000Z
+ 9 calendar years since 1930-01-01 00:00:00Z == 1939-01-01T00:00:00.000Z
+10 calendar years since 1930-01-01 00:00:00Z == 1940-01-01T00:00:00.000Z
+11 calendar years since 1930-01-01 00:00:00Z == 1941-01-01T00:00:00.000Z
+12 calendar years since 1930-01-01 00:00:00Z == 1942-01-01T00:00:00.000Z
+~~~
+
+Note that invalid dates are decremented until valid. For example:
+~~~
+ 0 calendar months since 1930-01-31 00:00:00Z == 1930-01-31T00:00:00.000Z
+ 1 calendar months since 1930-01-31 00:00:00Z == 1930-02-28T00:00:00.000Z (1930-02-31
+                                                                           1930-02-30
+                                                                           1930-02-29 not valid)
+ 2 calendar months since 1930-01-31 00:00:00Z == 1930-03-31T00:00:00.000Z
+ 3 calendar months since 1930-01-31 00:00:00Z == 1930-04-30T00:00:00.000Z (1930-04-31 not valid)
+ 4 calendar months since 1930-01-31 00:00:00Z == 1930-05-31T00:00:00.000Z
+ 5 calendar months since 1930-01-31 00:00:00Z == 1930-06-30T00:00:00.000Z (1930-06-31 not valid)
+ 6 calendar months since 1930-01-31 00:00:00Z == 1930-07-31T00:00:00.000Z
+ 7 calendar months since 1930-01-31 00:00:00Z == 1930-08-31T00:00:00.000Z
+ 8 calendar months since 1930-01-31 00:00:00Z == 1930-09-30T00:00:00.000Z (1930-09-31 not valid)
+ 9 calendar months since 1930-01-31 00:00:00Z == 1930-10-31T00:00:00.000Z
+10 calendar months since 1930-01-31 00:00:00Z == 1930-11-30T00:00:00.000Z (1930-11-31 not valid)
+11 calendar months since 1930-01-31 00:00:00Z == 1930-12-31T00:00:00.000Z
+12 calendar months since 1930-01-31 00:00:00Z == 1931-01-31T00:00:00.000Z
+~~~
+
+and:
+~~~
+ 0 calendar years since 2008-02-29 00:00:00Z == 2008-02-29T00:00:00.000Z
+ 1 calendar years since 2008-02-29 00:00:00Z == 2009-02-28T00:00:00.000Z (2009-02-29 not valid)
+ 2 calendar years since 2008-02-29 00:00:00Z == 2010-02-28T00:00:00.000Z (2010-02-29 not valid)
+ 3 calendar years since 2008-02-29 00:00:00Z == 2011-02-28T00:00:00.000Z (2011-02-29 not valid)
+ 4 calendar years since 2008-02-29 00:00:00Z == 2012-02-29T00:00:00.000Z
+ 5 calendar years since 2008-02-29 00:00:00Z == 2013-02-28T00:00:00.000Z (2013-02-29 not valid)
+ 6 calendar years since 2008-02-29 00:00:00Z == 2014-02-28T00:00:00.000Z (2014-02-29 not valid)
+ 7 calendar years since 2008-02-29 00:00:00Z == 2015-02-28T00:00:00.000Z (2015-02-29 not valid)
+ 8 calendar years since 2008-02-29 00:00:00Z == 2016-02-29T00:00:00.000Z
+ 9 calendar years since 2008-02-29 00:00:00Z == 2017-02-28T00:00:00.000Z (2017-02-29 not valid)
+10 calendar years since 2008-02-29 00:00:00Z == 2018-02-28T00:00:00.000Z (2018-02-29 not valid)
+11 calendar years since 2008-02-29 00:00:00Z == 2019-02-28T00:00:00.000Z (2019-02-29 not valid)
+12 calendar years since 2008-02-29 00:00:00Z == 2020-02-29T00:00:00.000Z
+13 calendar years since 2008-02-29 00:00:00Z == 2021-02-28T00:00:00.000Z (2021-02-29 not valid)
+14 calendar years since 2008-02-29 00:00:00Z == 2022-02-28T00:00:00.000Z (2022-02-29 not valid)
+~~~
+
+## W3C profile of ISO 8601
+The CDM uses the [W3C profile of ISO 8601](http://www.w3.org/TR/NOTE-datetime.html){:target="_blank"} formatting for reading and writing calendar dates:
+
+> The formats defined by the W3C profile of ISO 8601 are as follows.
+>
+> Exactly the components shown here must be present, with exactly this punctuation.
+> Note that the `T` appears literally in the string, to indicate the beginning of the time element, as specified in ISO 8601.
+>
+>  ~~~
+>  Year:
+>    YYYY (eg 1997)
+>  Year and month:
+>    YYYY-MM (eg 1997-07)
+>  Complete date:
+>    YYYY-MM-DD (eg 1997-07-16)
+>  Complete date plus hours and minutes:
+>    YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
+>  Complete date plus hours, minutes and seconds:
+>    YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+>  Complete date plus hours, minutes, seconds and a decimal fraction of a second
+>    YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+>  ~~~
+>
+>  where:
+>
+>  ~~~
+>  YYYY = four-digit year
+>  MM   = two-digit month (01=January, etc.)
+>  DD   = two-digit day of month (01 through 31)
+>  hh   = two digits of hour (00 through 23) (am/pm NOT allowed)
+>  mm   = two digits of minute (00 through 59)
+>  ss   = two digits of second (00 through 59)
+>  s    = one or more digits representing a decimal fraction of a second
+>  TZD  = time zone designator (Z or +hh:mm or -hh:mm)
+>  ~~~
+
+but with the following differences, to allow backwards compatibility with UDUNITS:
+* You may use a space (` `) instead of the `T`
+* The year may be preceded by a `+` (ignored) or a `-` (makes the date `BCE`)
+* The date part uses a `-` delimiter instead of a fixed number of digits for each field
+* The time part uses a `:` delimiter instead of a fixed number of digits for each field
+* The time zone designator may be `Z`, `UTC`, or `GMT` (case insensitive) or `+hh:mm` or `-hh:mm`
+* The time zone may be omitted, and then `UTC` is assumed.
+
+In addition, the following must be done:
+* Any fields that are not specified are set to zero.
+
+## Possible extentions (not implemented)
+
+~~~
+N [calendar] UNITS since DATE         // current
+
+
+N [calendar] UNITS since 65500 BCE   // assume we mean 0Z on 1 Jan. always calendar years
+N [calendar] UNITS since 65500k BCE
+N [calendar] UNITS since 65M BCE
+
+
+N calendar Myears before 1980-01-01
+~~~
+

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -11,9 +11,25 @@ then
 elif [[ $TASK == "test-tds" ]]
 then
     echo "Testing the THREDDS Data Server against the netCDF-Java PR"
-    # publish netcdf-java artifacts to local maven repo (~/.m2/repository)
-    echo "build netcdf-java and publish artifacts to local maven repository"
+    # build netCDF-Java
+    echo "Build netCDF-java"
+    $TRAVIS_BUILD_DIR/gradlew assemble
+    # if netCDF-java fails to assemble its artifacts, bail.
+    if [ $? -eq 1 ]
+    then
+      echo "Could not build netcdf-java, exiting." >&2
+      exit 1
+    fi
+
+    # publish netCDF-java artifacts to local maven repo (~/.m2/repository)
+    echo "Publish netCDF-java artifacts to local maven repository"
     $TRAVIS_BUILD_DIR/gradlew publishToMavenLocal
+    # if netCDF-java fails to build or publish its artifacts locally, bail.
+    if [ $? -eq 1 ]
+    then
+      echo "Could not locally publish netcdf-java artifacts, exiting." >&2
+      exit 1
+    fi
 
     # find netcdf-java version as specified in the PR
     NCJ_VERSION=$($TRAVIS_BUILD_DIR/gradlew properties -q | grep "^version:" | awk '{print $2}')


### PR DESCRIPTION
Currently, we are able to perform a `joinExisting` aggregation when the unit of the time coordinate variable changes between the individual files of the aggregation. However, the code that does this is not calendar aware, and so the new aggregated time coordinate variable values can be incorrect. This PR makes the aggregation code (both old and new) calendar aware, and puts in place a few rules for when this can be done:

1. Either all time coordinate variables across all datasets in the aggregation have a calendar attribute defined, or none of the datasets have it. It's all or nothing.
1. When time units change between files in the aggregation, their calendars must be equivalent:
   * A `360_day` calendar is equivalent with `uniform30day`
   * A `gregorian` calendar is not equivalent with `366_day`

If you try to do a `joinExisting` aggregation that violates either of those rules, you'll earn yourself a shiny `UnsupportedOperationException`. Included are data (in the form of NcML files) and tests.