### PR TITLE
Fix ARV2 version check

### DIFF
--- a/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
@@ -39,7 +39,7 @@ public class Nexrad2IOServiceProvider extends AbstractIOServiceProvider {
     // somewhat duplicated in Nexrad2RadialAdapter - so if changing something here, also
     // look in cdm-core module's Nexrad2RadialAdapter.isNEXRAD2Format
     if (format != null && (format.equals("ARCHIVE2") || format.startsWith("AR2V"))) {
-      if (Integer.parseInt(format.substring(4)) > 8)
+      if (format.startsWith("AR2V") && Integer.parseInt(format.substring(4)) > 8)
         logger.warn("Trying to handle unknown but valid-looking format: " + format);
       return true;
     }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Pds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Pds.java
@@ -68,7 +68,7 @@ public abstract class Grib2Pds {
         return new Grib2Pds61(input);
       default:
         log.warn("Missing template " + template);
-        throw new UnsupportedOperationException ("Product Definition " + template + " not yet implemented.");
+        throw new UnsupportedOperationException("Product Definition " + template + " not yet implemented.");
     }
   }
 


### PR DESCRIPTION
Fixes Unidata/netcdf-java#174 

Pulled from Unidata/netcdf-java#173, as I'm going to look at added a `LoadingCache` for S3 and HTTP remote random access files, but I don't want to hold this fix up.