### PR TITLE
Maintain percent encoding in user credentials

### DIFF
--- a/httpservices/build.gradle
+++ b/httpservices/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compile libraries["re2j"]
     compile libraries["slf4j-api"]
     testRuntime libraries["logback-classic"]
+    testCompile libraries["truth"]
 }
 
 test {

--- a/httpservices/src/main/java/ucar/httpservices/Escape.java
+++ b/httpservices/src/main/java/ucar/httpservices/Escape.java
@@ -237,7 +237,10 @@ public class Escape {
         return null;
       }
       protocol = u.getScheme();
-      authority = u.getAuthority();
+      // authority may contain encoded characters (such as a username containing
+      // the @ symbol), and we want to preserve those, so use getRawAuthority()
+      // here.
+      authority = u.getRawAuthority();
       path = u.getPath();
       query = u.getQuery();
       fragment = u.getFragment();

--- a/httpservices/src/main/java/ucar/httpservices/HTTPUtil.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPUtil.java
@@ -5,21 +5,35 @@
 
 package ucar.httpservices;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-import org.apache.http.*;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.protocol.HttpContext;
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
 
 public abstract class HTTPUtil {
 
@@ -271,7 +285,7 @@ public abstract class HTTPUtil {
           urib.setScheme(uri.getScheme());
           break;
         case USERINFO:
-          urib.setUserInfo(uri.getUserInfo());
+          urib.setUserInfo(uri.getRawUserInfo());
           break;
         case HOST:
           urib.setHost(uri.getHost());

--- a/httpservices/src/test/java/ucar/httpservices/TestUrlCreds.java
+++ b/httpservices/src/test/java/ucar/httpservices/TestUrlCreds.java
@@ -1,0 +1,60 @@
+package ucar.httpservices;
+
+import com.google.common.truth.Truth;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Parameterized.class)
+public class TestUrlCreds {
+
+  private static final Logger logger = LoggerFactory.getLogger(TestUrlCreds.class);
+  private String username;
+  private String password;
+  private String host;
+
+  // Each parameter should be placed as an argument here
+  // Every time runner triggers, it will pass the arguments
+  // from parameters we defined in primeNumbers() method
+
+  public TestUrlCreds(String username, String password, String host) {
+    this.username = username;
+    this.password = password;
+    this.host = host;
+  }
+
+  @Parameterized.Parameters
+  public static Collection primeNumbers() {
+    return Arrays.asList(new Object[][] {{"user", "someCoolFruitOrSomething", "my.server.edu"},
+        {"user%40emailaddress.com", "someCoolerFruitOrSomething", "server.com"},});
+  }
+
+  @Test
+  public void testUrlCred() throws HTTPException {
+    String url = "https://" + username + ":" + password + "@" + host + "/something/garbage.grb?query";
+    logger.warn("Testing {}", url);
+    try (HTTPMethod method = HTTPFactory.Get(url)) {
+      HTTPSession session = method.getSession();
+      method.close();
+      session.setCredentialsProvider(new BasicCredentialsProvider());
+      try (HTTPMethod method2 = HTTPFactory.Get(session, url)) {
+        HTTPSession session2 = method2.getSession();
+        CredentialsProvider credentialsProvider = session2.sessionprovider;
+        Truth.assertThat(credentialsProvider).isNotNull();
+        AuthScope expectedAuthScope = new AuthScope(host, 80);
+        Credentials credentials = credentialsProvider.getCredentials(expectedAuthScope);
+        Truth.assertThat(credentials).isNotNull();
+        Truth.assertThat(credentials.getUserPrincipal().getName()).isEqualTo(username);
+        Truth.assertThat(credentials.getPassword()).isEqualTo(password);
+      }
+    }
+  }
+}


### PR DESCRIPTION
When using credentials via URL, any encoded characters need to remain encoded. An example of this would be a user name that has an `@` symbol. The `@` symbol must be encoded as `%40`. Before this PR, uri methods related to user credentials would decode `%40` back into `@`. This PR changes `getAuthority` and `getUserInfo` calls to `getRawAuthority` and `getRawUserInfo`, which preserve percent encoded characters.