### PR TITLE
Fix failing Jenkins test

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggExistingTimeUnitsChange.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestOffAggExistingTimeUnitsChange.java
@@ -5,23 +5,24 @@
 
 package ucar.nc2.ncml;
 
+import static com.google.common.truth.Truth.assertThat;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import junit.framework.TestCase;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
-import ucar.ma2.InvalidRangeException;
 import ucar.nc2.NCdumpW;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.time.CalendarDateUnit;
 import ucar.unidata.util.test.Assert2;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
-import java.io.IOException;
-import java.io.StringReader;
-import java.lang.invoke.MethodHandles;
 
 /**
  * Test aggregation where timeUnitsChange='true'
@@ -30,6 +31,7 @@ import java.lang.invoke.MethodHandles;
  */
 @Category(NeedsCdmUnitTest.class)
 public class TestOffAggExistingTimeUnitsChange extends TestCase {
+
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public TestOffAggExistingTimeUnitsChange(String name) {
@@ -37,19 +39,21 @@ public class TestOffAggExistingTimeUnitsChange extends TestCase {
   }
   // String location = "file:R:/testdata2/ncml/nc/narr/narr.ncml";
 
-  public void testNamExtract() throws IOException, InvalidRangeException {
+  public void testNamExtract() throws IOException {
     String location = TestDir.cdmUnitTestDir + "ncml/nc/namExtract/test_agg.ncml";
     logger.debug(" TestOffAggExistingTimeUnitsChange.open {}", location);
 
     NetcdfFile ncfile = NetcdfDataset.openFile(location, null);
 
     Variable v = ncfile.findVariable("time");
+
     assert v != null;
-    assert v.getDataType() == DataType.DOUBLE;
+    assertThat(v.getDataType()).isEqualTo(DataType.DOUBLE);
 
     String units = v.getUnitsString();
     assert units != null;
-    assert units.equals("hours since 2006-09-25T06:00:00Z");
+    CalendarDateUnit expectedCalendarDateUnit = CalendarDateUnit.of(null, "hours since 2006-09-25T06:00:00Z");
+    assertThat(units).ignoringCase().isEqualTo(expectedCalendarDateUnit.getUdUnit());
 
     int count = 0;
     Array data = v.read();
@@ -63,7 +67,7 @@ public class TestOffAggExistingTimeUnitsChange extends TestCase {
     ncfile.close();
   }
 
-  public void testNarrGrib() throws IOException, InvalidRangeException {
+  public void testNarrGrib() throws IOException {
     String ncml = "<?xml version='1.0' encoding='UTF-8'?>\n"
         + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n"
         + " <aggregation type='joinExisting' dimName='time' timeUnitsChange='true' >\n"

--- a/cdm/core/src/test/java/ucar/nc2/units/TestDateRange.java
+++ b/cdm/core/src/test/java/ucar/nc2/units/TestDateRange.java
@@ -4,7 +4,8 @@
  */
 package ucar.nc2.units;
 
-import com.google.common.truth.Truth;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,7 @@ public class TestDateRange {
     try {
       drStartIsPresent = new DateRange(new DateType("present", null, null), null, new TimeDuration("P7D"), null);
     } catch (ParseException e) {
-      Truth.assertWithMessage("Failed to parse \"present\" and/or \"P7D\": " + e.getMessage()).fail();
+      assertWithMessage("Failed to parse \"present\" and/or \"P7D\": " + e.getMessage()).fail();
       return;
     }
     checkValuesAfterDelay(drStartIsPresent);
@@ -46,7 +47,7 @@ public class TestDateRange {
     try {
       drEndIsPresent = new DateRange(null, new DateType("present", null, null), new TimeDuration("P7D"), null);
     } catch (ParseException e) {
-      Truth.assertWithMessage("Failed to parse \"present\" and/or \"P7D\": " + e.getMessage()).fail();
+      assertWithMessage("Failed to parse \"present\" and/or \"P7D\": " + e.getMessage()).fail();
       return;
     }
     checkValuesAfterDelay(drEndIsPresent);
@@ -69,7 +70,7 @@ public class TestDateRange {
         }
       }
     } catch (InterruptedException e) {
-      Truth.assertWithMessage("Failed to wait: " + e.getMessage()).fail();
+      assertWithMessage("Failed to wait: " + e.getMessage()).fail();
       return;
     }
 
@@ -80,7 +81,7 @@ public class TestDateRange {
     System.out.println("Start   : [" + startDate2.getTime() + "].");
     System.out.println("End     : [" + endDate2.getTime() + "].");
 
-    Truth.assertThat(startDate).isNotEqualTo(startDate2);
-    Truth.assertThat(endDate).isNotEqualTo(endDate2);
+    assertThat(startDate).isNotEqualTo(startDate2);
+    assertThat(endDate).isNotEqualTo(endDate2);
   }
 }

--- a/cdm/core/src/test/java/ucar/unidata/geoloc/TestProjections.java
+++ b/cdm/core/src/test/java/ucar/unidata/geoloc/TestProjections.java
@@ -1,7 +1,7 @@
 
 package ucar.unidata.geoloc;
 
-import com.google.common.truth.Truth;
+import static com.google.common.truth.Truth.assertThat;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -201,7 +201,7 @@ public class TestProjections {
     testProjection(new LambertConformal());
     LambertConformal p = new LambertConformal();
     LambertConformal p2 = (LambertConformal) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -225,7 +225,7 @@ public class TestProjections {
 
     TransverseMercator p = new TransverseMercator();
     TransverseMercator p2 = (TransverseMercator) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -233,7 +233,7 @@ public class TestProjections {
     testProjection(new Stereographic());
     Stereographic p = new Stereographic();
     Stereographic p2 = (Stereographic) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -241,7 +241,7 @@ public class TestProjections {
     testProjection(new LambertAzimuthalEqualArea());
     LambertAzimuthalEqualArea p = new LambertAzimuthalEqualArea();
     LambertAzimuthalEqualArea p2 = (LambertAzimuthalEqualArea) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -249,7 +249,7 @@ public class TestProjections {
     testProjectionLonMax(new Orthographic(), 10, 10);
     Orthographic p = new Orthographic();
     Orthographic p2 = (Orthographic) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -257,7 +257,7 @@ public class TestProjections {
     testProjection(new AlbersEqualArea());
     AlbersEqualArea p = new AlbersEqualArea();
     AlbersEqualArea p2 = (AlbersEqualArea) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -265,7 +265,7 @@ public class TestProjections {
     testProjection(new CylindricalEqualAreaProjection());
     CylindricalEqualAreaProjection p = new CylindricalEqualAreaProjection();
     CylindricalEqualAreaProjection p2 = (CylindricalEqualAreaProjection) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -273,21 +273,21 @@ public class TestProjections {
     testProjection(new EquidistantAzimuthalProjection());
     EquidistantAzimuthalProjection p = new EquidistantAzimuthalProjection();
     EquidistantAzimuthalProjection p2 = (EquidistantAzimuthalProjection) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   public void utestAEAE() {
     testProjectionLonMax(new AlbersEqualAreaEllipse(), 180, 80);
     AlbersEqualAreaEllipse p = new AlbersEqualAreaEllipse();
     AlbersEqualAreaEllipse p2 = (AlbersEqualAreaEllipse) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   public void utestLCCE() {
     testProjectionLonMax(new LambertConformalConicEllipse(), 360, 80);
     LambertConformalConicEllipse p = new LambertConformalConicEllipse();
     LambertConformalConicEllipse p2 = (LambertConformalConicEllipse) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -295,7 +295,7 @@ public class TestProjections {
     testProjectionProjMax(new FlatEarth(), 5000, 5000);
     FlatEarth p = new FlatEarth();
     FlatEarth p2 = (FlatEarth) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -303,7 +303,7 @@ public class TestProjections {
     testProjection(new Mercator());
     Mercator p = new Mercator();
     Mercator p2 = (Mercator) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   private void showProjVal(ProjectionImpl proj, double lat, double lon) {
@@ -331,7 +331,7 @@ public class TestProjections {
     testProjectionLonMax(new RotatedPole(37, 177), 360, 88);
     RotatedPole p = new RotatedPole();
     RotatedPole p2 = (RotatedPole) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   /*
@@ -344,7 +344,7 @@ public class TestProjections {
     testProjectionLonMax(new RotatedLatLon(-30, -15, 0), 360, 88);
     RotatedLatLon p = new RotatedLatLon();
     RotatedLatLon p2 = (RotatedLatLon) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -353,7 +353,7 @@ public class TestProjections {
     testProjection(new Sinusoidal(0, 0, 0, 6371.007));
     Sinusoidal p = new Sinusoidal();
     Sinusoidal p2 = (Sinusoidal) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2);
+    assertThat(p).isEqualTo(p2);
   }
 
   @Test
@@ -368,7 +368,7 @@ public class TestProjections {
 
     UtmProjection p = new UtmProjection();
     UtmProjection p2 = (UtmProjection) p.constructCopy();
-    Truth.assertThat(p).isEqualTo(p2); // */
+    assertThat(p).isEqualTo(p2); // */
   }
 
   private void testProjectionUTM(double lat, double lon) {


### PR DESCRIPTION
Compare expected unit string based on the unit from `CalendarDate` (singular period with capital letter). The units being compared in the failure were essentially the same though (`hours since 2006-09-25T06:00:00Z` vs `Hour since 2006-09-25T06:00:00Z`)

Minor: use static imports from Truth.