### PR TITLE
Update NetcdfFile header javadoc

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2;
@@ -46,17 +46,19 @@ import ucar.unidata.util.StringUtil2;
  * <p>
  * Read-only scientific datasets that are accessible through the netCDF API.
  * Immutable after {@code setImmutable()} is called. Reading data is not
- * thread-safe because of the use of RandomAccessFile.
+ * thread-safe because of the use of {@code RandomAccessFile}.
  * </p>
  *
  * <p>
- * Be sure to close the file when done. Either enclose in a try/finally block:
+ * Using this class's {@code Builder} scheme, opening a {@code NetcdfFile} could, for
+ * example, be accomplished as follows. Be sure to close the file when done. Either
+ * enclose in a try/finally block:
  * </p>
  *
  * <pre>
  * NetcdfFile ncfile = null;
  * try {
- *   ncfile = NetcdfFile.open(fileName);
+ *   ncfile = NetcdfFile.builder().setLocation(fileName).build();
  *   // do stuff
  * } finally {
  *   if (ncfile != null) {
@@ -66,11 +68,26 @@ import ucar.unidata.util.StringUtil2;
  * </pre>
  *
  * <p>
+ * More conveniently, a {@code NetcdfFile} may be opened using one of the static methods
+ * in {@code NetcdfFiles}:
+ * </p>
+ *
+ * <pre>
+ * NetcdfFile ncfile = null;
+ * try {
+ *   ncfile = NetcdfFiles.open(fileName);
+ *   // do stuff
+ * } finally {
+ *   if (ncfile != null) {
+ *     ncfile.close();
+ *   }
+ * }
+ * <p>
  * Or better yet, use try-with-resources:
  * </p>
  *
  * <pre>
- * try (NetcdfFile ncfile = NetcdfFile.open(fileName)) {
+ * try (NetcdfFile ncfile = NetcdfFiles.open(fileName)) {
  *   // do stuff
  * }
  * </pre>

--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
@@ -50,9 +50,9 @@ import ucar.unidata.util.StringUtil2;
  * </p>
  *
  * <p>
- * Using this class's {@code Builder} scheme, opening a {@code NetcdfFile} could, for
- * example, be accomplished as follows. Be sure to close the file when done. Either
- * enclose in a try/finally block:
+ * Using this class's {@code Builder} scheme to create a {@code NetcdfFile} object could, for
+ * example, be accomplished as follows, using a try/finally block to ensure that the
+ * {@code NetcdfFile} is closed when done.
  * </p>
  *
  * <pre>
@@ -68,7 +68,7 @@ import ucar.unidata.util.StringUtil2;
  * </pre>
  *
  * <p>
- * More conveniently, a {@code NetcdfFile} may be opened using one of the static methods
+ * More conveniently, a {@code NetcdfFile} object may be created using one of the static methods
  * in {@code NetcdfFiles}:
  * </p>
  *
@@ -966,7 +966,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
 
   /**
    * Find a Variable by short name, in the given group.
-   * 
+   *
    * @param g A group in this file. Null for root group.
    * @param shortName short name of the Variable.
    * @return Variable if found, else null.
@@ -1037,7 +1037,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
   /**
    * Look in the given Group and in its nested Groups for a Variable with a String valued Attribute with the given name
    * and value.
-   * 
+   *
    * @param g start with this Group, null for the root Group.
    * @param attName look for an Attribuite with this name.
    * @param attValue look for an Attribuite with this value.
@@ -1632,7 +1632,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
   /**
    * For subclass construction.
    * Use NetcdfFileSubclass to access this constructor
-   * 
+   *
    * @deprecated use NetcdfFile.builder()
    */
   @Deprecated
@@ -1714,7 +1714,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
 
   /**
    * Public by accident.
-   * 
+   *
    * @deprecated Use NetcdfFile.builder()
    */
   @Deprecated
@@ -2001,7 +2001,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
   /**
    * Completely empty the objects in the netcdf file.
    * Used for rereading the file on a sync().
-   * 
+   *
    * @deprecated
    */
   @Deprecated
@@ -2023,7 +2023,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
    * Finish constructing the object model.
    * This construsts the "global" variables, attributes and dimensions.
    * It also looks for coordinate variables.
-   * 
+   *
    * @deprecated Use NetcdfFile.builder()
    */
   @Deprecated
@@ -2574,7 +2574,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
   /**
    * Get Builder for this class.
    * Allows subclassing.
-   * 
+   *
    * @see "https://community.oracle.com/blogs/emcmanus/2010/10/24/using-builder-pattern-subclasses"
    */
   public static Builder<?> builder() {

--- a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
@@ -23,7 +23,7 @@ import java.io.PrintWriter;
 import java.util.*;
 
 /**
- * Mp>
+ * <p>
  * {@code NetcdfDataset} extends the netCDF API, adding standard attribute parsing such as
  * scale and offset, and explicit support for Coordinate Systems.
  * A {@code NetcdfDataset} wraps a {@code NetcdfFile}, or is defined by an NcML document.

--- a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.dataset;
@@ -23,23 +23,29 @@ import java.io.PrintWriter;
 import java.util.*;
 
 /**
- * NetcdfDataset extends the netCDF API, adding standard attribute parsing such as
+ * Mp>
+ * {@code NetcdfDataset} extends the netCDF API, adding standard attribute parsing such as
  * scale and offset, and explicit support for Coordinate Systems.
- * A NetcdfDataset wraps a NetcdfFile, or is defined by an NcML document.
+ * A {@code NetcdfDataset} wraps a {@code NetcdfFile}, or is defined by an NcML document.
+ * </p>
+ *
  * <p>
- * <p>
- * Be sure to close the dataset when done, best practice is to use try-with-resource:
+ * Be sure to close the dataset when done.
+ * Using statics in {@code NetcdfDatets}, best practice is to use try-with-resource:
+ * </p>
  * 
  * <pre>
- * try (NetcdfDataset ncd = NetcdfDataset.openDataset(fileName)) {
+ * try (NetcdfDataset ncd = NetcdfDatasets.openDataset(fileName)) {
  *   ...
  * }
  * </pre>
+ *
  * <p>
- * <p>
- * By default NetcdfDataset is opened with all enhancements turned on. The default "enhance
- * mode" can be set through setDefaultEnhanceMode(). One can also explicitly set the enhancements you want in
- * the dataset factory methods. The enhancements are:
+ * By default @code NetcdfDataset} is opened with all enhancements turned on. The default "enhance
+ * mode" can be set through setDefaultEnhanceMode(). One can also explicitly set the enhancements
+ * you want in the dataset factory methods. The enhancements are:
+ * </p>
+ *
  * <ul>
  * <li>ConvertEnums: convert enum values to their corresponding Strings. If you want to do this manually,
  * you can call Variable.lookupEnumString().</li>
@@ -48,10 +54,12 @@ import java.util.*;
  * <li>ConvertMissing: replace missing data with NaNs, for efficiency.</li>
  * <li>CoordSystems: extract CoordinateSystem using the CoordSysBuilder plug-in mechanism.</li>
  * </ul>
+ *
  * <p>
  * Automatic scale/offset processing has some overhead that you may not want to incur up-front. If so, open the
  * NetcdfDataset without {@code ApplyScaleOffset}. The VariableDS data type is not promoted and the data is not
  * converted on a read, but you can call the convertScaleOffset() routines to do the conversion later.
+ * </p>
  *
  * @author caron
  * @see ucar.nc2.NetcdfFile


### PR DESCRIPTION
This replaces #198 which was failing due to a spotless conflict.

Demonstrates use of `NetcdfFile.builder()`, but then recommends use of `NetcdfFiles` statics.