### PR TITLE
Increase size of missing_value array

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrNumbers.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrNumbers.java
@@ -15,7 +15,7 @@ import ucar.unidata.io.RandomAccessFile;
 public final class BufrNumbers {
 
   // used to check missing values when value is packed with all 1's
-  private static final long[] missing_value = new long[65];
+  private static final long[] missing_value = new long[2049];
 
   static {
     long accum = 0;


### PR DESCRIPTION
Increase size of `missing_value` array from `65` to `2049` elements based on the maximum bit-width found in the BUFR B Tables that we have. Fixes an issue with a new user submitted BUFR file (will be added to test datasets today).