### PR TITLE
Fix jenkins test, windows error

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/write/CDLWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/write/CDLWriter.java
@@ -316,7 +316,12 @@ public class CDLWriter {
 
     indent.incr();
     for (Variable v : s.getVariables()) {
-      writeCDL(v, indent, useFullName);
+      // nested structures
+      if (v instanceof Structure) {
+        writeCDL((Structure) v, indent, useFullName);
+      } else {
+        writeCDL(v, indent, useFullName);
+      }
     }
     indent.decr();
 

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -1957,7 +1957,7 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   private Array decodeVlen(DataType dt, int pos, ByteBuffer bbuff) throws IOException {
     Array array;
     int n = (int) bbuff.getLong(pos); // Note that this does not increment the buffer position
-    long addr = getNativeAddr(pos + NativeLong.SIZE, bbuff); // LOOK: this assumes 64 bit pointers
+    long addr = getNativeAddr(pos + com.sun.jna.Native.POINTER_SIZE, bbuff);
     Pointer p = new Pointer(addr);
     Object data;
     switch (dt) {


### PR DESCRIPTION
This PR fixes a new failure on Jenkins related to CDL writing and nested Structures (minor change), as well as a vlen related failure on windows due to making an assumption about pointer sizes in our JNA code.