### PR TITLE
Fix addition of javax.servlet-api dependency

### DIFF
--- a/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishingUtilTest.groovy
+++ b/buildSrc/src/test/groovy/edu/ucar/build/publishing/PublishingUtilTest.groovy
@@ -209,7 +209,7 @@ class PublishingUtilTest extends Specification {
         buildSrcClasspathAsCsvString == "C:/Users/cwardgar/Desktop,D:/git/gh958"
     }
     
-    def "adjustMavenPublicationPomScopes() on Java pub with various deps"() {
+    def "adjustMavenPublication() on Java pub with various deps"() {
         setup: "settings file"
         File settingsFile = testProjectDir.newFile('settings.gradle')
         settingsFile << "rootProject.name = 'test'"
@@ -232,7 +232,7 @@ class PublishingUtilTest extends Specification {
             
             import edu.ucar.build.publishing.PublishingUtil
             PublishingUtil.addMavenPublicationsForSoftwareComponents(project)
-            PublishingUtil.adjustMavenPublicationPomScopes(project)   // Testing this.
+            PublishingUtil.adjustMavenPublication(project)   // Testing this.
             
             dependencies {
                 compile "org.slf4j:slf4j-api:1.7.7"
@@ -265,17 +265,17 @@ class PublishingUtilTest extends Specification {
         Node hamcrestDepNode = depNodes.find { it.artifactId.text() == 'hamcrest-core' }
         hamcrestDepNode?.scope.text() == 'runtime'
 
-        and: "One is slf4j-api, with compile scope. Corrected by adjustMavenPublicationPomScopes()."
+        and: "One is slf4j-api, with compile scope. Corrected by adjustMavenPublication()."
         Node slf4jDepNode = depNodes.find { it.artifactId.text() == 'slf4j-api' }
         slf4jDepNode?.scope.text() == 'compile'
 
-        and: "One is objenesis, with compile scope. Corrected by adjustMavenPublicationPomScopes()."
+        and: "One is objenesis, with compile scope. Corrected by adjustMavenPublication()."
         Node objenesisDepNode = depNodes.find { it.artifactId.text() == 'objenesis' }
         objenesisDepNode?.scope.text() == 'compile'
     }
     
     @Issue("gh-596")
-    def "adjustMavenPublicationPomScopes() on Web pub"() {
+    def "adjustMavenPublication() on Web pub"() {
         setup: "settings file"
         File settingsFile = testProjectDir.newFile('settings.gradle')
         settingsFile << "rootProject.name = 'test'"
@@ -298,7 +298,7 @@ class PublishingUtilTest extends Specification {
             
             import edu.ucar.build.publishing.PublishingUtil
             PublishingUtil.addMavenPublicationsForSoftwareComponents(project)
-            PublishingUtil.adjustMavenPublicationPomScopes(project)   // Testing this.
+            PublishingUtil.adjustMavenPublication(project)   // Testing this.
         """
         
         and: "Setup GradleRunner and execute it to get build result."
@@ -320,7 +320,7 @@ class PublishingUtilTest extends Specification {
     }
     
     @Issue("gh-596")
-    def "adjustMavenPublicationPomScopes() on artifact pub"() {  // Specifically our fat jars.
+    def "adjustMavenPublication() on artifact pub"() {  // Specifically our fat jars.
         setup: "settings file"
         File settingsFile = testProjectDir.newFile('settings.gradle')
         settingsFile << "rootProject.name = 'test'"
@@ -355,7 +355,7 @@ class PublishingUtilTest extends Specification {
             }
             
             import edu.ucar.build.publishing.PublishingUtil
-            PublishingUtil.adjustMavenPublicationPomScopes(project)   // Testing this.
+            PublishingUtil.adjustMavenPublication(project)   // Testing this.
         """
         
         and: "Setup GradleRunner and execute it to get build result."

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -77,39 +77,3 @@ farm {
     sslKeyStorePassword = 'secret666'
     logbackConfigFile = "$rootDir/gradle/gretty/logback.xml"
 }
-
-/**
- * Overlay the named project onto this project and apply its Gretty config to this project as well. The named project
- * is expected to have a property named 'grettyConfig' that modifies a org.akhikhl.gretty.GrettyExtension object.
- *
- * @param projectPath  the path of the project that is being overlaid.
- * @throws UnknownProjectException  if no project with the given path exists.
- * @throws MissingPropertyException if no property named 'grettyConfig' was found on the named project.
- */
-void overlayAndApplyConfigOf(String projectPath) {
-    Project proj = rootProject.project(projectPath)
-    
-    // Need to evaluate proj first so that the 'grettyConfig' property is available.
-    evaluationDependsOn proj.path
-    
-    gretty proj.grettyConfig
-    
-    // See http://akhikhl.github.io/gretty-doc/Web-app-overlays.html
-    gretty.overlay projectPath
-    
-    gretty.afterEvaluate {
-        // Remove the 'assemble' task's dependency on 'overlayArchive', which was established in
-        // GrettyPlugin.addTasks() (see https://goo.gl/cJYmuU). Essentially, 'overlayArchive' modifies the archive
-        // produced by a project (i.e. its JAR or WAR) to include the artifacts of the overlaid projects.
-        // I can't imagine why we'd ever want that, because we only use overlays for testing.
-        project.tasks.assemble.dependsOn.remove project.tasks.overlayArchive
-    }
-}
-
-// It isn't possible to share methods, but we can share extra properties containing a closure, which boils down to
-// the same thing. We're going to do that by converting our methods to closures.
-// See http://stackoverflow.com/questions/18715137/extract-common-methods-from-gradle-build-script
-ext {
-    // Export method by turning it into a closure.
-    overlayAndApplyConfigOf = this.&overlayAndApplyConfigOf
-}

--- a/gradle/any/publishing.gradle
+++ b/gradle/any/publishing.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 
 // These are safe to apply to the root project. They'll basically have no effect.
 PublishingUtil.addMavenPublicationsForSoftwareComponents(project)
-PublishingUtil.adjustMavenPublicationPomScopes(project)
+PublishingUtil.adjustMavenPublication(project)
 
 publishing {
     repositories {


### PR DESCRIPTION
After bumping to mainline gretty and having our client tests use a
gretty managed local server for testing, we picked up (for some reason)
a dependency on javax.servlet-api in the poms of the client artifacts
(httpservices, for example). This causes a problem when building the TDS,
for example, as we do not want a javax.servlet-api compile dependency
being added directly to the war. These changes remove the unwanted
dependency. This might be a bug in gradle, but we're running 3.5, so
maybe once we upgrade to 6, things will work without a special
workaround.