### PR TITLE
S3, RemoteRandomAccess file tweaks

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/io/http/HTTPRandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/http/HTTPRandomAccessFile.java
@@ -38,8 +38,8 @@ public final class HTTPRandomAccessFile extends RemoteRandomAccessFile {
   private static final int httpBufferSize =
       Integer.parseInt(System.getProperty("ucar.unidata.io.http.httpBufferSize", String.valueOf(maxHttpBufferSize)));
 
-  private static final int httpMaxCacheSize = Integer
-      .parseInt(System.getProperty("ucar.unidata.io.http.maxReadCacheSize", String.valueOf(defaultMaxReadCacheSize)));
+  private static final long httpMaxCacheSize = Long
+      .parseLong(System.getProperty("ucar.unidata.io.http.maxReadCacheSize", String.valueOf(defaultMaxReadCacheSize)));
 
   private static final boolean debug = false, debugDetails = false;
 
@@ -54,7 +54,7 @@ public final class HTTPRandomAccessFile extends RemoteRandomAccessFile {
 
   // TODO make private in 6?
   @Urlencoded
-  public HTTPRandomAccessFile(String url, int bufferSize, int maxRemoteCacheSize) throws IOException {
+  public HTTPRandomAccessFile(String url, int bufferSize, long maxRemoteCacheSize) throws IOException {
     super(url, bufferSize, maxRemoteCacheSize);
 
     if (debugLeaks)

--- a/cdm/s3/src/main/java/ucar/unidata/io/s3/S3RandomAccessFile.java
+++ b/cdm/s3/src/main/java/ucar/unidata/io/s3/S3RandomAccessFile.java
@@ -35,8 +35,8 @@ public final class S3RandomAccessFile extends RemoteRandomAccessFile implements 
   private static final int s3BufferSize = Integer
       .parseInt(System.getProperty("ucar.unidata.io.s3.bufferSize", String.valueOf(defaultRemoteFileBufferSize)));
 
-  private static final int s3MaxReadCacheSize = Integer
-      .parseInt(System.getProperty("ucar.unidata.io.s3.maxReadCacheSize", String.valueOf(defaultMaxReadCacheSize)));
+  private static final long s3MaxReadCacheSize = Long
+      .parseLong(System.getProperty("ucar.unidata.io.s3.maxReadCacheSize", String.valueOf(defaultMaxReadCacheSize)));
   /**
    * The maximum number of connections allowed in the S3 http connection pool. Each built S3 HTTP client has it's own
    * private connection pool.

--- a/uicdm/src/main/java/ucar/nc2/ui/op/NcmlEditor.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/op/NcmlEditor.java
@@ -12,8 +12,10 @@ import org.bounce.text.xml.XMLEditorKit;
 import org.bounce.text.xml.XMLStyleConstants;
 import org.jdom2.Element;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.ncml.NcMLReader;
 import ucar.nc2.ncml.NcMLWriter;
+import ucar.nc2.ui.ToolsUI;
 import ucar.nc2.ui.dialog.NetcdfOutputChooser;
 import ucar.ui.widget.BAMutil;
 import ucar.ui.widget.FileManager;
@@ -282,7 +284,9 @@ public class NcmlEditor extends JPanel {
 
   private NetcdfDataset openDataset(String location, boolean addCoords, CancelTask task) {
     try {
-      return NetcdfDataset.openDataset(location, addCoords, task);
+      boolean useBuilders = ToolsUI.getToolsUI().getUseBuilders();
+      return useBuilders ? NetcdfDatasets.openDataset(location, addCoords, task)
+          : NetcdfDataset.openDataset(location, addCoords, task);
 
       // if (setUseRecordStructure)
       // ncd.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
@@ -336,8 +340,9 @@ public class NcmlEditor extends JPanel {
     if (ncmlLocation == null) {
       return;
     }
-
-    try (NetcdfDataset ncd = NetcdfDataset.openDataset(ncmlLocation)) {
+    boolean useBuilders = ToolsUI.getToolsUI().getUseBuilders();
+    try (NetcdfDataset ncd =
+        useBuilders ? NetcdfDatasets.openDataset(ncmlLocation) : NetcdfDataset.openDataset(ncmlLocation)) {
       ncd.check(f);
     } catch (IOException ioe) {
       JOptionPane.showMessageDialog(this, "ERROR: " + ioe.getMessage());


### PR DESCRIPTION
* a few tweaks to RemoteRandomAccessFile, S3RandomAccessFile (read remote size using long, not int - oops)
*  Allow NcML editor to use `NetcdfDatasets.open`, which enables S3 read capabilities 