### PR TITLE
First pass at correcting know issues with URLs in links and references.

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/conv/NUWGConvention.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/conv/NUWGConvention.java
@@ -23,7 +23,7 @@ import java.util.*;
 
 /**
  * NUWG Convention (ad hoc).
- * see http://www.unidata.ucar.edu/packages/netcdf/NUWG/
+ * see http://www.unidata.ucar.edu/software/netcdf/NUWG/
  *
  * @author caron
  */

--- a/cdm/core/src/main/java/ucar/nc2/dataset/conv/package.html
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/conv/package.html
@@ -12,7 +12,7 @@
   Parses the information in netCDF datasets using <i>Conventions,</i> and extracts
   information about coordinate systems. The extracted information is put into 
   a NetcdfDataset.
-See: <a href="http://www.unidata.ucar.edu/packages/netcdf/conventions.html">NetcdfConventions</a>
+See: <a href="http://www.unidata.ucar.edu/software/netcdf/conventions.html">Netcdf Conventions</a>
 </pre>
 </BODY>
 </HTML>

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/NUWGConvention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/NUWGConvention.java
@@ -39,7 +39,7 @@ import ucar.unidata.util.StringUtil2;
 
 /**
  * NUWG Convention (ad hoc).
- * see http://www.unidata.ucar.edu/packages/netcdf/NUWG/
+ * see http://www.unidata.ucar.edu/software/netcdf/NUWG/
  */
 public class NUWGConvention extends CoordSystemBuilder {
   private static final String CONVENTION_NAME = "NUWG";

--- a/cdm/core/src/test/data/thredds/catalog/InvCatalog-1.0.xml
+++ b/cdm/core/src/test/data/thredds/catalog/InvCatalog-1.0.xml
@@ -55,7 +55,7 @@
     <!-- example of documentation, attribute, and metadata elements -->
     <dataset name="Doc examples" dataType="Grid" serviceName="ACD" ID="hasProp">
       <property name="GoodThing" value="Where have you gone?"/>
-      <documentation xlink:href="http://my.unidata.ucar.edu/content/projects/THREDDS/currentwork.html">
+      <documentation xlink:href="https://www.unidata.ucar.edu/netcdf-java/">
         This is the inline documentation.
       </documentation>
       <documentation xlink:title="Metar Format Description" xlink:href="testReletive.html"/>

--- a/docs/src/private/internal/CoordinateSystemsNeeded.adoc
+++ b/docs/src/private/internal/CoordinateSystemsNeeded.adoc
@@ -17,7 +17,7 @@ map variables) but I think none have done a complete job.
 Most well-written datasets specify the coordinate systems in the
 dataset, but without explicit library support, they do so in different
 ways, often documented by a
-http://www.unidata.ucar.edu/packages/netcdf/conventions.html[Convention].
+http://www.unidata.ucar.edu/software/netcdf/conventions.html[Convention].
 We are working closely with the HDF5 developers, who are interested in
 extending dimensions scales, and we are considering extensions of the
 netCDF model to comprise netCDF-4. With OpenDAP 4.0 under consideration,
@@ -27,11 +27,11 @@ consider new features in ways that are compatible with each other.
 I have done some prototyping of the functionality I think we need for
 coordinate systems in the netcdf-Java library, see the user manual,
 chapter
-http://www.unidata.ucar.edu/packages/netcdf-java/v2.1/NetcdfJavaUserManual.htm#_Toc42914935[3.2]
+http://www.unidata.ucar.edu/software/netcdf-java/v2.1/NetcdfJavaUserManual.htm#_Toc42914935[3.2]
 for some of the details, and implemented the prototype in the
 CoordinateSystem, CoordinateAxis, and CoordinateTransform classes of the
 ucar.nc2.dataset package (see the
-http://www.unidata.ucar.edu/packages/netcdf-java/v2.1/javadoc/index.html[javadoc]).
+http://www.unidata.ucar.edu/software/netcdf-java/v2.1/javadoc/index.html[javadoc]).
 
 To summarize some definitions:
 

--- a/docs/src/private/internal/release.md
+++ b/docs/src/private/internal/release.md
@@ -53,8 +53,8 @@ If so, you can skip to step 4.
     - As long as we don't make it to the artifact publishing step, we can always fix any issues by squashing new commits and pushing to the branch on Unidata/netcdf-java
 
 1. Update Unidata download page
-    - check https://www.unidata.ucar.edu/downloads/netcdf-java/index.jsp
-      * Edit (on machine www) `/content/downloads/netcdf-java/toc.xml` as needed
+    - check https://www.unidata.ucar.edu/downloads/netcdf-java/
+      * Edit (on machine www) `/content/downloads/netcdf-java/index.html` as needed
 
 1. Update netcdf-java landing page (if major or minor version change)
     - Edit (on machine www) /web/content/software/netcdf-java/index.html, update major.minor version string as needed.

--- a/docs/src/private/website/netcdf-java/metadata/DataDiscoveryAttConvention.adoc
+++ b/docs/src/private/website/netcdf-java/metadata/DataDiscoveryAttConvention.adoc
@@ -284,7 +284,7 @@ modification with each line including a timestamp, user name, 
 modification name, and modification arguments. Its use is recommended
 and its value will be used by THREDDS as a history-type documentation.
 The "history" attribute is recommended by the
-link:/packages/netcdf/docs/netcdf/[NetCDF Users Guide] and the
+link:/software/netcdf/docs/netcdf/[NetCDF Users Guide] and the
 http://www.cgd.ucar.edu/cms/eaton/cf-metadata/[CF convention].
 
 === id and naming_authority Attributes
@@ -447,7 +447,7 @@ The "title" attribute gives a brief description of the dataset. Its
 use is highly recommended and its value will be used by THREDDS as the
 name of the dataset. It therefore should be human readable and
 reasonable to display in a list of such names. The "title" attribute
-is recommended by the "link:/packages/netcdf/docs/netcdf/[NetCDF Users
+is recommended by the "link:/software/netcdf/docs/netcdf/[NetCDF Users
 Guide]" and the http://www.cgd.ucar.edu/cms/eaton/cf-metadata/[CF
 convention].
 

--- a/docs/src/private/website/netcdf-java/ncml/index.adoc
+++ b/docs/src/private/website/netcdf-java/ncml/index.adoc
@@ -8,7 +8,7 @@
 NcML is an XML representation of netCDF metadata, (approximately) the
 header information one gets from a netCDF file with the "ncdump -h" command. 
 NcML is similar to the netCDF
-http://www.unidata.ucar.edu/packages/netcdf/guidec/guidec-15.html#HEADING15-0[CDL]
+http://www.unidata.ucar.edu/software/netcdf/guidec/guidec-15.html#HEADING15-0[CDL]
 (network Common data form Description Language), except, of course, it
 uses XML syntax.
 

--- a/docs/src/private/website/netcdf-java/reference/ToolsUI/ToolsUI.adoc
+++ b/docs/src/private/website/netcdf-java/reference/ToolsUI/ToolsUI.adoc
@@ -10,7 +10,7 @@
 
 === Download and run locally
 You can download `toolsUI.jar` from either the NetCDF-Java
-link:/downloads/netcdf/netcdf-java-4/index.jsp[downloads] or
+link:/downloads/netcdf-java-4/[downloads] or
 link:../../documentation.htm#current[documentation] pages.
 You can then run the ToolsUI application using a command similar to: 
 ----

--- a/docs/src/private/website/netcdf-java/reference/ToolsUI/ToolsUI.adoc
+++ b/docs/src/private/website/netcdf-java/reference/ToolsUI/ToolsUI.adoc
@@ -4,13 +4,13 @@
 
 = ToolsUI
 :linkcss:
-:stylesheet: ../../cdm.css
+:stylesheet: ../../cdm.css:
 
 == Running ToolsUI
 
 === Download and run locally
 You can download `toolsUI.jar` from either the NetCDF-Java
-link:/downloads/netcdf-java-4/[downloads] or
+link:/downloads/netcdf-java/[downloads] or
 link:../../documentation.htm#current[documentation] pages.
 You can then run the ToolsUI application using a command similar to: 
 ----

--- a/docs/src/private/website/tds/catalog/InvCatalogSpec.adoc
+++ b/docs/src/private/website/tds/catalog/InvCatalogSpec.adoc
@@ -1449,7 +1449,7 @@ Aggregation Server configuration. A _File_ dataset is not readable by
 remote clients. *HTTPServer* should be used when your file is being
 served by an HTTP (Web) Server. This is used for bulk transfer just like
 FTP, and also can be used by the
-http://www.unidata.ucar.edu/packages/netcdf-java/[Java-NetCDF library]
+http://www.unidata.ucar.edu/software/netcdf-java/[Java-NetCDF library]
 to access NetCDF files remotely (in that case just make sure that the
 dataset has dataFormatType NetCDF or NcML).
 

--- a/docs/src/private/website/tds/reference/ThreddsConfigXMLFile.adoc
+++ b/docs/src/private/website/tds/reference/ThreddsConfigXMLFile.adoc
@@ -433,7 +433,7 @@ detail on the <<ncISO#,ncISO page>>.
 -----------------------------------------
 
 In order to write netCDF-4 files, you must have the
-http://www.unidata.ucar.edu/downloads/netcdf/index.jsp[netCDF-4 C library]—version 4.3.1 or above—compiled and
+http://www.unidata.ucar.edu/downloads/netcdf/[netCDF-4 C library]—version 4.3.1 or above—compiled and
 available on your system, along with all supporting libraries (HDF5, zlib, and curl). The
 <<../../netcdf-java/reference/netcdf4Clibrary.html#,details>> of this differ for each operating system. The elements
 above allow you to configure how the library is discovered and used.

--- a/docs/src/public/userguide/index.md
+++ b/docs/src/public/userguide/index.md
@@ -20,7 +20,7 @@ The [THREDDS Data Server (TDS)](https://www.unidata.ucar.edu/software/thredds/cu
 
 NetCDF-Java is Free and Open Source Software, and is hosted on [GitHub](https://github.com/unidata/netcdf-java){:target="_blank"}.
 To build the latest stable version from source or contribute code to the netCDF-Java project, [see here](building_from_source.html).
-Most projects use netcdfAll.jar or toolsUI.jar (download [here](https://www.unidata.ucar.edu/downloads/netcdf-java/index.jsp){:target="_blank"}), or include the desired artifacts in their maven or gradle builds.
+Most projects use netcdfAll.jar or toolsUI.jar (download [here](https://www.unidata.ucar.edu/downloads/netcdf-java/){:target="_blank"}), or include the desired artifacts in their maven or gradle builds.
 See [Using netCDF-Java Maven Artifacts](using_netcdf_java_artifacts.html) for details.
 
 As of version 5.0, netCDF-Java is released under the BSD-3 licence, which can be found can be found [here](https://github.com/Unidata/netcdf-java/blob/master/LICENSE){:target="_blank"}.

--- a/docs/src/public/userguide/pages/netcdfJava/ToolsUi.md
+++ b/docs/src/public/userguide/pages/netcdfJava/ToolsUi.md
@@ -10,7 +10,7 @@ permalink: toolsui_ref.html
 
 ### Download and run locally
 
-You can download toolsUI.jar from the [netCDF-Java downloads page](https://www.unidata.ucar.edu/downloads/netcdf-java/index.jsp){:target="_blank"}.
+You can download toolsUI.jar from the [netCDF-Java downloads page](https://www.unidata.ucar.edu/downloads/netcdf-java/){:target="_blank"}.
 You can then run the ToolsUI application using a command similar to:
 
 ~~~bash


### PR DESCRIPTION
In netcdf-java repo:

- removed unidata downloads site index.jsp references
- removed references to my.unidata domain
- removed references to old package convention in unidata urls