### PR TITLE
Add a version string to the documentation build configuration

### DIFF
--- a/docs/src/public/userguide/_config.yml
+++ b/docs/src/public/userguide/_config.yml
@@ -11,10 +11,13 @@ site_title: netCDF-Java Documentation
 site_topic: netCDF-Java
 # this appears in the footer
 
+doc_version: 5.4
+# this will appear in an HTML meta tag
+
 company_name: Unidata
 # this appears in the footer
 
-github_editme_path: 
+github_editme_path:
 
 #github_editme_path: tomjohnson1492/documentation-theme-jekyll/blob/gh-pages/pages/
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.

--- a/docs/src/public/userguide/_includes/head.html
+++ b/docs/src/public/userguide/_includes/head.html
@@ -3,6 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
+<meta name="doc_version" content="{{site.doc_version}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
 <link rel="stylesheet" href="{{ "css/syntax.css" }}">
 


### PR DESCRIPTION
Add a version string to the build configuration, and reflect that version number in a meta tag in the head of the built HTML files.