### PR TITLE
Fix S3 tests, add gradle test option

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/TestNetcdfFilesRafs.java
+++ b/cdm-test/src/test/java/ucar/nc2/TestNetcdfFilesRafs.java
@@ -29,7 +29,7 @@ public class TestNetcdfFilesRafs {
   private final String s3Bucket = "noaa-goes16";
   private final String s3Key =
       "ABI-L1b-RadM/2017/241/23/OR_ABI-L1b-RadM1-M3C11_G16_s20172412359247_e20172412359304_c20172412359341.nc";
-  private final String s3uri = "cdms3://" + s3Bucket + "?" + s3Key;
+  private final String s3uri = "cdms3:" + s3Bucket + "?" + s3Key;
 
   private final String baseHttpLocation = "noaa-goes16.s3.amazonaws.com/" + s3Key;
   private final String inMemLocation = "slurp://" + baseHttpLocation;

--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
@@ -26,7 +26,7 @@ public class TestS3ExternalCompressionRead {
     String region = Region.US_EAST_1.toString();
     String bucket = "noaa-nexrad-level2";
     String key = "1991/07/20/KTLX/KTLX19910720_160529.gz";
-    String s3uri = "cdms3://" + bucket + "?" + key;
+    String s3uri = "cdms3:" + bucket + "?" + key;
 
     System.setProperty("aws.region", region);
     try (NetcdfFile ncfile = NetcdfFiles.open(s3uri)) {

--- a/gradle/any/testing.gradle
+++ b/gradle/any/testing.gradle
@@ -17,33 +17,36 @@ tasks.withType(Test).all {
     }
     
     useJUnit {
-        if (isJenkins) {
-            excludeCategories 'ucar.unidata.util.test.category.NotJenkins'
-        }
-        
-        if (isTravis) {
-            excludeCategories 'ucar.unidata.util.test.category.NotTravis'
-            excludeCategories 'ucar.unidata.util.test.category.NeedsExternalResource'
-        }
-        
-        if (!isContentRootAvailable && !isJenkins) { // Don't skip tests on Jenkins, except NotJenkins ones.
-            excludeCategories 'ucar.unidata.util.test.category.NeedsContentRoot'
-        }
-        
-        if (!isCdmUnitTestDirAvailable && !isJenkins) {  // Don't skip tests on Jenkins, except NotJenkins ones.
-            excludeCategories 'ucar.unidata.util.test.category.NeedsCdmUnitTest'
-        }
-        
-        if (!isRdaDataAvailable) {
-            excludeCategories 'ucar.unidata.util.test.category.NeedsRdaData'
-        }
+        // if we are not explicitly trying to run all tests, allow some categories to be ignored
+        if (!runAllTests) {
+            if (isJenkins) {
+                excludeCategories 'ucar.unidata.util.test.category.NotJenkins'
+            }
 
-        if (!runSlowTests) {
-            excludeCategories 'ucar.unidata.util.test.category.Slow'
-        }
+            if (isTravis) {
+                excludeCategories 'ucar.unidata.util.test.category.NotTravis'
+                excludeCategories 'ucar.unidata.util.test.category.NeedsExternalResource'
+            }
 
-        if (!isUcarNetworkAvailable) {
-            excludeCategories 'ucar.unidata.util.test.category.NeedsUcarNetwork'
+            if (!isContentRootAvailable && !isJenkins) { // Don't skip tests on Jenkins, except NotJenkins ones.
+                excludeCategories 'ucar.unidata.util.test.category.NeedsContentRoot'
+            }
+
+            if (!isCdmUnitTestDirAvailable && !isJenkins) {  // Don't skip tests on Jenkins, except NotJenkins ones.
+                excludeCategories 'ucar.unidata.util.test.category.NeedsCdmUnitTest'
+            }
+
+            if (!isRdaDataAvailable) {
+                excludeCategories 'ucar.unidata.util.test.category.NeedsRdaData'
+            }
+
+            if (!runSlowTests) {
+                excludeCategories 'ucar.unidata.util.test.category.Slow'
+            }
+
+            if (!isUcarNetworkAvailable) {
+                excludeCategories 'ucar.unidata.util.test.category.NeedsUcarNetwork'
+            }
         }
     }
 }

--- a/gradle/root/testing.gradle
+++ b/gradle/root/testing.gradle
@@ -8,45 +8,59 @@ if (name != "netcdf-java") {
 // but it's not worth the extra complication.
 // LOOK: What about if we only logged warnings in "gradle.taskGraph.whenReady{}"?
 ext {
+    // Inspect environment to see what tests we should run
+
     // These appear to be the only environment variables that Jenkins defines: http://goo.gl/iCh08k
     // Is there a better way to detect Jenkins?
     jenkinsEnvVar = 'JENKINS_URL'
     isJenkins = System.env[jenkinsEnvVar] as boolean  // We only care if prop is defined, not its actual value.
-    if (isJenkins) {
-        logger.warn "Skipping all NotJenkins tests: detected that we're running in the Jenkins environment."
-    }
 
     travisEnvVar = 'TRAVIS'
     isTravis = System.env[travisEnvVar] as boolean  // We only care if prop is defined, not its actual value.
-    if (isTravis) {
-        logger.warn "Skipping all NotTravis tests: detected that we're running in the Travis environment."
-    }
 
     contentRootKey = 'tds.content.root.path'
     isContentRootAvailable = isSystemPropertyAValidDirectory contentRootKey
-    if (!isContentRootAvailable && !isJenkins) {  // Don't skip tests on Jenkins, except NotJenkins ones.
-        logger.warn "Skipping all NeedsContentRoot tests."
-    }
 
     testdataDirKey = 'unidata.testdata.path'
     isCdmUnitTestDirAvailable = isSystemPropertyAValidDirectory testdataDirKey
-    if (!isCdmUnitTestDirAvailable && !isJenkins) {     // Don't skip tests on Jenkins, except NotJenkins ones.
-        logger.warn "Skipping all NeedsCdmUnitTest tests."
-    }
 
     runSlowTests = System.properties["runSlowTests"] as boolean // We only care if prop is defined, not its actual value.
-    if (!runSlowTests) {
-        logger.warn "Skipping all Slow tests."
-    }
-
     isRdaDataAvailable = System.properties["rdaDataAvailable"] as boolean // We only care if prop is defined, not its actual value.
-    if (!isRdaDataAvailable) {
-        logger.warn "Skipping all tests that require access to RDA data."
-    }
-
     isUcarNetworkAvailable = System.properties["ucarNetworkAvailable"] as boolean // We only care if prop is defined, not its actual value.
-    if (!isUcarNetworkAvailable) {
-        logger.warn "Skipping all tests that require access to the UCAR Network."
+
+    // Option to run all tests regardless of environment or resource availability
+    runAllTests = System.properties["runAllTestExceptIgnored"] as boolean // We only care if prop is defined, not its actual value.
+
+    if (runAllTests) {
+        logger.warn "Running all tests except those explicitly annotated with @Ignore."
+    } else {
+        if (isJenkins) {
+            logger.warn "Skipping all NotJenkins tests: detected that we're running in the Jenkins environment."
+        }
+
+        if (isTravis) {
+            logger.warn "Skipping all NotTravis tests: detected that we're running in the Travis environment."
+        }
+
+        if (!isContentRootAvailable && !isJenkins) {  // Don't skip tests on Jenkins, except NotJenkins ones.
+            logger.warn "Skipping all NeedsContentRoot tests."
+        }
+
+        if (!isCdmUnitTestDirAvailable && !isJenkins) {     // Don't skip tests on Jenkins, except NotJenkins ones.
+            logger.warn "Skipping all NeedsCdmUnitTest tests."
+        }
+
+        if (!runSlowTests) {
+            logger.warn "Skipping all Slow tests."
+        }
+
+        if (!isRdaDataAvailable) {
+            logger.warn "Skipping all tests that require access to RDA data."
+        }
+
+        if (!isUcarNetworkAvailable) {
+            logger.warn "Skipping all tests that require access to the UCAR Network."
+        }
     }
 }
 


### PR DESCRIPTION
This PR does two things:
1. Adds an option to the gradle build to run all tests except those annotated with `@Ignore`.
2. Fix the S3 URIs used in a few tests (simplified AWS form must be `cdms3:bucket?key`, not `cdms3://bucket?key`)