### PR TITLE
Add doc version menu

### DIFF
--- a/docs/src/public/userguide/_config.yml
+++ b/docs/src/public/userguide/_config.yml
@@ -3,6 +3,7 @@ output: web
 # this property is useful for conditional filtering of content that is separate from the PDF.
 
 docset_version: 5.4
+# this will appear in an HTML meta tag, sidebar, and perhaps elsewhere
 
 topnav_title: netCDF-Java Documentation
 # this appears on the top navigation bar next to the home button

--- a/docs/src/public/userguide/_config.yml
+++ b/docs/src/public/userguide/_config.yml
@@ -101,6 +101,7 @@ description: "This is a documentation site for the netCDF-Java and THREDDS Data 
 # the description is used in the feed.xml file
 
 # needed for sitemap.xml file only
-url: www.unidata.ucar.edu
+# must include trailing slash, leave off the version :-)
+base_docs_url: https://docs.unidata.ucar.edu/netcdf-java/
 
 google_analytics: UA-92978945-1

--- a/docs/src/public/userguide/_config.yml
+++ b/docs/src/public/userguide/_config.yml
@@ -17,13 +17,7 @@ site_topic: netCDF-Java
 company_name: Unidata
 # this appears in the footer
 
-<<<<<<< HEAD
-=======
 github_editme_path:
-
->>>>>>> 8d42b06b4a... Version menu floats to the left!
-#github_editme_path: tomjohnson1492/documentation-theme-jekyll/blob/gh-pages/pages/
-# if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.
 
 disqus_shortname:
 # if you're using disqus for comments, add the shortname here. if not, leave this value blank.

--- a/docs/src/public/userguide/_config.yml
+++ b/docs/src/public/userguide/_config.yml
@@ -5,7 +5,7 @@ output: web
 docset_version: 5.4
 # this will appear in an HTML meta tag, sidebar, and perhaps elsewhere
 
-topnav_title: netCDF-Java Documentation
+topnav_title: netCDF-Java
 # this appears on the top navigation bar next to the home button
 
 site_title: netCDF-Java Documentation
@@ -17,6 +17,11 @@ site_topic: netCDF-Java
 company_name: Unidata
 # this appears in the footer
 
+<<<<<<< HEAD
+=======
+github_editme_path:
+
+>>>>>>> 8d42b06b4a... Version menu floats to the left!
 #github_editme_path: tomjohnson1492/documentation-theme-jekyll/blob/gh-pages/pages/
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.
 

--- a/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
+++ b/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
@@ -2,8 +2,7 @@
 
 entries:
 - title: Sidebar
-  product: netCDF-Java Tutorial and Reference Documentation
-  version: 5.4
+  product: Tutorial and Reference Documentation
   folders:
 
   - title:
@@ -287,4 +286,3 @@ entries:
     - title: 5.0 Changes
       url: /upgrade_to_50.html
       output: web, pdf
-

--- a/docs/src/public/userguide/_data/topnav.yml
+++ b/docs/src/public/userguide/_data/topnav.yml
@@ -6,17 +6,19 @@
 #    - title: Introduction
 #      url: /index.html
 
+# Documentation version menu
+topnav_docvermenu:
+- title: Version
+  id: docmenu
+  folderitems:
+    - title: Menu Loading...
+      url:
+      id: remove
+
 #Topnav dropdowns
 topnav_dropdowns:
 - title: Topnav dropdowns
   folders:
-    - title: netCDF-Java Versions
-      id: docmenu
-      folderitems:
-        - title: Menu Loading...
-          url:
-          id: remove
-
     - title: THREDDS Source
       folderitems:
         - title: netCDF-Java Github Repo

--- a/docs/src/public/userguide/_data/topnav.yml
+++ b/docs/src/public/userguide/_data/topnav.yml
@@ -3,13 +3,20 @@
 #topnav:
 #- title: Topnav
 #  items:
-#    - title: Introduction 
+#    - title: Introduction
 #      url: /index.html
 
 #Topnav dropdowns
 topnav_dropdowns:
 - title: Topnav dropdowns
   folders:
+    - title: netCDF-Java Versions
+      id: docmenu
+      folderitems:
+        - title: Menu Loading...
+          url:
+          id: remove
+
     - title: THREDDS Source
       folderitems:
         - title: netCDF-Java Github Repo

--- a/docs/src/public/userguide/_includes/head.html
+++ b/docs/src/public/userguide/_includes/head.html
@@ -33,5 +33,3 @@
 <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 <![endif]-->
-
-<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">

--- a/docs/src/public/userguide/_includes/head.html
+++ b/docs/src/public/userguide/_includes/head.html
@@ -34,4 +34,4 @@
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 <![endif]-->
 
-<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "feed.xml" | prepend: site.url }}">
+<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">

--- a/docs/src/public/userguide/_includes/head.html
+++ b/docs/src/public/userguide/_includes/head.html
@@ -3,6 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
+<meta name="doc_version" content="{{site.docset_version}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
 <link rel="stylesheet" href="{{ "css/syntax.css" }}">
 
@@ -33,4 +34,4 @@
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 <![endif]-->
 
-<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" }}">
+<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "feed.xml" | prepend: site.url }}">

--- a/docs/src/public/userguide/_includes/sidebar.html
+++ b/docs/src/public/userguide/_includes/sidebar.html
@@ -1,7 +1,7 @@
 {% include custom/sidebarconfigs.html %}
 
 <ul id="mysidebar" class="nav">
-    <li class="sidebarTitle">{{sidebar[0].product}} {{site.docset_version}}</li>
+    <li class="sidebarTitle">{{sidebar[0].product}}</li>
     {% for entry in sidebar %}
     {% for folder in entry.folders %}
     {% if folder.output contains "web" %}

--- a/docs/src/public/userguide/_includes/topnav.html
+++ b/docs/src/public/userguide/_includes/topnav.html
@@ -1,56 +1,75 @@
 <!-- Navigation -->
 <nav class="navbar navbar-inverse navbar-fixed-top">
-    <div class="container topnavlinks">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-            <a class="fa fa-home fa-lg navbar-brand" href="index.html">&nbsp;<span class="projectTitle"> {{site.topnav_title}}</span></a>
-        </div>
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            <ul class="nav navbar-nav navbar-right">
-                <!-- entries without drop-downs appear here -->
-                {% for entry in site.data.topnav.topnav %}
-                {% for item in entry.items %}
-                {% if item.external_url %}
-                <li><a href="{{item.external_url}}" target="_blank">{{item.title}}</a></li>
-                {% elsif page.url contains item.url %}
-                <li class="active"><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
-                {% else %}
-                <li><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
-                {% endif %}
-                {% endfor %}
-                {% endfor %}
-                <!-- entries with drop-downs appear here -->
-                <!-- conditional logic to control which topnav appears for the audience defined in the configuration file.-->
-                {% for entry in site.data.topnav.topnav_dropdowns %}
-                {% for folder in entry.folders %}
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ folder.title }}<b class="caret"></b></a>
-                    <ul class="dropdown-menu" id="{{folder.id}}">
-                        {% for folderitem in folder.folderitems %}
-                        {% if folderitem.external_url %}
-                        <li id="{{folderitem.id}}"><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
-                        {% elsif page.url contains folderitem.url %}
-                        <li class="dropdownActive"><a href="{{folderitem.url |  remove: "/"}}">{{folderitem.title}}</a></li>
-                        {% else %}
-                        <li id="{{folderitem.id}}"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
-                        {% endif %}
-                        {% endfor %}
-                    </ul>
-                </li>
-                {% endfor %}
-                {% endfor %}
-                {% if site.feedback_disable == null or site.feedback_disable == false %}
-			{% include feedback.html %}
-		{% endif %}
-                <!--comment out this block if you want to hide search-->
-                <li>
-                    <!--start search-->
-                    <!--
+  <div class="container topnavlinks">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="fa fa-home fa-lg navbar-brand" href="index.html" style="padding-right:0px;">&nbsp;<span class="projectTitle">
+          {{site.topnav_title}}</span></a>
+    </div>
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+      <ul class="nav navbar-nav navbar-left">
+        {% for entry in site.data.topnav.topnav_docvermenu %}
+        <li class="dropdown" id="vermenu">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ entry.title }} {{site.docset_version}}<b class="caret"></b></a>
+          <ul class="dropdown-menu" id="{{entry.id}}">
+            {% for folderitem in entry.folderitems %}
+            {% if folderitem.external_url %}
+            <li id="{{folderitem.id}}"><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+            {% elsif page.url contains folderitem.url %}
+            <li class="dropdownActive"><a href="{{folderitem.url |  remove: "/"}}">{{folderitem.title}}</a></li>
+            {% else %}
+            <li id="{{folderitem.id}}"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </li>
+        {% endfor %}
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        <!-- entries without drop-downs appear here -->
+        {% for entry in site.data.topnav.topnav %}
+        {% for item in entry.items %}
+        {% if item.external_url %}
+        <li><a href="{{item.external_url}}" target="_blank">{{item.title}}</a></li>
+        {% elsif page.url contains item.url %}
+        <li class="active"><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
+        {% else %}
+        <li><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
+        {% endif %}
+        {% endfor %}
+        {% endfor %}
+        <!-- entries with drop-downs appear here -->
+        <!-- conditional logic to control which topnav appears for the audience defined in the configuration file.-->
+        {% for entry in site.data.topnav.topnav_dropdowns %}
+        {% for folder in entry.folders %}
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ folder.title }}<b class="caret"></b></a>
+          <ul class="dropdown-menu" id="{{folder.id}}">
+            {% for folderitem in folder.folderitems %}
+            {% if folderitem.external_url %}
+            <li id="{{folderitem.id}}"><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+            {% elsif page.url contains folderitem.url %}
+            <li class="dropdownActive"><a href="{{folderitem.url |  remove: "/"}}">{{folderitem.title}}</a></li>
+            {% else %}
+            <li id="{{folderitem.id}}"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </li>
+        {% endfor %}
+        {% endfor %}
+        {% if site.feedback_disable == null or site.feedback_disable == false %}
+        {% include feedback.html %}
+        {% endif %}
+        <!--comment out this block if you want to hide search-->
+        <li>
+          <!--start search-->
+          <!--
                     <div id="search-demo-container">
                         <input type="text" id="search-input" placeholder="{{site.data.strings.search_placeholder_text}}">
                         <ul id="results-container"></ul>
@@ -68,11 +87,11 @@
                     })
                     </script>
                     -->
-                    <!--end search-->
-                </li>
+          <!--end search-->
+        </li>
 
-            </ul>
-        </div>
-        </div>
-        <!-- /.container -->
+      </ul>
+    </div>
+  </div>
+  <!-- /.container -->
 </nav>

--- a/docs/src/public/userguide/_includes/topnav.html
+++ b/docs/src/public/userguide/_includes/topnav.html
@@ -30,14 +30,14 @@
                 {% for folder in entry.folders %}
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ folder.title }}<b class="caret"></b></a>
-                    <ul class="dropdown-menu">
+                    <ul class="dropdown-menu" id="{{folder.id}}">
                         {% for folderitem in folder.folderitems %}
                         {% if folderitem.external_url %}
-                        <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+                        <li id="{{folderitem.id}}"><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
                         {% elsif page.url contains folderitem.url %}
                         <li class="dropdownActive"><a href="{{folderitem.url |  remove: "/"}}">{{folderitem.title}}</a></li>
                         {% else %}
-                        <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                        <li id="{{folderitem.id}}"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
                         {% endif %}
                         {% endfor %}
                     </ul>

--- a/docs/src/public/userguide/css/theme-unidata.css
+++ b/docs/src/public/userguide/css/theme-unidata.css
@@ -101,3 +101,10 @@ li.sidebarTitle {
     margin-left: 5px;
 
 }
+/* left-floated version menu */ /* DD 2020_04 */
+@media (min-width: 768px) {
+  ul.navbar-left > li#vermenu > a {
+    font-size: 18px;
+    font-weight: 600;
+  }
+}

--- a/docs/src/public/userguide/js/customscripts.js
+++ b/docs/src/public/userguide/js/customscripts.js
@@ -26,7 +26,7 @@ function updateVersionMenu(package) {
     method: "GET",
     async: true
   });
-  
+
   request.success(function(data) {
     // Remove menu placeholder
     $("li#remove").remove();
@@ -36,7 +36,7 @@ function updateVersionMenu(package) {
     $.each(data.releases, function(index, rel) {
       var pVer = rel.version;
       var pDoc = rel.docURL;
-      var menuURL = "<li><a href=\""+ pDoc +"\">" + pName + " version " + pVer + "</a></li>";
+      var menuURL = "<li><a href=\""+ pDoc +"\">" + " version " + pVer + "</a></li>";
       if (parseInt(rel.include) && (thisVersion != rel.version)) {
         $("#docmenu").append(menuURL);
       }

--- a/docs/src/public/userguide/js/customscripts.js
+++ b/docs/src/public/userguide/js/customscripts.js
@@ -20,6 +20,7 @@ function updateVersionMenu(package) {
   var thisVersion = $('meta[name=doc_version]').attr("content");
   // Get the page currently being displayed, so we can go there in the selected doc set.
   var thisPage = window.location.pathname;
+  thisPage = thisPage.substring(thisPage.lastIndexOf("/"));
 
   // Get version info from static JSON file
   var request = $.ajax({

--- a/docs/src/public/userguide/js/customscripts.js
+++ b/docs/src/public/userguide/js/customscripts.js
@@ -1,55 +1,108 @@
-
 $('#mysidebar').height($(".nav").height());
 
+// The updateVersionMenu function populates a "package Versions" menu defined in topnav.yml.
+// The function is called on $(document).ready() below.
+// The 'package' argument is string containing the canonical package name.
+// DD 2020-04
+function updateVersionMenu(package) {
+  // Get list of versions from a static JSON file. Usually this will live on the
+  // docs.unidata.ucar.edu server, but during development it's a local file.
+  var thisLoc = window.location.origin;
+  var jsonFileSuffix = "_doc_versions.json";
+  if (thisLoc=="https://docs.unidata.ucar.edu") {
+    var versionQuery = thisLoc + '/' + package + '/' + package + jsonFileSuffix;
+  } else if (thisLoc=="http://127.0.0.1:4005") {
+    var versionQuery = thisLoc + '/files/' + package + jsonFileSuffix;
+  } else {
+    var versionQuery = '';
+  }
+  // Get the version currently being displayed from an HTML meta tag.
+  var thisVersion = $('meta[name=doc_version]').attr("content");
 
-$( document ).ready(function() {
+  // Get version info from static JSON file
+  var request = $.ajax({
+    dataType: "json",
+    url: versionQuery,
+    method: "GET",
+    async: true
+  });
+  
+  request.success(function(data) {
+    // Remove menu placeholder
+    $("li#remove").remove();
 
-    //this script says, if the height of the viewport is greater than 800px, then insert affix class, which makes the nav bar float in a fixed
-    // position as your scroll. if you have a lot of nav items, this height may not work for you.
-    var h = $(window).height();
-    //console.log (h);
-    if (h > 800) {
-        $( "#mysidebar" ).attr("class", "nav affix");
-    }
-    // activate tooltips. although this is a bootstrap js function, it must be activated this way in your theme.
-    $('[data-toggle="tooltip"]').tooltip({
-        placement : 'top'
+    // Build menu entries
+    var pName = data.packageName;
+    $.each(data.releases, function(index, rel) {
+      var pVer = rel.version;
+      var pDoc = rel.docURL;
+      var menuURL = "<li><a href=\""+ pDoc +"\">" + pName + " version " + pVer + "</a></li>";
+      if (parseInt(rel.include) && (thisVersion != rel.version)) {
+        $("#docmenu").append(menuURL);
+      }
     });
+  });
 
-    /**
-     * AnchorJS
-     */
-    anchors.add('h2,h3,h4,h5');
+  request.error(function(data) {
+    // Remove menu placeholder
+    $("li#remove").remove();
+    // Insert an error indicator. Maybe this should link somewhere?
+    $("#docmenu").append("<li><a href=\"\">Error finding other versions...</a></li>");
+    console.log("The JSON file containing version information was not found.");
+  });
+};
+// end updateMenu()
 
+$(document).ready(function() {
+
+  //this script says, if the height of the viewport is greater than 800px, then insert affix class, which makes the nav bar float in a fixed
+  // position as your scroll. if you have a lot of nav items, this height may not work for you.
+  var h = $(window).height();
+  //console.log (h);
+  if (h > 800) {
+    $("#mysidebar").attr("class", "nav affix");
+  }
+  // activate tooltips. although this is a bootstrap js function, it must be activated this way in your theme.
+  $('[data-toggle="tooltip"]').tooltip({
+    placement: 'top'
+  });
+
+  /**
+   * AnchorJS
+   */
+  anchors.add('h2,h3,h4,h5');
+
+  // Specify the package name to update the versions menu
+  updateVersionMenu("netcdf-java");
 });
 
 // needed for nav tabs on pages. See Formatting > Nav tabs for more details.
 // script from http://stackoverflow.com/questions/10523433/how-do-i-keep-the-current-tab-active-with-twitter-bootstrap-after-a-page-reload
 $(function() {
-    var json, tabsState;
-    $('a[data-toggle="pill"], a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
-        var href, json, parentId, tabsState;
-
-        tabsState = localStorage.getItem("tabs-state");
-        json = JSON.parse(tabsState || "{}");
-        parentId = $(e.target).parents("ul.nav.nav-pills, ul.nav.nav-tabs").attr("id");
-        href = $(e.target).attr('href');
-        json[parentId] = href;
-
-        return localStorage.setItem("tabs-state", JSON.stringify(json));
-    });
+  var json, tabsState;
+  $('a[data-toggle="pill"], a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+    var href, json, parentId, tabsState;
 
     tabsState = localStorage.getItem("tabs-state");
     json = JSON.parse(tabsState || "{}");
+    parentId = $(e.target).parents("ul.nav.nav-pills, ul.nav.nav-tabs").attr("id");
+    href = $(e.target).attr('href');
+    json[parentId] = href;
 
-    $.each(json, function(containerId, href) {
-        return $("#" + containerId + " a[href=" + href + "]").tab('show');
-    });
+    return localStorage.setItem("tabs-state", JSON.stringify(json));
+  });
 
-    $("ul.nav.nav-pills, ul.nav.nav-tabs").each(function() {
-        var $this = $(this);
-        if (!json[$this.attr("id")]) {
-            return $this.find("a[data-toggle=tab]:first, a[data-toggle=pill]:first").tab("show");
-        }
-    });
+  tabsState = localStorage.getItem("tabs-state");
+  json = JSON.parse(tabsState || "{}");
+
+  $.each(json, function(containerId, href) {
+    return $("#" + containerId + " a[href=" + href + "]").tab('show');
+  });
+
+  $("ul.nav.nav-pills, ul.nav.nav-tabs").each(function() {
+    var $this = $(this);
+    if (!json[$this.attr("id")]) {
+      return $this.find("a[data-toggle=tab]:first, a[data-toggle=pill]:first").tab("show");
+    }
+  });
 });

--- a/docs/src/public/userguide/js/customscripts.js
+++ b/docs/src/public/userguide/js/customscripts.js
@@ -18,6 +18,8 @@ function updateVersionMenu(package) {
   }
   // Get the version currently being displayed from an HTML meta tag.
   var thisVersion = $('meta[name=doc_version]').attr("content");
+  // Get the page currently being displayed, so we can go there in the selected doc set.
+  var thisPage = window.location.pathname;
 
   // Get version info from static JSON file
   var request = $.ajax({
@@ -32,11 +34,15 @@ function updateVersionMenu(package) {
     $("li#remove").remove();
 
     // Build menu entries
-    var pName = data.packageName;
     $.each(data.releases, function(index, rel) {
       var pVer = rel.version;
       var pDoc = rel.docURL;
-      var menuURL = "<li><a href=\""+ pDoc +"\">" + " version " + pVer + "</a></li>";
+      // docURL is a full path to the docset index file. Build path to current page instead.
+      pDoc = pDoc.substring(0, pDoc.lastIndexOf("/"));
+      pDoc = pDoc + ((typeof thisPage === 'string') ? thisPage : "/");
+      // Build the link
+      var menuURL = "<li><a href=\""+ pDoc +"\">" + " Version " + pVer + "</a></li>";
+      // Add menuURL to menu if json file says it's okay, and if it's not the current version.
       if (parseInt(rel.include) && (thisVersion != rel.version)) {
         $("#docmenu").append(menuURL);
       }

--- a/docs/src/public/userguide/sitemap_current.xml
+++ b/docs/src/public/userguide/sitemap_current.xml
@@ -5,7 +5,7 @@ search: exclude
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% assign userguide_name = "/userguide" %}
-  {% capture sitemap_version_url %}{{ site.base_docs_url | append: site.docset_version }}{% endcapture %}
+  {% capture sitemap_version_url %}{{ site.base_docs_url | append: "current" }}{% endcapture %}
   {% capture sitemap_url_prefix %}{{ sitemap_version_url | append: userguide_name}}{% endcapture %}
   {% for post in site.posts %}
   {% unless post.search == "exclude" %}


### PR DESCRIPTION
This adds a dynamic version menu to the netcdf-java docs, allowing the user to switch to the current topic in the docset for a different listed version.

Comments especially solicited on robustness/error-checking in the javascript (customscripts.js), behavior in "responsive" situations (small screens), and visual presentation.