### PR TITLE
Ignore access elements that use undefined service name

### DIFF
--- a/cdm/core/src/main/java/thredds/client/catalog/Dataset.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/Dataset.java
@@ -124,13 +124,16 @@ public class Dataset extends DatasetNode implements ThreddsMetadataContainer {
   }
 
   private void addAllAccess(Access a, List<Access> result) {
-    if (a.getService().getType() == ServiceType.Compound) {
-      for (Service nested : a.getService().getNestedServices()) {
-        Access nestedAccess = new Access(this, a.getUrlPath(), nested, a.getDataFormatName(), a.getDataSize());
-        addAllAccess(nestedAccess, result); // i guess it could recurse
+    Service service = a.getService();
+    if (service != null) {
+      if (a.getService().getType() == ServiceType.Compound) {
+        for (Service nested : a.getService().getNestedServices()) {
+          Access nestedAccess = new Access(this, a.getUrlPath(), nested, a.getDataFormatName(), a.getDataSize());
+          addAllAccess(nestedAccess, result); // i guess it could recurse
+        }
+      } else {
+        result.add(a);
       }
-    } else {
-      result.add(a);
     }
   }
 

--- a/cdm/core/src/test/data/thredds/catalog/BadAccess.xml
+++ b/cdm/core/src/test/data/thredds/catalog/BadAccess.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" xmlns:xlink="http://www.w3.org/1999/xlink" name="NCEI THREDDS Server : Category Listing :: marine and ocean data " version="1.0.1">
+  <service name="ALL" serviceType="Compound" base="">
+    <service name="ncdods" serviceType="OPENDAP" base="/thredds/dodsC/"/>
+    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="HTTPServer" serviceType="HTTPServer" base="/thredds/fileServer/"/>
+    <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
+    <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
+    <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
+    <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
+    <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
+  </service>
+  <service name="AGG" serviceType="Compound" base="">
+    <service name="ncdods" serviceType="OPENDAP" base="/thredds/dodsC/"/>
+    <service name="ncss" serviceType="NetcdfSubset" base="/thredds/ncss/"/>
+    <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
+    <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
+    <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
+    <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
+    <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
+  </service>
+  <dataset name="ERSST - Extended Reconstructed Sea Surface Temperatures">
+    <metadata inherited="true">
+      <serviceName>ALL</serviceName>
+      <authority>gov.noaa.ncdc</authority>
+      <dataType>GRID</dataType>
+      <documentation type="DOI">http://dx.doi.org/10.1175/2007JCLI2100.1</documentation>
+      <documentation type="summary">
+        Version 3b of the Extended Reconstruction Sea Surface Temperature (ERSST) is a Monthly Analysis on a 5 degree grid based on the International Comprehensive Ocean-Atmosphere Data Set (ICOADS) Release 2.4. ERSST v3b is generated using in situ SST data and improved statistical methods that allow stable reconstruction using sparse data throughout the 150 year record. Specifically, the reconstruction uses Empirical Orthogonal Teleconnections (EOT) modes from a one-time analysis of a fixed period of the Advanced Very High Resolution Radiometer (AVHRR) satellite data. The monthly analysis extends from January 1854 to the present, but because of sparse data in the early years, the analyzed signal is damped before 1880. After 1880, the strength of the signal is more consistent over time. ERSST is suitable for long-term Global and basin-specific SST studies as local and short-term variations have been smoothed in the analysis. Except for the removal of the AVHRR data input, ERSST v3b processing is identical to the previous Version 3.
+      </documentation>
+      <documentation xlink:href="https://www.ncdc.noaa.gov/data-access/marineocean-data/extended-reconstructed-sea-surface-temperature-ersst-v4" xlink:title="Extended Reconstructed Sea Surface Temperatures (ERSST) Website"/>
+      <documentation xlink:href="http://journals.ametsoc.org/doi/abs/10.1175/2007JCLI2100.1" xlink:title="Improvements to NOAA.s Historical Merged Land.Ocean Surface Temperature Analysis (1880.2006)"/>
+      <documentation type="comment">
+        Merged monthly global surface temperature anomaly analysis in spatial 5 degree grid boxes.
+      </documentation>
+      <documentation type="funding">
+        DOC/NOAA/NESDIS/NCDC > National Climatic Data Center, NESDIS, NOAA, U.S. Department of Commerce
+      </documentation>
+      <documentation type="processing_level">Level 4</documentation>
+      <documentation type="rights">
+        Electronic downloads of the data are free, however fees apply for data certification and distribution of the data on physical media. Fees vary based on order specifications.
+      </documentation>
+      <documentation type="abstract">
+        Observations of sea surface and land.near-surface merged temperature anomalies are used to monitor climate variations and to evaluate climate simulations; therefore, it is important to make analyses of these data as accurate as possible. Analysis uncertainty occurs because of data errors and incomplete sampling over the historical period. This manuscript documents recent improvements in NOAA.s merged global surface temperature anomaly analysis, monthly, in spatial 5° grid boxes. These improvements allow better analysis of temperatures throughout the record, with the greatest improvements in the late nineteenth century and since 1985. Improvements in the late nineteenth century are due to improved tuning of the analysis methods. Beginning in 1985, improvements are due to the inclusion of bias-adjusted satellite data. The old analysis (version 2) was documented in 2005, and this improved analysis is called version 3.
+      </documentation>
+      <contributor role="Investigator">Thomas M. Smith</contributor>
+      <contributor role="et al.">
+        Richard W. Reynolds , Thomas C. Peterson , and Jay Lawrimore
+      </contributor>
+      <creator>
+        <name vocabulary="GCMD">NOAA/NESDIS/STAR/SCSD</name>
+        <contact url="https://www.ncdc.noaa.gov/data-access/marineocean-data/extended-reconstructed-sea-surface-temperature-ersst-v4" email="Tom.Smith@noaa.gov"/>
+      </creator>
+      <keyword vocabulary="GCMD">Sea surface temperature</keyword>
+      <project>
+        Improvements to NOAA's Historical Merged Land-Ocean Surface Temperature Analysis (1880-2006)
+      </project>
+      <publisher>
+        <name vocabulary="GCMD">DOC/NOAA/NESDIS/NCDC</name>
+        <contact url="https://www.ncei.noaa.gov/" email="ncei.info@noaa.gov"/>
+      </publisher>
+      <date type="created">2007-09-24</date>
+      <date type="issued">2008-05-01</date>
+      <geospatialCoverage>
+        <name vocabulary="Thredds">global</name>
+        <name>global</name>
+      </geospatialCoverage>
+      <timeCoverage>
+        <start>1880-01-01T00:00</start>
+        <end>2006-12-31T10:29</end>
+      </timeCoverage>
+    </metadata>
+    <dataset name="Aggregations">
+      <dataset name="ERSST - Extended Reconstructed Sea Surface Temperatures version 3b - Period of Record Aggregation" ID="gov.noaa.ncdc:C00833_ersstv3Agg" urlPath="ersstv3Agg">
+        <metadata inherited="true">
+          <serviceName>AGG</serviceName>
+          <dataType>GRID</dataType>
+        </metadata>
+        <access urlPath="ersstv3Agg" serviceName="ersstAgg"/>
+      </dataset>
+    </dataset>
+    <dataset name="File Listings">
+      <catalogRef name="" ID="gov.noaa.ncdc:C00833_ersstv3b" xlink:href="/thredds/catalog/ersst/catalog.xml" xlink:title="ERSST - Extended Reconstructed Sea Surface Temperatures version 3b">
+        <metadata inherited="true">
+          <serviceName>ALL</serviceName>
+          <dataType>GRID</dataType>
+        </metadata>
+        <property name="DatasetScan" value="true"/>
+      </catalogRef>
+    </dataset>
+  </dataset>
+</catalog>

--- a/cdm/core/src/test/java/thredds/client/catalog/TestUndefinedAccess.java
+++ b/cdm/core/src/test/java/thredds/client/catalog/TestUndefinedAccess.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package thredds.client.catalog;
+
+
+import static com.google.common.truth.Truth.assertThat;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+import ucar.unidata.util.test.TestDir;
+
+public class TestUndefinedAccess {
+
+  private static final String urlString = "file:" + TestDir.cdmLocalTestDataDir + "thredds/catalog/BadAccess.xml";
+
+  @Test
+  public void testServiceGoodAccessBad() throws IOException {
+    Catalog catalog = ClientCatalogUtil.open(urlString);
+    assertThat(catalog).isNotNull();
+    Dataset ds = catalog.findDatasetByID("gov.noaa.ncdc:C00833_ersstv3Agg");
+    Service service = ds.getServiceDefault();
+    assertThat(service).isNotNull();
+    assertThat(service.getName()).isEqualTo("AGG");
+    List<Service> nestedServices = service.getNestedServices();
+    assertThat(nestedServices).isNotNull();
+    assertThat(nestedServices).isNotEmpty();
+    int expectedNumberOfServices = nestedServices.size();
+    List<Access> allAccessMethods = ds.getAccess();
+    // AGG is a Compound service with 7 services
+    assertThat(allAccessMethods).hasSize(expectedNumberOfServices);
+  }
+}


### PR DESCRIPTION
Current behavior is to throw an NPE when building a THREDDS dataset that
includes an access element with an undefined service name. Fixes
Unidata/netcdf-java#270