### PR TITLE
Fix file being unlocked in cache before resources fully released

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/util/cache/FileCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/cache/FileCache.java
@@ -466,8 +466,15 @@ public class FileCache implements FileCacheIF {
       }
       file.lastAccessed = System.currentTimeMillis();
       file.countAccessed++;
-      file.ncfile.release();
-      file.isLocked.set(false);
+
+      try {
+        file.ncfile.release();
+        file.isLocked.set(false);
+      } catch (IOException ioe) {
+        cacheLog.error("FileCache {} release failed on {} - will try to remove from cache. Failure due to:", name,
+            file.getCacheName(), ioe);
+        remove(file);
+      }
 
       if (cacheLog.isDebugEnabled())
         cacheLog.debug("FileCache " + name + " release " + ncfile.getLocation() + "; hash= " + ncfile.hashCode());

--- a/cdm/core/src/main/java/ucar/nc2/util/cache/FileCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/cache/FileCache.java
@@ -466,8 +466,8 @@ public class FileCache implements FileCacheIF {
       }
       file.lastAccessed = System.currentTimeMillis();
       file.countAccessed++;
-      file.isLocked.set(false);
       file.ncfile.release();
+      file.isLocked.set(false);
 
       if (cacheLog.isDebugEnabled())
         cacheLog.debug("FileCache " + name + " release " + ncfile.getLocation() + "; hash= " + ncfile.hashCode());


### PR DESCRIPTION
This _might_ resolve #316. The NPE occurs very inconsistently but I haven't observed it with this change.