### PR TITLE
Array as Value Object

### DIFF
--- a/cdm/core/src/main/java/ucar/ma2/Array.java
+++ b/cdm/core/src/main/java/ucar/ma2/Array.java
@@ -5,6 +5,7 @@
 package ucar.ma2;
 
 import javax.annotation.Nonnull;
+import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
@@ -48,7 +49,7 @@ import java.nio.*;
  * @see Index
  * @see IndexIterator
  */
-public abstract class Array {
+public abstract class Array implements Serializable {
 
   /**
    * Generate new Array with given dataType and shape and zeroed storage.
@@ -255,7 +256,7 @@ public abstract class Array {
 
   private static void reflectArrayCopyIn(Object jArray, Array aa, IndexIterator aaIter) {
     Class cType = jArray.getClass().getComponentType();
-    if (cType.isPrimitive()) {
+    if (!cType.isArray()) {
       aa.copyFrom1DJavaArray(aaIter, jArray); // subclass does type-specific copy
     } else {
       for (int i = 0; i < java.lang.reflect.Array.getLength(jArray); i++) // recurse

--- a/cdm/core/src/main/java/ucar/ma2/Index.java
+++ b/cdm/core/src/main/java/ucar/ma2/Index.java
@@ -4,6 +4,7 @@
  */
 package ucar.ma2;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -18,7 +19,7 @@ import java.util.List;
  * @see Array
  */
 
-public class Index implements Cloneable {
+public class Index implements Cloneable, Serializable {
   public static final Index0D scalarIndexImmutable = new Index0D(); // immutable, so can be shared
 
   /**


### PR DESCRIPTION
- Array and Index implement java.io.Serializable
- Tests for serialization of arrays of primitive and string
- Small correction to failure when Array.makeFromJavaArray with a String array

The purpose of this set of changes is to allow Array to be used as serializable Value Objects. Some systems and frameworks (e.g. Apache Storm/Kafka) require that objects be serializable. If Array has such capability it can be used directly when assembling NetCDF files in parts. There is otherwise no functional change in the classes involved, and no performance impact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/324)
<!-- Reviewable:end -->
