### PR TITLE
DiskCache2 createUniqueFile name duplication

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/util/DiskCache2.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/DiskCache2.java
@@ -31,7 +31,8 @@ import java.util.*;
  * TODO will move in ver 6
  */
 public class DiskCache2 {
-  private static org.slf4j.Logger cacheLog = org.slf4j.LoggerFactory.getLogger("cacheLogger");
+  private static final org.slf4j.Logger cacheLog = org.slf4j.LoggerFactory.getLogger("cacheLogger");
+  private static final String lockExtension = ".reserve";
   private static Timer timer;
 
   /** Be sure to call this when your application exits, otherwise your process may not exit without being killed. */
@@ -67,7 +68,7 @@ public class DiskCache2 {
    * Default DiskCache2 strategy: use $user_home/.unidata/cache/, no scouring, alwaysUseCache = false
    * Mimics default DiskCache static class
    */
-  public static DiskCache2 getDefault() {
+  static public DiskCache2 getDefault() {
     String root = System.getProperty("nj22.cache");
 
     if (root == null) {
@@ -89,7 +90,7 @@ public class DiskCache2 {
   }
 
   // NOOP
-  public static DiskCache2 getNoop() {
+  static public DiskCache2 getNoop() {
     DiskCache2 noop = new DiskCache2();
     noop.neverUseCache = true;
     return noop;
@@ -152,8 +153,13 @@ public class DiskCache2 {
 
     File dir = new File(root);
     if (!dir.mkdirs()) {
-      // ok
+      if (!dir.exists()) {
+        cacheLog.warn("Failed to create DiskCache2 root at {}. Reason unknown.", dir);
+      }
+    } else {
+      cacheLog.debug("DiskCache2 root created at {}.", dir);
     }
+
     if (!dir.exists()) {
       fail = true;
       cacheLog.error("DiskCache2 failed to create directory " + root);
@@ -305,10 +311,25 @@ public class DiskCache2 {
     if (suffix == null)
       suffix = ".tmp";
     Random random = new Random(System.currentTimeMillis());
-    File result = new File(getRootDirectory(), prefix + random.nextInt() + suffix);
-    while (result.exists())
-      result = new File(getRootDirectory(), prefix + random.nextInt() + suffix);
-    return result;
+    String lockName = prefix + random.nextInt() + suffix + lockExtension;
+    File lock = new File(getRootDirectory(), lockName);
+    while (lock.exists()) {
+      lockName = prefix + random.nextInt() + suffix + lockExtension;
+      lock = new File(getRootDirectory(), lockName);
+    }
+
+    // create a lock file to reserve the name
+    try {
+      lock.createNewFile();
+      cacheLog.debug(String.format("Reserved filename %s for future use.", lockName.replace(lockExtension, "")));
+    } catch (IOException e) {
+      // should not happen, as DiskCache2 had to make the directory before we can even get here
+      // ...but just in case...
+      cacheLog.warn(String.format("Error creating lock file: %s. May result in cache file collisions.", lock));
+    }
+    // reserved name will be the lock file name, minus the lock extension
+
+    return new File(getRootDirectory(), lock.getName().replace(lockExtension, ""));
   }
 
   /**
@@ -456,15 +477,7 @@ public class DiskCache2 {
 
     // check for empty directory
     if (!isRoot && (files.length == 0)) {
-      long duration = now - dir.lastModified();
-      duration /= 1000 * 60; // minutes
-      if (duration > persistMinutes) {
-        boolean ok = dir.delete();
-        if (!ok)
-          cacheLog.error("Unable to delete file " + dir.getAbsolutePath());
-        if (sbuff != null)
-          sbuff.format(" deleted %s %s lastModified= %s%n", ok, dir.getPath(), CalendarDate.of(dir.lastModified()));
-      }
+      purgeExpired(dir, sbuff, now);
       return;
     }
 
@@ -473,16 +486,23 @@ public class DiskCache2 {
       if (file.isDirectory()) {
         cleanCache(file, sbuff, false);
       } else {
-        long duration = now - file.lastModified();
-        duration /= 1000 * 60; // minutes
-        if (duration > persistMinutes) {
-          boolean ok = file.delete();
-          if (!ok)
-            cacheLog.error("Unable to delete file " + file.getAbsolutePath());
-          if (sbuff != null)
-            sbuff.format(" deleted %s %s lastModified= %s%n", ok, file.getPath(), CalendarDate.of(file.lastModified()));
-        }
+        purgeExpired(file, sbuff, now);
       }
+    }
+  }
+
+  private void purgeExpired(File deletable, Formatter sbuff, long now) {
+    long duration = now - deletable.lastModified();
+    duration /= 1000 * 60; // minutes
+    if (duration > persistMinutes) {
+      boolean ok = deletable.delete();
+      if (!ok) {
+        String type = deletable.isDirectory() ? "directory" : "file";
+        cacheLog.error("Unable to delete {} {}", type, deletable.getAbsolutePath());
+      }
+      if (sbuff != null)
+        sbuff.format(" deleted %s %s lastModified= %s%n", ok, deletable.getPath(),
+            CalendarDate.of(deletable.lastModified()));
     }
   }
 

--- a/cdm/core/src/test/java/ucar/nc2/util/DiskCache2Test.java
+++ b/cdm/core/src/test/java/ucar/nc2/util/DiskCache2Test.java
@@ -1,11 +1,11 @@
 package ucar.nc2.util;
 
+import static com.google.common.truth.Truth.assertThat;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,70 +15,125 @@ import java.nio.file.Paths;
  * @since 2015/06/23
  */
 public class DiskCache2Test {
-  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private static Path nearest;
+
+  private static Path dirForStaticTests;
+  private static DiskCache2 diskCache;
+
+  private static final List<File> filesToDelete = new ArrayList<>();
 
   @BeforeClass
   public static void beforeClass() throws IOException {
-    nearest = Files.createTempDirectory("nearest");
-  }
+    String cacheName = DiskCache2Test.class.getSimpleName();
+    dirForStaticTests = Files.createTempDirectory(cacheName + "-static-tests");
+    Path testCacheDir = Files.createTempDirectory(cacheName);
 
-  @AfterClass
-  public static void afterClass() throws IOException {
-    Files.delete(nearest);
+    try {
+      Files.deleteIfExists(testCacheDir);
+    } catch (IOException e) {
+      throw new IOException(
+          String.format("Unable to remove existing test cache directory %s - test setup failed.", testCacheDir), e);
+    }
+    assertThat(testCacheDir.toFile().exists());
+    // create a disk cache for the test to use
+    diskCache = new DiskCache2(testCacheDir.toString(), false, 1, 5);
   }
 
   @Test
   public void canWriteDir() {
-    File file = nearest.toFile();
+    File file = dirForStaticTests.toFile();
 
-    Assert.assertTrue(file.exists());
-    Assert.assertTrue(DiskCache2.canWrite(file));
+    assertThat(file.exists());
+    assertThat(DiskCache2.canWrite(file));
   }
-
-  // On Windows, can't make a directory read-only: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6728842
-  // So, we can't have this test:
-  // @Test public void cantWriteDir() { }
 
   @Test
   public void canWriteFile() throws IOException {
-    File file = Files.createTempFile(nearest, "temp", null).toFile();
-
-    try {
-      Assert.assertTrue(file.exists());
-      Assert.assertTrue(DiskCache2.canWrite(file));
-    } finally {
-      file.delete();
-    }
+    File file = Files.createTempFile(dirForStaticTests, "temp", null).toFile();
+    assertThat(file.exists());
+    filesToDelete.add(file);
+    assertThat(DiskCache2.canWrite(file));
   }
 
   @Test
   public void cantWriteFile() throws IOException {
-    File file = Files.createTempFile(nearest, "temp", null).toFile();
+    File file = Files.createTempFile(dirForStaticTests, "temp", null).toFile();
+    filesToDelete.add(file);
 
-    try {
-      Assert.assertTrue(file.exists());
-      Assert.assertTrue(file.setWritable(false));
-      Assert.assertFalse(DiskCache2.canWrite(file));
-    } finally {
-      file.delete();
-    }
+    Assert.assertTrue(file.exists());
+
+    // make unwritable
+    assertThat(file.setWritable(false)).isTrue();
+    assertThat(DiskCache2.canWrite(file));
+
+    // change back to writable so we can clean up
+    assertThat(file.setWritable(true)).isTrue();
+    assertThat(DiskCache2.canWrite(file));
   }
 
   @Test
   public void canWriteNonExistentFileWithExistentParent() {
-    File file = Paths.get(nearest.toString(), "non-existent-file.txt").toFile();
+    File file = Paths.get(dirForStaticTests.toString(), "non-existent-file.txt").toFile();
 
-    Assert.assertFalse(file.exists());
-    Assert.assertTrue(DiskCache2.canWrite(file));
+    assertThat(file.exists()).isFalse();
+    assertThat(DiskCache2.canWrite(file));
   }
 
   @Test
   public void cantWriteNonExistentFileWithNonExistentParent() {
-    File file = Paths.get(nearest.toString(), "A", "B", "C", "non-existent-file.txt").toFile();
+    File file = Paths.get(dirForStaticTests.toString(), "A", "B", "C", "non-existent-file.txt").toFile();
 
-    Assert.assertFalse(file.exists());
-    Assert.assertFalse(file.getParentFile().exists());
-    Assert.assertFalse(DiskCache2.canWrite(file));
+    assertThat(file.exists()).isFalse();
+    assertThat(file.getParentFile().exists()).isFalse();
+    assertThat(DiskCache2.canWrite(file)).isFalse();
+  }
+
+  @Test
+  public void checkUniqueFileNames() throws IOException {
+    final String prefix = "pre-";
+    final String suffix = "-suf";
+
+    // loop a few times to make sure it triggers.
+    for (int i = 0; i < 10; i++) {
+      File first = diskCache.createUniqueFile(prefix, suffix);
+      File second = diskCache.createUniqueFile(prefix, suffix);
+
+      // files do not exist yet
+      assertThat(first.exists()).isFalse();
+      assertThat(second.exists()).isFalse();
+
+      // make the files
+      assertThat(first.createNewFile());
+      assertThat(second.createNewFile());
+
+      // keep track of files that need to be cleaned up
+      filesToDelete.add(first);
+      filesToDelete.add(second);
+
+      // files should exist now
+      assertThat(first.exists());
+      assertThat(second.exists());
+
+      // make sure they start with prefix
+      assertThat(first.getName()).startsWith(prefix);
+      assertThat(second.getName()).startsWith(prefix);
+
+      // make sure they end with suffix
+      assertThat(first.getName()).endsWith(suffix);
+      assertThat(second.getName()).endsWith(suffix);
+
+      // make sure they are different files
+      assertThat(first.getAbsolutePath()).isNotEqualTo(second.getAbsolutePath());
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    for (File f : filesToDelete) {
+      Files.deleteIfExists(f.toPath());
+    }
+    Files.delete(dirForStaticTests);
+
+    diskCache.exit();
+    Files.deleteIfExists(Paths.get(diskCache.getRootDirectory()));
   }
 }

--- a/cdm/core/src/test/java/ucar/nc2/util/DiskCache2Test.java
+++ b/cdm/core/src/test/java/ucar/nc2/util/DiskCache2Test.java
@@ -91,6 +91,7 @@ public class DiskCache2Test {
   public void checkUniqueFileNames() throws IOException {
     final String prefix = "pre-";
     final String suffix = "-suf";
+    final String lockFileExtention = ".reserve";
 
     // loop a few times to make sure it triggers.
     for (int i = 0; i < 10; i++) {
@@ -113,6 +114,14 @@ public class DiskCache2Test {
       assertThat(first.exists());
       assertThat(second.exists());
 
+      // lock files should exist as well
+      File firstLockFile = Paths.get(first.getCanonicalFile().toString() + lockFileExtention).toFile();
+      File secondLockFile = Paths.get(second.getCanonicalFile().toString() + lockFileExtention).toFile();
+      Assert.assertTrue(firstLockFile.exists());
+      Assert.assertTrue(secondLockFile.exists());
+      filesToDelete.add(firstLockFile);
+      filesToDelete.add(secondLockFile);
+
       // make sure they start with prefix
       assertThat(first.getName()).startsWith(prefix);
       assertThat(second.getName()).startsWith(prefix);
@@ -133,7 +142,7 @@ public class DiskCache2Test {
     }
     Files.delete(dirForStaticTests);
 
-    diskCache.exit();
+    DiskCache2.exit();
     Files.deleteIfExists(Paths.get(diskCache.getRootDirectory()));
   }
 }


### PR DESCRIPTION
`DiskCache2.createUniqueFile` can result in a file name duplication. This has a tremendous impact on the TDS NCSS, in which multiple writers can, under certain circumstances, unknowingly write to the same file. This PR includes the netCDF-Java from https://github.com/Unidata/thredds/pull/1329.