### PR TITLE
More ports of unit tests to NetcdfFormatWriter.

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageAsPointFileWriter.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageAsPointFileWriter.java
@@ -12,16 +12,16 @@ import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.InvalidRangeException;
-import ucar.nc2.NetcdfFileWriter;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.ft.*;
-import ucar.nc2.ft.point.writer.CFPointWriter;
+import ucar.nc2.ft.point.writer2.CFPointWriter;
 import ucar.nc2.ft2.coverage.FeatureDatasetCoverage;
 import ucar.nc2.ft2.coverage.CoverageCollection;
 import ucar.nc2.ft2.coverage.CoverageDatasetFactory;
 import ucar.nc2.ft2.coverage.SubsetParams;
 import ucar.nc2.ft2.coverage.writer.CoverageAsPoint;
+import ucar.nc2.write.NetcdfFileFormat;
 import ucar.unidata.geoloc.LatLonPoint;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
@@ -32,12 +32,7 @@ import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 
-/**
- * Test CoverageAsPoint
- *
- * @author caron
- * @since 7/8/2015
- */
+/** Test CoverageAsPoint */
 @RunWith(Parameterized.class)
 @Category(NeedsCdmUnitTest.class)
 public class TestCoverageAsPointFileWriter {
@@ -47,20 +42,19 @@ public class TestCoverageAsPointFileWriter {
   public static List<Object[]> getTestParameters() {
     List<Object[]> result = new ArrayList<>();
     result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/03061219_ruc.nc",
-        Lists.newArrayList("P_sfc", "P_trop"), NetcdfFileWriter.Version.netcdf3});
+        Lists.newArrayList("P_sfc", "P_trop"), NetcdfFileFormat.NETCDF3});
     return result;
   }
 
-  String endpoint;
-  List<String> covList;
-  NetcdfFileWriter.Version version;
+  private String endpoint;
+  private List<String> covList;
+  private NetcdfFileFormat version;
 
-  public TestCoverageAsPointFileWriter(String endpoint, List<String> covList, NetcdfFileWriter.Version version) {
+  public TestCoverageAsPointFileWriter(String endpoint, List<String> covList, NetcdfFileFormat version) {
     this.endpoint = endpoint;
     this.covList = covList;
     this.version = version;
   }
-
 
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
@@ -90,7 +84,7 @@ public class TestCoverageAsPointFileWriter {
 
       DsgFeatureCollection fc = fdp.getPointFeatureCollectionList().get(0);
 
-      CFPointWriter.writeFeatureCollection(fdp, tempFile.getAbsolutePath(), NetcdfFileWriter.Version.netcdf3);
+      CFPointWriter.writeFeatureCollection(fdp, tempFile.getAbsolutePath(), NetcdfFileFormat.NETCDF3);
     }
 
     // open the new file as a Coverage

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageFileWriterP.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageFileWriterP.java
@@ -12,14 +12,15 @@ import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.InvalidRangeException;
-import ucar.nc2.NetcdfFileWriter;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.ft2.coverage.*;
-import ucar.nc2.ft2.coverage.writer.CFGridCoverageWriter2;
+import ucar.nc2.ft2.coverage.writer.CFGridCoverageWriter;
 import ucar.nc2.jni.netcdf.Nc4Iosp;
-import ucar.nc2.util.Optional;
+import ucar.nc2.write.NetcdfFileFormat;
+import ucar.nc2.write.NetcdfFormatWriter;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
 import java.io.File;
@@ -28,12 +29,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Test CFGridCoverageWriter
- *
- * @author caron
- * @since 7/8/2015
- */
+/** Test CFGridCoverageWriter */
 @RunWith(Parameterized.class)
 @Category(NeedsCdmUnitTest.class)
 public class TestCoverageFileWriterP {
@@ -46,36 +42,36 @@ public class TestCoverageFileWriterP {
     // SRC
     result.add(new Object[] {TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1",
         FeatureType.GRID, Lists.newArrayList("Temperature_isobaric"),
-        new SubsetParams().set(SubsetParams.timePresent, true), NetcdfFileWriter.Version.netcdf3});
+        new SubsetParams().set(SubsetParams.timePresent, true), NetcdfFileFormat.NETCDF3});
 
     result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/03061219_ruc.nc", FeatureType.GRID,
-        Lists.newArrayList("P_sfc", "P_trop"), null, NetcdfFileWriter.Version.netcdf3});
+        Lists.newArrayList("P_sfc", "P_trop"), null, NetcdfFileFormat.NETCDF3});
     result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/03061219_ruc.nc", FeatureType.GRID,
-        Lists.newArrayList("P_sfc", "P_trop"), null, NetcdfFileWriter.Version.netcdf4});
+        Lists.newArrayList("P_sfc", "P_trop"), null, NetcdfFileFormat.NETCDF4});
     result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/03061219_ruc.nc", FeatureType.GRID,
-        Lists.newArrayList("P_sfc", "P_trop", "T"), null, NetcdfFileWriter.Version.netcdf3});
+        Lists.newArrayList("P_sfc", "P_trop", "T"), null, NetcdfFileFormat.NETCDF3});
 
     result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/ECME_RIZ_201201101200_00600_GB", FeatureType.GRID,
-        Lists.newArrayList("Surface_pressure_surface"), null, NetcdfFileWriter.Version.netcdf3}); // scalar runtime, ens
-                                                                                                  // coord
+        Lists.newArrayList("Surface_pressure_surface"), null, NetcdfFileFormat.NETCDF3}); // scalar runtime, ens
+                                                                                          // coord
     result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/testCFwriter.nc", FeatureType.GRID,
-        Lists.newArrayList("PS", "Temperature"), null, NetcdfFileWriter.Version.netcdf3}); // both x,y and lat,lon
+        Lists.newArrayList("PS", "Temperature"), null, NetcdfFileFormat.NETCDF3}); // both x,y and lat,lon
 
     result.add(new Object[] {TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4", FeatureType.GRID,
-        Lists.newArrayList("Soil_temperature_depth_below_surface_layer"), null, NetcdfFileWriter.Version.netcdf4}); // TwoD
-                                                                                                                    // Best
+        Lists.newArrayList("Soil_temperature_depth_below_surface_layer"), null, NetcdfFileFormat.NETCDF4}); // TwoD
+                                                                                                            // Best
     // */
     return result;
   }
 
-  String endpoint;
-  List<String> covList;
-  NetcdfFileWriter.Version version;
-  FeatureType type;
-  SubsetParams params;
+  private String endpoint;
+  private List<String> covList;
+  private NetcdfFileFormat version;
+  private FeatureType type;
+  private SubsetParams params;
 
   public TestCoverageFileWriterP(String endpoint, FeatureType type, List<String> covList, SubsetParams params,
-      NetcdfFileWriter.Version version) {
+      NetcdfFileFormat version) {
     this.endpoint = endpoint;
     this.type = type;
     this.covList = covList;
@@ -89,7 +85,7 @@ public class TestCoverageFileWriterP {
   @Test
   public void writeTestFile() throws IOException, InvalidRangeException {
     // skip test requiring netcdf4 if not present.
-    if (version.useJniIosp() && !Nc4Iosp.isClibraryPresent()) {
+    if (version.isNetdf4format() && !Nc4Iosp.isClibraryPresent()) {
       return;
     }
     System.out.printf("Test Dataset %s type %s%n", endpoint, type);
@@ -104,12 +100,11 @@ public class TestCoverageFileWriterP {
       for (String covName : covList)
         Assert.assertNotNull(covName, gcs.findCoverage(covName));
 
-      try (NetcdfFileWriter writer = NetcdfFileWriter.createNew(version, tempFile.getPath(), null)) {
-
-        Optional<Long> estimatedSizeo = CFGridCoverageWriter2.write(gcs, covList, params, false, writer);
-        if (!estimatedSizeo.isPresent())
-          throw new InvalidRangeException("Request contains no data: " + estimatedSizeo.getErrorMessage());
-      }
+      NetcdfFormatWriter.Builder writer =
+          NetcdfFormatWriter.builder().setNewFile(true).setLocation(tempFile.getPath()).setFormat(version);
+      NetcdfFormatWriter.Result result = CFGridCoverageWriter.write(gcs, covList, params, false, writer, -1);
+      if (!result.wasWritten())
+        throw new InvalidRangeException("Request failed: " + result.getErrorMessage());
     }
 
     // open the new file as a Coverage. Since its a netcdf file, it will open through the DtAdapter (!)
@@ -133,7 +128,7 @@ public class TestCoverageFileWriterP {
     }
 
     // open the file as old style Grid
-    try (NetcdfDataset nf = NetcdfDataset.openDataset(tempFile.getPath())) {
+    try (NetcdfDataset nf = NetcdfDatasets.openDataset(tempFile.getPath())) {
       ucar.nc2.dt.grid.GridDataset dtDataset = new ucar.nc2.dt.grid.GridDataset(nf);
       for (String covName : covList)
         Assert.assertNotNull(covName, dtDataset.findGridByName(covName));

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestCFPointDatasets.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestCFPointDatasets.java
@@ -11,11 +11,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.nc2.FileWriter2;
 import ucar.nc2.NetcdfFile;
-import ucar.nc2.NetcdfFileWriter;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.write.NetcdfCopier;
+import ucar.nc2.write.NetcdfFormatWriter;
 import ucar.unidata.util.test.TestDir;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -153,10 +153,10 @@ public class TestCFPointDatasets {
     return result;
   }
 
-  String location;
-  FeatureType ftype;
-  int countExpected;
-  boolean show = false;
+  private String location;
+  private FeatureType ftype;
+  private int countExpected;
+  private boolean show = false;
 
   public TestCFPointDatasets(String location, FeatureType ftype, int countExpected) {
     this.location = location;
@@ -171,7 +171,7 @@ public class TestCFPointDatasets {
 
   // Convert all NCML files in CFpointObs_topdir to NetCDF-3 files.
   public static void main(String[] args) throws IOException {
-    File examplesDir = new File(CFpointObs_topdir);
+    File examplesDir = new File("cdm/core/src/test/data/point/");
     File convertedDir = new File(examplesDir, "converted");
     convertedDir.mkdirs();
 
@@ -181,13 +181,11 @@ public class TestCFPointDatasets {
       String outputFilePath = new File(convertedDir, outputFileName).getCanonicalPath();
       System.out.printf("Writing %s to %s.%n", inputFilePath, outputFilePath);
 
-      try (NetcdfFile ncfileIn = NetcdfDataset.openFile(inputFilePath, null)) {
-        NetcdfFileWriter.Version version = NetcdfFileWriter.Version.netcdf3;
-        FileWriter2 writer = new FileWriter2(ncfileIn, outputFilePath, version, null);
-
-        NetcdfFile ncfileOut = writer.write(null);
-        if (ncfileOut != null) {
-          ncfileOut.close();
+      try (NetcdfFile ncfileIn = NetcdfDatasets.openFile(inputFilePath, null)) {
+        NetcdfFormatWriter.Builder builder = NetcdfFormatWriter.createNewNetcdf3(outputFilePath);
+        NetcdfCopier copier = NetcdfCopier.create(ncfileIn, builder);
+        try (NetcdfFile ncout2 = copier.write(null)) {
+          // empty
         }
       }
     }

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlReaderProblems.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlReaderProblems.java
@@ -22,6 +22,7 @@ import ucar.nc2.ft.point.TestCFPointDatasets;
 import ucar.nc2.internal.ncml.NcMLReaderNew;
 import ucar.nc2.util.CompareNetcdf2;
 import ucar.nc2.util.CompareNetcdf2.ObjFilter;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 /** Compare old and new NcmlReaders on specific problem datasets. */
@@ -32,8 +33,12 @@ public class TestNcmlReaderProblems {
   @Test
   public void problem() throws IOException {
     // This has self contained data
-    compare("file:" + TestCFPointDatasets.CFpointObs_topdir + "stationData2Levels.ncml");
-    compareDS("file:" + TestCFPointDatasets.CFpointObs_topdir + "stationData2Levels.ncml");
+    // compare("file:" + TestCFPointDatasets.CFpointObs_topdir + "stationData2Levels.ncml");
+    // compareDS("file:" + TestCFPointDatasets.CFpointObs_topdir + "stationData2Levels.ncml");
+
+    // compare("file:" + TestDir.cdmLocalFromTestDataDir + "cfDocDsgExamples/H.2.1.1.ncml");
+    compare("file:" + TestDir.cdmLocalFromTestDataDir + "point//stationData2Levels.ncml");
+    // compareVarData("file:" + TestDir.cdmLocalFromTestDataDir + "point//stationData2Levels.ncml", "trajectory");
   }
 
   private void compare(String ncmlLocation) throws IOException {
@@ -47,6 +52,22 @@ public class TestNcmlReaderProblems {
         CompareNetcdf2 compare = new CompareNetcdf2(f, false, false, true);
         boolean ok = compare.compare(org, withBuilder, new CoordsObjFilter());
         System.out.printf("%s %s%n", ok ? "OK" : "NOT OK", f);
+        assertThat(ok).isTrue();
+      }
+    }
+  }
+
+  private void compareVarData(String ncmlLocation, String varName) throws IOException {
+    System.out.printf("Compare NcMLReader.readNcML %s%n", ncmlLocation);
+    logger.info("TestNcmlReaders on {}%n", ncmlLocation);
+    try (NetcdfDataset org = NcMLReader.readNcML(ncmlLocation, null)) {
+      Variable v = org.findVariable(varName);
+      assert v != null;
+      try (NetcdfDataset withBuilder = NcMLReaderNew.readNcML(ncmlLocation, null, null).build()) {
+        Variable vb = withBuilder.findVariable(varName);
+        assert vb != null;
+        boolean ok = CompareNetcdf2.compareData(varName, v.read(), vb.read());
+        System.out.printf("%s%n", ok ? "OK" : "NOT OK");
         assertThat(ok).isTrue();
       }
     }

--- a/cdm-test/src/test/java/ucar/nc2/write/TestNetcdfCopierCompare.java
+++ b/cdm-test/src/test/java/ucar/nc2/write/TestNetcdfCopierCompare.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.nc2.write;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Formatter;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ucar.nc2.FileWriter2;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFileWriter;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.util.CompareNetcdf2;
+import ucar.unidata.util.test.TestDir;
+
+/** Compare NetcdfCopier with old NetcdfFileWriter */
+public class TestNetcdfCopierCompare {
+
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private String filename = "file:" + TestDir.cdmLocalFromTestDataDir + "point/stationData2Levels.ncml";
+
+  @Test
+  public void doOne() throws IOException {
+    File fin = new File(filename);
+    File foutOrg = tempFolder.newFile();
+    File foutNew = tempFolder.newFile();
+
+    try (NetcdfFile ncfileIn = ucar.nc2.dataset.NetcdfDatasets.openFile(fin.getPath(), null)) {
+      FileWriter2 fileWriter = new FileWriter2(ncfileIn, foutOrg.getPath(), NetcdfFileWriter.Version.netcdf3, null);
+      try (NetcdfFile ncfileOut = fileWriter.write()) {
+      }
+
+      NetcdfFormatWriter.Builder builder = NetcdfFormatWriter.createNewNetcdf3(foutNew.getPath());
+      NetcdfCopier copier = NetcdfCopier.create(ncfileIn, builder);
+      try (NetcdfFile ncfileOut = copier.write(null)) {
+      }
+    }
+
+    try (NetcdfFile org = NetcdfFiles.open(foutOrg.getPath());
+        NetcdfFile withBuilder = NetcdfFiles.open(foutNew.getPath())) {
+      Formatter f = new Formatter();
+      CompareNetcdf2 compare = new CompareNetcdf2(f, false, false, true);
+      boolean ok = compare.compare(org, withBuilder);
+      System.out.printf("Compare old and new copy of %s is %s%n", filename, ok);
+      if (!ok) {
+        System.out.printf("%s%n", f);
+        assert false;
+      }
+    }
+  }
+
+}

--- a/cdm-test/src/test/java/ucar/nc2/write/TestNetcdfFormatWriter.java
+++ b/cdm-test/src/test/java/ucar/nc2/write/TestNetcdfFormatWriter.java
@@ -1,6 +1,10 @@
-package ucar.nc2;
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
 
-import static junit.framework.TestCase.fail;
+package ucar.nc2.write;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,19 +14,18 @@ import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
 import ucar.nc2.constants.CDM;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import ucar.nc2.util.CompareNetcdf2;
-import ucar.nc2.write.NetcdfFormatWriter;
 
-/**
- * Misc netcdf3 NetcdfFileWriter tests
- *
- * @author caron
- * @since 4/26/12
- */
-public class TestWriteMisc {
+/** NetcdfFormatWriter tests */
+public class TestNetcdfFormatWriter {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   /*

--- a/cdm-test/src/test/java/ucar/nc2/write/TestRedefine3.java
+++ b/cdm-test/src/test/java/ucar/nc2/write/TestRedefine3.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
-package ucar.nc2;
+package ucar.nc2.write;
 
 import static org.junit.Assert.fail;
 import java.io.IOException;
@@ -15,8 +15,12 @@ import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
-import ucar.nc2.write.NetcdfFormatWriter;
+import ucar.nc2.Attribute;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
 
+/** Test that redefine no longer supported by NetcdfFormatWriter. */
 public class TestRedefine3 {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/cdm/core/src/main/java/ucar/nc2/FileWriter2.java
+++ b/cdm/core/src/main/java/ucar/nc2/FileWriter2.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * <p/>
  * Use NetcdfFileWriter object for a lower level API.
  *
- * @deprecated use ucar.nc2.write.NetcdfCopier (library) or ucar.nc2.write.Nccopy (command line)
+ * @deprecated use {@link ucar.nc2.write.NetcdfCopier} (library) or {@link ucar.nc2.write.Nccopy} (command line)
  */
 @Deprecated
 public class FileWriter2 {

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
@@ -35,10 +35,10 @@ import java.util.*;
  * <ul>
  * <li>netcdf3: use indexed ragged array representation</li>
  * </ul>
- *
- * @author caron
- * @since 4/11/12
+ * 
+ * @deprecated use writer2
  */
+@Deprecated
 public abstract class CFPointWriter implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(CFPointWriter.class);
 
@@ -68,8 +68,6 @@ public abstract class CFPointWriter implements Closeable {
   public static final String trajIdName = "trajectoryId";
 
   public static final int idMissingValue = -9999;
-
-
   private static boolean debug;
 
   public static int writeFeatureCollection(FeatureDatasetPoint fdpoint, String fileOut,

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/package.html
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/package.html
@@ -4,6 +4,6 @@
    <title>package ucar.nc2.ft.point.writer</title>
 </head>
 <body bgcolor="#FFFFFF">
-<h3>Write Point Feature Types to netcdf/CF-1.6 DSG files</h3>
+<h3>DEPRECATED DO NOT USE use ucar.nc2.ft.point.writer2 package</h3>
 </body>
 </html>

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CFGridCoverageWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CFGridCoverageWriter.java
@@ -104,7 +104,7 @@ public class CFGridCoverageWriter {
 
     ////////////////////////////////////////////////////////////////////
 
-    Group.Builder rootGroup = Group.builder();
+    Group.Builder rootGroup = writer.getRootGroup();
     addGlobalAttributes(subsetDataset, rootGroup);
     addDimensions(subsetDataset, rootGroup);
     addCoordinateAxes(subsetDataset, rootGroup);
@@ -388,7 +388,7 @@ public class CFGridCoverageWriter {
           System.out.printf("CFGridCoverageWriter write axis %s%n", v.getNameAndDimensions());
         writer.write(v, axis.getCoordsAsArray());
       } else {
-        logger.error("CFGridCoverageWriter No variable for {}%n", axis.getName());
+        logger.error("CFGridCoverageWriter No variable for {}", axis.getName());
       }
 
       if (axis.isInterval()) {

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
@@ -36,7 +36,6 @@ import ucar.nc2.ft2.coverage.CoverageCoordSys;
 import ucar.nc2.ft2.coverage.GeoReferencedArray;
 import ucar.nc2.ft2.coverage.SubsetParams;
 import ucar.nc2.time.CalendarDateUnit;
-import ucar.nc2.util.Misc;
 import ucar.unidata.geoloc.LatLonPoint;
 import ucar.unidata.geoloc.LatLonPoints;
 import ucar.unidata.util.StringUtil2;
@@ -60,7 +59,7 @@ public class CoverageAsPoint {
     Coverage cov;
     GeoReferencedArray array;
 
-    public VarData(Coverage cov) throws IOException {
+    VarData(Coverage cov) throws IOException {
       this.cov = cov;
       try {
         this.array = cov.readData(subset);
@@ -102,7 +101,7 @@ public class CoverageAsPoint {
   }
 
   private class CoverageAsFeatureDatasetPoint extends ucar.nc2.ft.point.PointDatasetImpl {
-    protected CoverageAsFeatureDatasetPoint(FeatureType featureType) {
+    CoverageAsFeatureDatasetPoint(FeatureType featureType) {
       super(featureType);
       CoverageAsStationFeatureCollection fc =
           new CoverageAsStationFeatureCollection(gcd.getName() + " AsStationFeatureCollection", dateUnit, null);
@@ -121,7 +120,7 @@ public class CoverageAsPoint {
 
   private class CoverageAsStationFeatureCollection extends StationTimeSeriesCollectionImpl {
 
-    public CoverageAsStationFeatureCollection(String name, CalendarDateUnit dateUnit, String altUnits) {
+    CoverageAsStationFeatureCollection(String name, CalendarDateUnit dateUnit, String altUnits) {
       super(name, dateUnit, altUnits);
     }
 
@@ -139,7 +138,7 @@ public class CoverageAsPoint {
 
   private class MyStationFeature extends StationTimeSeriesFeatureImpl {
 
-    public MyStationFeature(String name, String desc, String wmoId, double lat, double lon, double alt,
+    MyStationFeature(String name, String desc, String wmoId, double lat, double lon, double alt,
         CalendarDateUnit timeUnit, String altUnits, int npts) {
       // String name, String desc, String wmoId, double lat, double lon, double alt, DateUnit timeUnit, String altUnits,
       // int npts
@@ -162,7 +161,7 @@ public class CoverageAsPoint {
       GeoReferencedArray geoA;
       IndexIterator dataIter;
 
-      public VarIter(Coverage cov, GeoReferencedArray array, IndexIterator dataIter) {
+      VarIter(Coverage cov, GeoReferencedArray array, IndexIterator dataIter) {
         this.cov = cov;
         this.geoA = array;
         this.dataIter = dataIter;
@@ -224,7 +223,7 @@ public class CoverageAsPoint {
       StationFeature stn;
       StructureData sdata;
 
-      public MyPointFeature(StationFeature stn, double obsTime, double nomTime, CalendarDateUnit timeUnit,
+      MyPointFeature(StationFeature stn, double obsTime, double nomTime, CalendarDateUnit timeUnit,
           StructureData sdata) {
         super(MyStationFeature.this, stn, obsTime, nomTime, timeUnit);
         this.stn = stn;

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcMLReaderNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcMLReaderNew.java
@@ -29,6 +29,7 @@ import ucar.ma2.DataType;
 import ucar.nc2.Attribute;
 import ucar.nc2.AttributeContainer;
 import ucar.nc2.Dimension;
+import ucar.nc2.Dimensions;
 import ucar.nc2.EnumTypedef;
 import ucar.nc2.Group;
 import ucar.nc2.NetcdfFile;
@@ -1297,13 +1298,15 @@ public class NcMLReaderNew {
         for (int i = 0; i < nhave; i++) {
           data[i] = values.charAt(i);
         }
-        Array dataArray = Array.factory(DataType.CHAR, new int[] {nhave}, data);
+        Array dataArray = Array.factory(DataType.CHAR, Dimensions.makeShape(v.getDimensions()), data);
         v.setCachedData(dataArray, true);
 
       } else {
         List<String> valList = getTokens(values, sep);
-        Array data = Array.makeArray(dtype, valList); // TODO assumes 1D, can reshape later
-
+        Array data = Array.makeArray(dtype, valList);
+        if (v.getDimensions().size() != 1) { // dont have to reshape for rank 1
+          data = data.reshape(Dimensions.makeShape(v.getDimensions()));
+        }
         v.setCachedData(data, true);
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/util/CompareNetcdf2.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/CompareNetcdf2.java
@@ -7,6 +7,7 @@
 
 package ucar.nc2.util;
 
+import java.util.Arrays;
 import javax.annotation.Nullable;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.dataset.*;
@@ -686,8 +687,15 @@ public class CompareNetcdf2 {
       ok = false;
     }
 
-    if (!ok)
+    if (!Misc.compare(data1.getShape(), data2.getShape(), f)) {
+      f.format(" DIFF %s: data shape %s !== %s%n", name, Arrays.toString(data1.getShape()),
+          Arrays.toString(data2.getShape()));
+      ok = false;
+    }
+
+    if (!ok) {
       return false;
+    }
 
     DataType dt = data1.getDataType();
 

--- a/cdm/core/src/main/java/ucar/nc2/util/Misc.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/Misc.java
@@ -205,9 +205,11 @@ public class Misc {
     return ndiff == 0 && (raw1.length == raw2.length);
   }
 
-  public static void compare(float[] raw1, float[] raw2, Formatter f) {
+  public static boolean compare(float[] raw1, float[] raw2, Formatter f) {
+    boolean ok = true;
     if (raw1.length != raw2.length) {
       f.format("compareFloat: length 1= %3d != length 2=%3d%n", raw1.length, raw2.length);
+      ok = false;
     }
     int len = Math.min(raw1.length, raw2.length);
 
@@ -216,9 +218,31 @@ public class Misc {
       if (!Misc.nearlyEquals(raw1[i], raw2[i]) && !Double.isNaN(raw1[i]) && !Double.isNaN(raw2[i])) {
         f.format(" %5d : %3f != %3f%n", i, raw1[i], raw2[i]);
         ndiff++;
+        ok = false;
       }
     }
     f.format("tested %d floats diff = %d %n", len, ndiff);
+    return ok;
+  }
+
+  public static boolean compare(int[] raw1, int[] raw2, Formatter f) {
+    boolean ok = true;
+    if (raw1.length != raw2.length) {
+      f.format("compareFloat: length 1= %3d != length 2=%3d%n", raw1.length, raw2.length);
+      ok = false;
+    }
+    int len = Math.min(raw1.length, raw2.length);
+
+    int ndiff = 0;
+    for (int i = 0; i < len; i++) {
+      if (raw1[i] != raw2[i]) {
+        f.format(" %5d : %3d != %3d%n", i, raw1[i], raw2[i]);
+        ndiff++;
+        ok = false;
+      }
+    }
+    f.format("tested %d floats diff = %d %n", len, ndiff);
+    return ok;
   }
 
   /** @deprecated use Integer.compare(x, y) */

--- a/cdm/core/src/main/java/ucar/nc2/write/NetcdfCopier.java
+++ b/cdm/core/src/main/java/ucar/nc2/write/NetcdfCopier.java
@@ -237,9 +237,10 @@ public class NetcdfCopier {
 
         // add last dimension
         String strlenDimName = oldVar.getShortName() + "_strlen";
-        Dimension anon = Dimension.builder(strlenDimName, max_len).setIsShared(false).build();
+        parent.addDimension(Dimension.builder(strlenDimName, max_len).setIsShared(false).build());
 
         newType = DataType.CHAR;
+        vb.setDataType(DataType.CHAR);
         dimNames += " " + strlenDimName;
       }
     }
@@ -315,8 +316,7 @@ public class NetcdfCopier {
       if (!extended && oldVar.getDataType() == DataType.STRING) {
         data = convertDataToChar(newVar, data);
       }
-      if (data.getSize() > 0) // zero when record dimension = 0
-      {
+      if (data.getSize() > 0) { // zero when record dimension = 0
         ncwriter.write(newVar, data);
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
@@ -88,7 +88,7 @@ public class NetcdfFormatWriter implements Closeable {
   public static class Builder {
     private String location;
     private NetcdfFileFormat format = NetcdfFileFormat.NETCDF3;
-    private boolean isNewFile;
+    private boolean isNewFile = true;
     private boolean fill = true;
     private int extraHeaderBytes;
     private long preallocateSize;
@@ -123,7 +123,7 @@ public class NetcdfFormatWriter implements Closeable {
       return this.format;
     }
 
-    /** True if its a new file, false if its an existing file. Default false. */
+    /** True if its a new file, false if its an existing file. Default true. */
     public Builder setNewFile(boolean newFile) {
       isNewFile = newFile;
       return this;


### PR DESCRIPTION
Fixed bugs in NcmlReaderNew, CFGridCoverageWriter, NetcdfCopier.
Changed default on NetcdfFormatWriter.Builder.isNewFile to true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/328)
<!-- Reviewable:end -->
