### PR TITLE
Fix geostationary scaling

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -66,29 +66,45 @@ import ucar.unidata.geoloc.ProjectionImpl;
  * @since 12/5/13
  */
 public class Geostationary extends AbstractTransformBuilder implements HorizTransformBuilderIF {
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Geostationary.class);
 
   private static double defaultScaleFactor = -1.0;
 
+  /**
+   *
+   */
   public String getTransformName() {
     return CF.GEOSTATIONARY;
   }
 
+  /**
+   *
+   */
   public TransformType getTransformType() {
     return TransformType.Projection;
   }
 
+  /**
+   *
+   */
   private double getScaleFactor(String geoCoordinateUnits) {
     // default value of -1.0 interpreted as no scaling in the class
     // ucar.unidata.geoloc.projection.sat.Geostationary
     double scaleFactor = defaultScaleFactor;
     String neededMapCoordinateUnit = "radian";
+
     if (SimpleUnit.isCompatible(geoCoordinateUnits, neededMapCoordinateUnit)) {
       scaleFactor = SimpleUnit.getConversionFactor(geoCoordinateUnits, neededMapCoordinateUnit);
     }
 
+    logger.debug("geoCoordinateUnits {}, scaleFactor {}", geoCoordinateUnits, scaleFactor);
+
     return scaleFactor;
   }
 
+  /**
+   *
+   */
   public ProjectionCT makeCoordinateTransform(AttributeContainer ctv, String geoCoordinateUnits) {
     readStandardParams(ctv, geoCoordinateUnits);
 
@@ -131,21 +147,23 @@ public class Geostationary extends AbstractTransformBuilder implements HorizTran
     String sweep_angle = ctv.findAttributeString(CF.SWEEP_ANGLE_AXIS, null);
     String fixed_angle = ctv.findAttributeString(CF.FIXED_ANGLE_AXIS, null);
 
-    if (sweep_angle == null && fixed_angle == null)
+    if (sweep_angle == null && fixed_angle == null) {
       throw new IllegalArgumentException("Must specify " + CF.SWEEP_ANGLE_AXIS + " or " + CF.FIXED_ANGLE_AXIS);
+    }
     boolean isSweepX;
-    if (sweep_angle != null)
+    if (sweep_angle != null) {
       isSweepX = sweep_angle.equals("x");
-    else
+    } else {
       isSweepX = fixed_angle.equals("y");
+    }
 
     // scales less than zero indicate no scaling of axis (i.e. map coords have units of radians)
-    double geoCoordinateScaeFactor;
+    double geoCoordinateScaleFactor;
 
-    geoCoordinateScaeFactor = getScaleFactor(geoCoordinateUnits);
+    geoCoordinateScaleFactor = getScaleFactor(geoCoordinateUnits);
 
     ProjectionImpl proj = new ucar.unidata.geoloc.projection.sat.Geostationary(subLonDegrees, perspective_point_height,
-        semi_minor_axis, semi_major_axis, inv_flattening, isSweepX, geoCoordinateScaeFactor);
+        semi_minor_axis, semi_major_axis, inv_flattening, isSweepX, geoCoordinateScaleFactor);
 
     return new ProjectionCT(ctv.getName(), "FGDC", proj);
   }

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
@@ -70,23 +70,14 @@ public class Geostationary extends AbstractTransformBuilder implements HorizTran
 
   private static double defaultScaleFactor = -1.0;
 
-  /**
-   *
-   */
   public String getTransformName() {
     return CF.GEOSTATIONARY;
   }
 
-  /**
-   *
-   */
   public TransformType getTransformType() {
     return TransformType.Projection;
   }
 
-  /**
-   *
-   */
   private double getScaleFactor(String geoCoordinateUnits) {
     // default value of -1.0 interpreted as no scaling in the class
     // ucar.unidata.geoloc.projection.sat.Geostationary
@@ -102,9 +93,6 @@ public class Geostationary extends AbstractTransformBuilder implements HorizTran
     return scaleFactor;
   }
 
-  /**
-   *
-   */
   public ProjectionCT makeCoordinateTransform(AttributeContainer ctv, String geoCoordinateUnits) {
     readStandardParams(ctv, geoCoordinateUnits);
 

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -228,10 +228,9 @@ public class Geostationary extends ProjectionImpl {
     double x = satCoords[0];
     double y = satCoords[1];
 
-    if (isGeoCoordinateScaled())
-    {
-        x /= geoCoordinateScaleFactor;
-        y /= geoCoordinateScaleFactor;
+    if (isGeoCoordinateScaled()) {
+      x /= geoCoordinateScaleFactor;
+      y /= geoCoordinateScaleFactor;
     }
 
     destPoint.setLocation(x, y);
@@ -246,10 +245,9 @@ public class Geostationary extends ProjectionImpl {
     double x = ppt.getX();
     double y = ppt.getY();
 
-    if (isGeoCoordinateScaled())
-    {
-        x *= geoCoordinateScaleFactor;
-        y *= geoCoordinateScaleFactor;
+    if (isGeoCoordinateScaled()) {
+      x *= geoCoordinateScaleFactor;
+      y *= geoCoordinateScaleFactor;
     }
 
     final double[] lonlat = navigation.satToEarth(x, y);
@@ -271,10 +269,9 @@ public class Geostationary extends ProjectionImpl {
     double x1 = pt1.getX();
     double x2 = pt2.getX();
 
-    if (isGeoCoordinateScaled())
-    {
-        x1 *= geoCoordinateScaleFactor;
-        x2 *= geoCoordinateScaleFactor;
+    if (isGeoCoordinateScaled()) {
+      x1 *= geoCoordinateScaleFactor;
+      x2 *= geoCoordinateScaleFactor;
     }
 
     // opposite signed X values, larger then 100 km

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -78,9 +78,6 @@ public class Geostationary extends ProjectionImpl {
 
   private GEOSTransform navigation;
 
-  /**
-   *
-   */
   public Geostationary(double subLonDegrees, double perspective_point_height, double semi_minor_axis,
       double semi_major_axis, double inv_flattening, boolean isSweepX) {
 
@@ -88,9 +85,6 @@ public class Geostationary extends ProjectionImpl {
     this(subLonDegrees, perspective_point_height, semi_minor_axis, semi_major_axis, inv_flattening, isSweepX, -1.0);
   }
 
-  /**
-   *
-   */
   public Geostationary(double subLonDegrees, double perspective_point_height, double semi_minor_axis,
       double semi_major_axis, double inv_flattening, boolean isSweepX, double geoCoordinateScaleFactor) {
     super(NAME, false);
@@ -117,27 +111,18 @@ public class Geostationary extends ProjectionImpl {
     logger.debug("scaleGeoCoordinate {}, geoCoordinateScaleFactor {}", scaleGeoCoordinate, geoCoordinateScaleFactor);
   }
 
-  /**
-   *
-   */
   public Geostationary() {
     super(NAME, false);
     navigation = new GEOSTransform();
     makePP();
   }
 
-  /**
-   *
-   */
   public Geostationary(double subLonDegrees) {
     super(NAME, false);
     navigation = new GEOSTransform(subLonDegrees, GEOSTransform.GOES);
     makePP();
   }
 
-  /**
-   *
-   */
   public Geostationary(double subLonDegrees, boolean isSweepX) {
     super(NAME, false);
 
@@ -152,9 +137,6 @@ public class Geostationary extends ProjectionImpl {
     makePP();
   }
 
-  /**
-   *
-   */
   public Geostationary(double subLonDegrees, String sweepAngleAxis, double geoCoordinateScaleFactor) {
     super(NAME, false);
 
@@ -172,9 +154,6 @@ public class Geostationary extends ProjectionImpl {
     makePP();
   }
 
-  /**
-   *
-   */
   private void makePP() {
     addParameter(CF.GRID_MAPPING_NAME, NAME);
     addParameter(CF.LONGITUDE_OF_PROJECTION_ORIGIN, navigation.sub_lon_degrees);
@@ -185,9 +164,6 @@ public class Geostationary extends ProjectionImpl {
     addParameter(CF.SEMI_MINOR_AXIS, navigation.r_pol * 1000.0);
   }
 
-  /**
-   *
-   */
   private boolean isGeoCoordinateScaled() {
     return scaleGeoCoordinate && geoCoordinateScaleFactor > Double.MIN_VALUE;
   }
@@ -206,19 +182,20 @@ public class Geostationary extends ProjectionImpl {
     return new Geostationary(navigation.sub_lon_degrees, sweepAxisAngle, geoCoordinateScaleFactor);
   }
 
-  /**
-   *
-   */
   @Override
   public String paramsToString() {
     return "";
   }
 
   /**
-   * Return a lat/lon point in projection coordinates (result in radians)
+   * Returns an x/y grid point in projection coordinate matching a lat/lon point.
+   * The units of the returned result will be in radians unless the {@code Geostationary} object
+   * was created using one of the constructors that takes a {@code geoCoordinateScaleFactor}
+   * parameter. If that parameter is provided, then the units of x and y are in radians
+   * divided by the scaling factor.
    *
    * @param latlon convert from these lat, lon coordinates
-   * @param destPoint the object to write to (values in radians)
+   * @param destPoint the object to write to
    * @return destPoint
    */
   @Override
@@ -237,9 +214,6 @@ public class Geostationary extends ProjectionImpl {
     return destPoint;
   }
 
-  /**
-   *
-   */
   @Override
   public LatLonPoint projToLatLon(ProjectionPoint ppt, LatLonPointImpl destPoint) {
     double x = ppt.getX();
@@ -256,9 +230,6 @@ public class Geostationary extends ProjectionImpl {
     return destPoint;
   }
 
-  /**
-   *
-   */
   @Override
   public boolean crossSeam(ProjectionPoint pt1, ProjectionPoint pt2) {
     // either point is infinite
@@ -279,9 +250,6 @@ public class Geostationary extends ProjectionImpl {
     return (x1 * x2 < 0) && (Math.abs(x1 - x2) > 100);
   }
 
-  /**
-   *
-   */
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -300,9 +268,6 @@ public class Geostationary extends ProjectionImpl {
     return geoCoordinateScaleFactor == that.geoCoordinateScaleFactor;
   }
 
-  /**
-   *
-   */
   @Override
   public int hashCode() {
     return navigation.hashCode();

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -70,14 +70,17 @@ import ucar.unidata.geoloc.ProjectionRect;
 
 public class Geostationary extends ProjectionImpl {
 
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Geostationary.class);
+  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Geostationary.class);
 
   private static final String NAME = CF.GEOSTATIONARY;
   private boolean scaleGeoCoordinate;
   private double geoCoordinateScaleFactor = Double.MIN_VALUE;
 
-  GEOSTransform navigation;
+  private GEOSTransform navigation;
 
+  /**
+   *
+   */
   public Geostationary(double subLonDegrees, double perspective_point_height, double semi_minor_axis,
       double semi_major_axis, double inv_flattening, boolean isSweepX) {
 
@@ -85,6 +88,9 @@ public class Geostationary extends ProjectionImpl {
     this(subLonDegrees, perspective_point_height, semi_minor_axis, semi_major_axis, inv_flattening, isSweepX, -1.0);
   }
 
+  /**
+   *
+   */
   public Geostationary(double subLonDegrees, double perspective_point_height, double semi_minor_axis,
       double semi_major_axis, double inv_flattening, boolean isSweepX, double geoCoordinateScaleFactor) {
     super(NAME, false);
@@ -107,20 +113,31 @@ public class Geostationary extends ProjectionImpl {
       scaleGeoCoordinate = true;
       this.geoCoordinateScaleFactor = geoCoordinateScaleFactor;
     }
+
+    logger.debug("scaleGeoCoordinate {}, geoCoordinateScaleFactor {}", scaleGeoCoordinate, geoCoordinateScaleFactor);
   }
 
+  /**
+   *
+   */
   public Geostationary() {
     super(NAME, false);
     navigation = new GEOSTransform();
     makePP();
   }
 
+  /**
+   *
+   */
   public Geostationary(double subLonDegrees) {
     super(NAME, false);
     navigation = new GEOSTransform(subLonDegrees, GEOSTransform.GOES);
     makePP();
   }
 
+  /**
+   *
+   */
   public Geostationary(double subLonDegrees, boolean isSweepX) {
     super(NAME, false);
 
@@ -135,6 +152,9 @@ public class Geostationary extends ProjectionImpl {
     makePP();
   }
 
+  /**
+   *
+   */
   public Geostationary(double subLonDegrees, String sweepAngleAxis, double geoCoordinateScaleFactor) {
     super(NAME, false);
 
@@ -147,9 +167,14 @@ public class Geostationary extends ProjectionImpl {
       this.geoCoordinateScaleFactor = geoCoordinateScaleFactor;
     }
 
+    logger.debug("scaleGeoCoordinate {}, geoCoordinateScaleFactor {}", scaleGeoCoordinate, geoCoordinateScaleFactor);
+
     makePP();
   }
 
+  /**
+   *
+   */
   private void makePP() {
     addParameter(CF.GRID_MAPPING_NAME, NAME);
     addParameter(CF.LONGITUDE_OF_PROJECTION_ORIGIN, navigation.sub_lon_degrees);
@@ -160,16 +185,11 @@ public class Geostationary extends ProjectionImpl {
     addParameter(CF.SEMI_MINOR_AXIS, navigation.r_pol * 1000.0);
   }
 
+  /**
+   *
+   */
   private boolean isGeoCoordinateScaled() {
     return scaleGeoCoordinate && geoCoordinateScaleFactor > Double.MIN_VALUE;
-  }
-
-  private double getX(ProjectionPoint ppt) {
-    return isGeoCoordinateScaled() ? ppt.getX() * geoCoordinateScaleFactor : ppt.getX();
-  }
-
-  private double getY(ProjectionPoint ppt) {
-    return isGeoCoordinateScaled() ? ppt.getY() * geoCoordinateScaleFactor : ppt.getY();
   }
 
   /**
@@ -186,6 +206,9 @@ public class Geostationary extends ProjectionImpl {
     return new Geostationary(navigation.sub_lon_degrees, sweepAxisAngle, geoCoordinateScaleFactor);
   }
 
+  /**
+   *
+   */
   @Override
   public String paramsToString() {
     return "";
@@ -200,54 +223,89 @@ public class Geostationary extends ProjectionImpl {
    */
   @Override
   public ProjectionPoint latLonToProj(LatLonPoint latlon, ProjectionPointImpl destPoint) {
-    double[] satCoords = navigation.earthToSat(latlon.getLongitude(), latlon.getLatitude());
+    final double[] satCoords = navigation.earthToSat(latlon.getLongitude(), latlon.getLatitude());
+
     double x = satCoords[0];
     double y = satCoords[1];
 
-    destPoint.setLocation(satCoords[0], satCoords[1]);
+    if (isGeoCoordinateScaled())
+    {
+        x /= geoCoordinateScaleFactor;
+        y /= geoCoordinateScaleFactor;
+    }
+
+    destPoint.setLocation(x, y);
     return destPoint;
   }
 
+  /**
+   *
+   */
   @Override
   public LatLonPoint projToLatLon(ProjectionPoint ppt, LatLonPointImpl destPoint) {
-    double x = getX(ppt);
-    double y = getY(ppt);
+    double x = ppt.getX();
+    double y = ppt.getY();
 
-    double[] lonlat = navigation.satToEarth(x, y);
+    if (isGeoCoordinateScaled())
+    {
+        x *= geoCoordinateScaleFactor;
+        y *= geoCoordinateScaleFactor;
+    }
+
+    final double[] lonlat = navigation.satToEarth(x, y);
     destPoint.setLongitude(lonlat[0]);
     destPoint.setLatitude(lonlat[1]);
     return destPoint;
   }
 
+  /**
+   *
+   */
   @Override
   public boolean crossSeam(ProjectionPoint pt1, ProjectionPoint pt2) {
     // either point is infinite
-    if (LatLonPoints.isInfinite(pt1) || LatLonPoints.isInfinite(pt2))
+    if (LatLonPoints.isInfinite(pt1) || LatLonPoints.isInfinite(pt2)) {
       return true;
+    }
 
-    double x1 = getX(pt1);
-    double x2 = getX(pt2);
+    double x1 = pt1.getX();
+    double x2 = pt2.getX();
+
+    if (isGeoCoordinateScaled())
+    {
+        x1 *= geoCoordinateScaleFactor;
+        x2 *= geoCoordinateScaleFactor;
+    }
 
     // opposite signed X values, larger then 100 km
+    // LOOK! BUG? This proj works in units of radians rather than km.
     return (x1 * x2 < 0) && (Math.abs(x1 - x2) > 100);
   }
 
+  /**
+   *
+   */
   @Override
   public boolean equals(Object o) {
-    if (this == o)
+    if (this == o) {
       return true;
-    if (o == null || getClass() != o.getClass())
+    }
+    if (o == null || getClass() != o.getClass()) {
       return false;
+    }
 
     Geostationary that = (Geostationary) o;
 
-    if (!navigation.equals(that.navigation))
+    if (!navigation.equals(that.navigation)) {
       return false;
+    }
 
     return geoCoordinateScaleFactor == that.geoCoordinateScaleFactor;
-
   }
 
+  /**
+   *
+   */
   @Override
   public int hashCode() {
     return navigation.hashCode();


### PR DESCRIPTION
If grid x/y units were not radians but something else compatible (e.g., microradians), appropriate scaling of the transform in `ucar.unidata.geoloc.projection.sat.Geostationary` was not done.