### PR TITLE
More NcML camel case fixes and new deprecation

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlReaderProblems.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestNcmlReaderProblems.java
@@ -45,7 +45,7 @@ public class TestNcmlReaderProblems {
     logger.info("TestNcmlReaders on {}%n", ncmlLocation);
     try (NetcdfDataset org = NcMLReader.readNcML(ncmlLocation, null)) {
       System.out.printf("NcMLReader == %s%n", org);
-      try (NetcdfDataset withBuilder = NcmlReader.readNcML(ncmlLocation, null, null).build()) {
+      try (NetcdfDataset withBuilder = NcmlReader.readNcml(ncmlLocation, null, null).build()) {
         System.out.printf("NcMLReaderNew == %s%n", withBuilder);
         Formatter f = new Formatter();
         CompareNetcdf2 compare = new CompareNetcdf2(f, false, false, true);
@@ -62,7 +62,7 @@ public class TestNcmlReaderProblems {
     try (NetcdfDataset org = NcMLReader.readNcML(ncmlLocation, null)) {
       Variable v = org.findVariable(varName);
       assert v != null;
-      try (NetcdfDataset withBuilder = NcmlReader.readNcML(ncmlLocation, null, null).build()) {
+      try (NetcdfDataset withBuilder = NcmlReader.readNcml(ncmlLocation, null, null).build()) {
         Variable vb = withBuilder.findVariable(varName);
         assert vb != null;
         boolean ok = CompareNetcdf2.compareData(varName, v.read(), vb.read());

--- a/cdm/core/src/main/java/thredds/client/catalog/tools/CatalogXmlWriter.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/tools/CatalogXmlWriter.java
@@ -188,7 +188,7 @@ public class CatalogXmlWriter {
     return dsElem;
   }
 
-  private void writeDatasetInfo(Dataset ds, Element dsElem, boolean doNestedDatasets, boolean showNcML) {
+  private void writeDatasetInfo(Dataset ds, Element dsElem, boolean doNestedDatasets, boolean showNcml) {
     String name = ds.getName();
     if (name == null)
       name = ""; // eg catrefs

--- a/cdm/core/src/main/java/thredds/inventory/NcmlCollectionReader.java
+++ b/cdm/core/src/main/java/thredds/inventory/NcmlCollectionReader.java
@@ -45,8 +45,36 @@ public class NcmlCollectionReader {
    * @param errlog put error messages here
    * @return the resulting NetcdfDataset
    * @throws IOException on read error, or bad referencedDatasetUri URI
+   * @deprecated see {@link #readNcml(String, Formatter)}
    */
+  @Deprecated
   public static NcmlCollectionReader readNcML(String ncmlString, Formatter errlog) throws IOException {
+    StringReader reader = new StringReader(ncmlString);
+
+    org.jdom2.Document doc;
+    try {
+      SAXBuilder builder = new SAXBuilder();
+      if (debugURL)
+        System.out.println(" NetcdfDataset NcML String = <" + ncmlString + ">");
+      doc = builder.build(new StringReader(ncmlString));
+    } catch (JDOMException e) {
+      throw new IOException(e.getMessage());
+    }
+    if (debugXML)
+      System.out.println(" SAXBuilder done");
+
+    return readXML(doc, errlog, null);
+  }
+
+  /**
+   * Read an NcML file from a String, and construct a NcmlCollectionReader from its scan or scanFmrc element.
+   *
+   * @param ncmlString the NcML to construct the reader from
+   * @param errlog put error messages here
+   * @return the resulting NetcdfDataset
+   * @throws IOException on read error, or bad referencedDatasetUri URI
+   */
+  public static NcmlCollectionReader readNcml(String ncmlString, Formatter errlog) throws IOException {
     StringReader reader = new StringReader(ncmlString);
 
     org.jdom2.Document doc;

--- a/cdm/core/src/main/java/ucar/nc2/ft/fmrc/Fmrc.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/fmrc/Fmrc.java
@@ -74,7 +74,7 @@ public class Fmrc implements Closeable {
   }
 
   public static Fmrc readNcML(String ncmlString, Formatter errlog) throws IOException {
-    NcmlCollectionReader ncmlCollection = NcmlCollectionReader.readNcML(ncmlString, errlog);
+    NcmlCollectionReader ncmlCollection = NcmlCollectionReader.readNcml(ncmlString, errlog);
     if (ncmlCollection == null)
       return null;
     Fmrc fmrc = new Fmrc(ncmlCollection.getCollectionManager(), new FeatureCollectionConfig());

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordSystemFactory.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordSystemFactory.java
@@ -211,10 +211,10 @@ public class CoordSystemFactory {
 
     // look for ncml first
     if (convName != null) {
-      String convNcML = ncmlHash.get(convName);
-      if (convNcML != null) {
+      String convNcml = ncmlHash.get(convName);
+      if (convNcml != null) {
         CoordSystemBuilder csb = new CoordSystemBuilder(ds);
-        NcmlReader.wrapNcML(ds, convNcML, cancelTask);
+        NcmlReader.wrapNcml(ds, convNcml, cancelTask);
         return Optional.of(csb);
       }
     }

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/ATDRadarConvention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/ATDRadarConvention.java
@@ -24,7 +24,7 @@ public class ATDRadarConvention extends CoordSystemBuilder {
 
   @Override
   public void augmentDataset(CancelTask cancelTask) throws IOException {
-    NcmlReader.wrapNcMLresource(datasetBuilder, CoordSystemFactory.resourcesDir + "ATDRadar.ncml", cancelTask);
+    NcmlReader.wrapNcmlResource(datasetBuilder, CoordSystemFactory.resourcesDir + "ATDRadar.ncml", cancelTask);
   }
 
   public static class Factory implements CoordSystemBuilderFactory {

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CEDRICRadarConvention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CEDRICRadarConvention.java
@@ -47,7 +47,7 @@ public class CEDRICRadarConvention extends CF1Convention {
 
   @Override
   protected void augmentDataset(CancelTask cancelTask) throws IOException {
-    NcmlReader.wrapNcMLresource(datasetBuilder, CoordSystemFactory.resourcesDir + "CEDRICRadar.ncml", cancelTask);
+    NcmlReader.wrapNcmlResource(datasetBuilder, CoordSystemFactory.resourcesDir + "CEDRICRadar.ncml", cancelTask);
 
     VariableDS.Builder lat = (VariableDS.Builder) rootGroup.findVariableLocal("radar_latitude")
         .orElseThrow(() -> new IllegalStateException("Must have radar_latitude variable"));

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/GIEFConvention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/GIEFConvention.java
@@ -32,7 +32,7 @@ public class GIEFConvention extends CoordSystemBuilder {
 
   @Override
   protected void augmentDataset(CancelTask cancelTask) throws IOException {
-    NcmlReader.wrapNcMLresource(datasetBuilder, CoordSystemFactory.resourcesDir + "GIEF.ncml", cancelTask);
+    NcmlReader.wrapNcmlResource(datasetBuilder, CoordSystemFactory.resourcesDir + "GIEF.ncml", cancelTask);
 
     Dimension timeDim = rootGroup.findDimension("time").orElse(null);
     VariableDS.Builder base_time = (VariableDS.Builder) rootGroup.findVariableLocal("base_time").orElse(null);

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/ZebraConvention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/ZebraConvention.java
@@ -32,7 +32,7 @@ public class ZebraConvention extends CoordSystemBuilder {
 
   @Override
   protected void augmentDataset(CancelTask cancelTask) throws IOException {
-    NcmlReader.wrapNcMLresource(datasetBuilder, CoordSystemFactory.resourcesDir + "Zebra.ncml", cancelTask);
+    NcmlReader.wrapNcmlResource(datasetBuilder, CoordSystemFactory.resourcesDir + "Zebra.ncml", cancelTask);
 
     // special time handling
     // the time coord var is created in the NcML

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
@@ -112,7 +112,7 @@ class AggDataset implements Comparable<AggDataset> {
     if (ncmlElem == null && (enhance.isEmpty()))
       return ncfile;
 
-    NetcdfDataset.Builder builder = NcmlReader.mergeNcML(ncfile, ncmlElem); // create new dataset
+    NetcdfDataset.Builder builder = NcmlReader.mergeNcml(ncfile, ncmlElem); // create new dataset
     builder.setEnhanceMode(enhance);
 
     if (debugOpenFile)

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlNetcdfFileProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlNetcdfFileProvider.java
@@ -21,7 +21,7 @@ public class NcmlNetcdfFileProvider implements NetcdfFileProvider {
 
   @Override
   public NetcdfFile open(String location, CancelTask cancelTask) throws IOException {
-    return NcmlReader.readNcML(location, (String) null, cancelTask).build();
+    return NcmlReader.readNcml(location, (String) null, cancelTask).build();
   }
 
   @Override

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -186,7 +186,7 @@ public class NcmlReader {
    * @param cancelTask allow user to cancel task; may be null
    * @throws IOException on read error
    */
-  public static void wrapNcML(NetcdfDataset.Builder ncDataset, String ncmlLocation, CancelTask cancelTask)
+  public static void wrapNcml(NetcdfDataset.Builder ncDataset, String ncmlLocation, CancelTask cancelTask)
       throws IOException {
     org.jdom2.Document doc;
     try {
@@ -212,7 +212,7 @@ public class NcmlReader {
     NcmlReader reader = new NcmlReader();
     reader.readNetcdf(ncmlLocation, ncDataset, netcdfElem, cancelTask);
     if (debugOpen) {
-      System.out.println("***NcMLReader.wrapNcML result= \n" + ncDataset);
+      System.out.println("***NcmlReader.wrapNcml result= \n" + ncDataset);
     }
   }
 
@@ -226,7 +226,7 @@ public class NcmlReader {
    * @param cancelTask allow user to cancel task; may be null
    * @throws IOException on read error
    */
-  public static void wrapNcMLresource(NetcdfDataset.Builder ncDataset, String ncmlResourceLocation,
+  public static void wrapNcmlResource(NetcdfDataset.Builder ncDataset, String ncmlResourceLocation,
       CancelTask cancelTask) throws IOException {
     ClassLoader cl = ncDataset.getClass().getClassLoader();
     try (InputStream is = cl.getResourceAsStream(ncmlResourceLocation)) {
@@ -265,7 +265,7 @@ public class NcmlReader {
       NcmlReader reader = new NcmlReader();
       reader.readNetcdf(ncDataset.location, ncDataset, netcdfElem, cancelTask);
       if (debugOpen) {
-        System.out.println("***NcMLReader.wrapNcML result= \n" + ncDataset);
+        System.out.println("***NcmlReader.wrapNcml result= \n" + ncDataset);
       }
     }
   }
@@ -279,7 +279,7 @@ public class NcmlReader {
    * @return new dataset with the merged info
    * @throws IOException on read error
    */
-  public static NetcdfDataset.Builder mergeNcML(NetcdfFile ref, @Nullable Element ncmlElem) throws IOException {
+  public static NetcdfDataset.Builder mergeNcml(NetcdfFile ref, @Nullable Element ncmlElem) throws IOException {
     NetcdfDataset.Builder targetDS = new NetcdfDataset(ref.toBuilder()).toBuilder(); // no enhance
 
     if (ncmlElem != null) {
@@ -294,7 +294,7 @@ public class NcmlReader {
 
   /**
    * Read NcML doc from a Reader, and construct a NetcdfDataset.
-   * eg: NcMLReader.readNcML(new StringReader(ncml), location, null);
+   * eg: NcmlReader.readNcML(new StringReader(ncml), location, null);
    *
    * @param r the Reader containing the NcML document
    * @param ncmlLocation the URL location string of the NcML document, used to resolve reletive path of the referenced
@@ -304,7 +304,7 @@ public class NcmlReader {
    * @return the resulting NetcdfDataset
    * @throws IOException on read error, or bad referencedDatasetUri URI
    */
-  public static NetcdfDataset.Builder readNcML(Reader r, String ncmlLocation, CancelTask cancelTask)
+  public static NetcdfDataset.Builder readNcml(Reader r, String ncmlLocation, CancelTask cancelTask)
       throws IOException {
 
     org.jdom2.Document doc;
@@ -331,7 +331,7 @@ public class NcmlReader {
       referencedDatasetUri = AliasTranslator.translateAlias(referencedDatasetUri);
 
     NcmlReader reader = new NcmlReader();
-    return reader.readNcML(ncmlLocation, referencedDatasetUri, netcdfElem, cancelTask);
+    return reader.readNcml(ncmlLocation, referencedDatasetUri, netcdfElem, cancelTask);
   }
 
   /**
@@ -344,12 +344,12 @@ public class NcmlReader {
    * @return the resulting NetcdfDataset
    * @throws IOException on read error, or bad referencedDatasetUri URI
    */
-  public static NetcdfDataset.Builder readNcML(String ncmlLocation, String referencedDatasetUri, CancelTask cancelTask)
+  public static NetcdfDataset.Builder readNcml(String ncmlLocation, String referencedDatasetUri, CancelTask cancelTask)
       throws IOException {
     URL url = new URL(ncmlLocation);
 
     if (debugURL) {
-      System.out.println(" NcMLReader open " + ncmlLocation);
+      System.out.println(" NcmlReader open " + ncmlLocation);
       System.out.println("   URL = " + url);
       System.out.println("   external form = " + url.toExternalForm());
       System.out.println("   protocol = " + url.getProtocol());
@@ -391,7 +391,7 @@ public class NcmlReader {
     }
 
     NcmlReader reader = new NcmlReader();
-    return reader.readNcML(ncmlLocation, referencedDatasetUri, netcdfElem, cancelTask);
+    return reader.readNcml(ncmlLocation, referencedDatasetUri, netcdfElem, cancelTask);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////
@@ -414,7 +414,7 @@ public class NcmlReader {
    * @return NetcdfDataset the constructed dataset
    * @throws IOException on read error, or bad referencedDatasetUri URI
    */
-  private NetcdfDataset.Builder readNcML(String ncmlLocation, @Nullable String referencedDatasetUri, Element netcdfElem,
+  private NetcdfDataset.Builder readNcml(String ncmlLocation, @Nullable String referencedDatasetUri, Element netcdfElem,
       @Nullable CancelTask cancelTask) throws IOException {
 
     // get ncml namespace and set namespace variable
@@ -1567,105 +1567,12 @@ public class NcmlReader {
       if (debugAggDetail) {
         System.out.println(" NcmlElementReader open nested dataset " + cacheName);
       }
-      NetcdfFile.Builder result = readNcML(ncmlLocation, location, netcdfElem, cancelTask);
+      NetcdfFile.Builder result = readNcml(ncmlLocation, location, netcdfElem, cancelTask);
       result.setLocation(ncmlLocation + "#" + location);
       return result.build();
     }
   }
 
-  //////////////////////////////////////////////////////
-
-  /*
-   * LOOK
-   * private void processLogicalViews(Variable.Builder v, @Nullable Group refGroup, Element varElem) {
-   *
-   * Element viewElem = varElem.getChild("logicalSection", ncNS);
-   * if (null != viewElem) {
-   * String sectionSpec = viewElem.getAttributeValue("section");
-   * if (sectionSpec != null) {
-   * try {
-   * Section s = new Section(sectionSpec); // parse spec
-   * Section viewSection = Section.fill(s, v.getShape());
-   * // check that its a subset
-   * if (!v.getShapeAsSection().contains(viewSection)) {
-   * errlog.format("Invalid logicalSection on variable=%s section =(%s) original=(%s) %n", v.getFullName(),
-   * sectionSpec, v.getShapeAsSection());
-   * return;
-   * }
-   * Variable view = v.section(viewSection);
-   * g.removeVariable(v.getShortName());
-   * g.addVariable(view);
-   *
-   * } catch (InvalidRangeException e) {
-   * errlog.format("Invalid logicalSection on variable=%s section=(%s) error=%s %n", v.getFullName(), sectionSpec,
-   * e.getMessage());
-   * return;
-   * }
-   * }
-   * }
-   *
-   * viewElem = varElem.getChild("logicalSlice", ncNS);
-   * if (null != viewElem) {
-   * String dimName = viewElem.getAttributeValue("dimName");
-   * if (null == dimName) {
-   * errlog.format("NcML logicalSlice: dimName is required, variable=%s %n", v.getFullName());
-   * return;
-   * }
-   * int dim = v.findDimensionIndex(dimName);
-   * if (dim < 0) {
-   * errlog.format("NcML logicalSlice: cant find dimension %s in variable=%s %n", dimName, v.getFullName());
-   * return;
-   * }
-   *
-   * String indexS = viewElem.getAttributeValue("index");
-   * int index;
-   * if (null == indexS) {
-   * errlog.format("NcML logicalSlice: index is required, variable=%s %n", v.getFullName());
-   * return;
-   * }
-   * try {
-   * index = Integer.parseInt(indexS);
-   * } catch (NumberFormatException e) {
-   * errlog.format("NcML logicalSlice: index=%s must be integer, variable=%s %n", indexS, v.getFullName());
-   * return;
-   * }
-   *
-   * try {
-   * Variable view = v.slice(dim, index);
-   * g.removeVariable(v.getShortName());
-   * g.addVariable(view);
-   *
-   * } catch (InvalidRangeException e) {
-   * errlog.format("Invalid logicalSlice (%d,%d) on variable=%s error=%s %n", dim, index, v.getFullName(),
-   * e.getMessage());
-   * }
-   * }
-   *
-   * viewElem = varElem.getChild("logicalReduce", ncNS);
-   * if (null != viewElem) {
-   * String dimName = viewElem.getAttributeValue("dimNames");
-   * if (null == dimName) {
-   * errlog.format("NcML logicalReduce: dimNames is required, variable=%s %n", v.getFullName());
-   * return;
-   * }
-   * String[] dims = StringUtil2.splitString(dimName);
-   * List<Dimension> dimList = new ArrayList<>();
-   * for (String s : dims) {
-   * int idx = v.findDimensionIndex(s);
-   * if (idx < 0) {
-   * errlog.format("NcML logicalReduce: cant find dimension %s in variable=%s %n", dimName, v.getFullName());
-   * return;
-   * }
-   * dimList.add(v.getDimension(idx));
-   * }
-   *
-   * Variable view = v.reduce(dimList);
-   * g.removeVariable(v.getShortName());
-   * g.addVariable(view);
-   * }
-   *
-   * }
-   */
   /////////////////////////////////////////////
   // command procesing
 
@@ -1717,67 +1624,4 @@ public class NcmlReader {
       log.info(f.toString());
     }
   }
-
-  ///////////////////////////////////////////////////////////////////////////////////
-
-  /*
-   * Read an NcML file and write an equivalent NetcdfFile to a physical file, using Netcdf-3 file format.
-   *
-   * @param ncmlLocation read this NcML file
-   *
-   * @param fileOutName write to this local file
-   *
-   * @throws IOException on write error
-   *
-   * @see ucar.nc2.FileWriter2
-   *
-   * public static void writeNcMLToFile(String ncmlLocation, String fileOutName) throws IOException {
-   * NetcdfFile ncd = NetcdfDataset.acquireFile(ncmlLocation, null);
-   *
-   * FileWriter2 writer = new FileWriter2(ncd, fileOutName, NetcdfFileWriter.Version.netcdf3, null);
-   * NetcdfFile result = writer.write();
-   * result.close();
-   * ncd.close();
-   * }
-   */
-
-  /*
-   * Read an NcML and write an equivalent NetcdfFile to a physical file, using Netcdf-3 file format.
-   * The NcML may have a referenced dataset in the location URL, in which case the underlying data
-   * (modified by the NcML) is written to the new file. If the NcML does not have a referenced dataset,
-   * then the new file is filled with fill values, like ncgen.
-   *
-   * @param ncml read NcML from this input stream
-   *
-   * @param fileOutName write to this local file
-   *
-   * @see ucar.nc2.FileWriter2
-   *
-   * public static void writeNcMLToFile(InputStream ncml, String fileOutName) throws IOException {
-   * writeNcMLToFile(ncml, fileOutName, NetcdfFileWriter.Version.netcdf3, null);
-   * }
-   */
-
-  /*
-   * Read an NcML and write an equivilent NetcdfFile to a physical file, using Netcdf-3 file format.
-   * The NcML may have a referenced dataset in the location URL, in which case the underlying data
-   * (modified by the NcML) is written to the new file. If the NcML does not have a referenced dataset,
-   * then the new file is filled with fill values, like ncgen.
-   *
-   * @param ncml read NcML from this input stream
-   *
-   * @param fileOutName write to this local file
-   *
-   * @param version kind of netcdf file
-   *
-   * @param chunker optional chunking (netcdf4 only)
-   * public static void writeNcMLToFile(InputStream ncml, String fileOutName, NetcdfFileWriter.Version version,
-   * Nc4Chunking chunker) throws IOException {
-   * NetcdfDataset ncd = NcMLReaderNew.readNcML(ncml, null);
-   * FileWriter2 writer = new FileWriter2(ncd, fileOutName, version, chunker);
-   * NetcdfFile result = writer.write();
-   * result.close();
-   * ncd.close();
-   * }
-   */
 }

--- a/cdm/core/src/test/groovy/ucar/nc2/ncml/CacheAggregationsSpec.groovy
+++ b/cdm/core/src/test/groovy/ucar/nc2/ncml/CacheAggregationsSpec.groovy
@@ -41,7 +41,7 @@ class CacheAggregationsSpec extends Specification {
     // Demonstrates eSupport ticket OPV-470285.
     def "union"() {
         setup:
-        String filename = "file:./" + TestNcMLRead.topDir + "aggUnion.xml"
+        String filename = "file:./" + TestNcmlRead.topDir + "aggUnion.xml"
         def expecteds = [5.0, 10.0, 15.0, 20.0]
         def actuals
 
@@ -60,7 +60,7 @@ class CacheAggregationsSpec extends Specification {
 
     def "joinExisting"() {
         setup:
-        String filename = "file:./"+TestNcMLRead.topDir + "aggExisting.xml";
+        String filename = "file:./"+TestNcmlRead.topDir + "aggExisting.xml";
         def expecteds = [8420.0, 8422.0, 8424.0, 8426.0]
         def actuals
 
@@ -79,7 +79,7 @@ class CacheAggregationsSpec extends Specification {
 
     def "joinNew"() {
         setup:
-        String filename = "file:./"+TestNcMLRead.topDir + "aggSynthetic.xml";
+        String filename = "file:./"+TestNcmlRead.topDir + "aggSynthetic.xml";
         def expecteds = [110.0, 111.0, 112.0, 113.0]
         def actuals
 
@@ -118,7 +118,7 @@ class CacheAggregationsSpec extends Specification {
 
     def "fmrc"() {
         setup:
-        String filename = "file:./"+TestNcMLRead.topDir + "fmrc/testAggFmrcScan.ncml";
+        String filename = "file:./"+TestNcmlRead.topDir + "fmrc/testAggFmrcScan.ncml";
         def expecteds = [232.0, 232.4, 232.5]
         def actuals
 

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExisting.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExisting.java
@@ -22,7 +22,7 @@ import ucar.nc2.Variable;
 import ucar.nc2.constants.CF;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.nc2.time.Calendar;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateUnit;
@@ -35,9 +35,9 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDirect() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
 
     testDimensions(ncfile);
@@ -51,7 +51,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDataset() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -66,7 +66,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilename() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -84,7 +84,7 @@ public class TestAggExisting {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -102,7 +102,7 @@ public class TestAggExisting {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -117,7 +117,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetNoProtocolInNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -132,7 +132,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilenameOrNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -147,7 +147,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetWcoords() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingWcoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingWcoords.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" testNcmlDatasetWcoords.open {}", filename);
@@ -164,7 +164,7 @@ public class TestAggExisting {
   // remove test - now we get a coordinate initialized to missing data, but at least testCoordsAdded works!
   // @Test
   public void testNoCoords() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoords.xml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -185,7 +185,7 @@ public class TestAggExisting {
   // LOOK this test expects an Exception, but it seems to work. Why isnt this test failing in travis?
   // @Test
   public void testNoCoordsDir() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
 
     try (NetcdfDataset ncd = NetcdfDatasets.openDataset(filename, true, null)) {
       System.out.printf("testNoCoordsDir supposed to fail = %s", ncd);
@@ -198,7 +198,7 @@ public class TestAggExisting {
 
   @Test
   public void testCoordsAdded() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingAddCoord.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingAddCoord.ncml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -214,16 +214,16 @@ public class TestAggExisting {
   @Test(expected = UnsupportedOperationException.class)
   public void testNcmlAggInequivalentCals() throws IOException {
     // Tests that an aggregation with inequivalent calendars across the individual datasets will fail
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
-    NcmlReader.readNcML(filename, null, null);
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
+    NcmlReader.readNcml(filename, null, null);
   }
 
   @Test
   public void testNcmlAggExistingNoCal() throws IOException {
     // no calendar attribute in the aggregation, which should default to using proleptic_gregorian
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -255,9 +255,9 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingNoLeapCal() throws IOException {
     // with calendar = noleap, each year should have 365 days, even in a leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -283,9 +283,9 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingAllLeapCal() throws IOException {
     // with calendar = all_leap, each year should have 366 days, even in non-leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -311,7 +311,7 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingUniform30DayCal() throws IOException {
     // with calendar = uniform30day, each year should have 360 days (12 months, each with 30 days)
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
@@ -320,12 +320,12 @@ public class TestAggExisting {
     // in this NcML agg, one file uses uniform30day calendar, the other uses 360_day calendar, but
     // those are equivalent, so we let it slide. Otherwise, identical to the ncml agg used in
     // testNcmlAggExistingUniform30DayCal()
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
   private void testNcmlAggExisting30DayCals(String filename) throws IOException {
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -352,9 +352,9 @@ public class TestAggExisting {
   public void testNcmlAggExistingJulienCal() throws IOException {
     // with calendar = Julian, 4 October 1582 was followed by 5 October 1582 (unlike gregorian, where 4 October
     // was followed by 15 October).
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -411,9 +411,9 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingGregorianCal() throws IOException {
     // with calendar = gregorian, 4 October 1582 was followed by 15 October 1582
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -477,9 +477,9 @@ public class TestAggExisting {
   public void testNcmlAggExistingProlepticGregorianCal() throws IOException {
     // with calendar = proleptic_gregorian, 1582 and 1583 should each have 365 days
     // (for a gregorian calendar, 1852 would only have 355
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExistingCoordVars.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExistingCoordVars.java
@@ -16,7 +16,7 @@ import ucar.ma2.DataType;
 import ucar.ma2.IndexIterator;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.nc2.units.DateFormatter;
 import ucar.nc2.units.DateUnit;
 import ucar.nc2.write.Ncdump;
@@ -28,9 +28,9 @@ public class TestAggExistingCoordVars {
 
   @Test
   public void testType1() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting1.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting1.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
 
     Variable time = ncfile.findVariable("time");
@@ -76,9 +76,9 @@ public class TestAggExistingCoordVars {
 
   @Test
   public void testType2() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting2.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting2.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(aggExisting2), filename, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(aggExisting2), filename, null).build();
     logger.debug(" TestNcmlAggExisting.open {}\n{}", filename, ncfile);
 
     Variable time = ncfile.findVariable("time");
@@ -113,9 +113,9 @@ public class TestAggExistingCoordVars {
 
   @Test
   public void testType3() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}\n{}", filename, ncfile);
 
     Variable time = ncfile.findVariable("time");
@@ -149,9 +149,9 @@ public class TestAggExistingCoordVars {
 
   @Test
   public void testType4() throws IOException {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExisting4.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExisting4.ncml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     Variable time = ncfile.findVariable("time");
     assert null != time;
@@ -184,9 +184,9 @@ public class TestAggExistingCoordVars {
 
   @Test
   public void testWithDateFormatMark() throws Exception {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingOne.xml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingOne.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     Variable time = ncfile.findVariable("time");
     assert null != time;
@@ -222,9 +222,9 @@ public class TestAggExistingCoordVars {
 
   // @Test
   public void oldTestWithDateFormatMark() throws Exception {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingOne.xml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingOne.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     Variable time = ncfile.findVariable("time");
     assert null != time;
@@ -266,9 +266,9 @@ public class TestAggExistingCoordVars {
 
   @Test
   public void testClimatologicalDate() throws IOException {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExisting5.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExisting5.ncml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     Variable time = ncfile.findVariable("time");
     assert null != time;

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExistingNew.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExistingNew.java
@@ -23,7 +23,7 @@ import ucar.nc2.constants.CF;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDataset.Builder;
 import ucar.nc2.dataset.NetcdfDatasets;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.nc2.time.Calendar;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateUnit;
@@ -37,9 +37,9 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDirect() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
 
     testDimensions(ncfile);
@@ -53,7 +53,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDataset() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -68,7 +68,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilename() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -86,7 +86,7 @@ public class TestAggExistingNew {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -104,7 +104,7 @@ public class TestAggExistingNew {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -119,7 +119,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetNoProtocolInNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -134,7 +134,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilenameOrNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -149,7 +149,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetWcoords() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingWcoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingWcoords.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" testNcmlDatasetWcoords.open {}", filename);
@@ -166,7 +166,7 @@ public class TestAggExistingNew {
   // remove test - now we get a coordinate initialized to missing data, but at least testCoordsAdded works!
   // @Test
   public void testNoCoords() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoords.xml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -187,7 +187,7 @@ public class TestAggExistingNew {
   // LOOK this test expects an Exception, but it seems to work. Why isnt this test failing in travis?
   // @Test
   public void testNoCoordsDir() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
 
     try (NetcdfDataset ncd = NetcdfDatasets.openDataset(filename, true, null)) {
       System.out.printf("testNoCoordsDir supposed to fail = %s", ncd);
@@ -200,7 +200,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testCoordsAdded() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingAddCoord.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingAddCoord.ncml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -216,16 +216,16 @@ public class TestAggExistingNew {
   @Test(expected = UnsupportedOperationException.class)
   public void testNcmlAggInequivalentCals() throws IOException {
     // Tests that an aggregation with inequivalent calendars across the individual datasets will fail
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
-    NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
+    NcmlReader.readNcml(filename, null, null).build();
   }
 
   @Test
   public void testNcmlAggExistingNoCal() throws IOException {
     // no calendar attribute in the aggregation, which should default to using proleptic_gregorian
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
 
-    Builder netcdfFileBuilder = NcmlReader.readNcML(filename, null, null);
+    Builder netcdfFileBuilder = NcmlReader.readNcml(filename, null, null);
     NetcdfFile ncfile = netcdfFileBuilder.build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
@@ -258,9 +258,9 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingNoLeapCal() throws IOException {
     // with calendar = noleap, each year should have 365 days, even in a leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -286,9 +286,9 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingAllLeapCal() throws IOException {
     // with calendar = all_leap, each year should have 366 days, even in non-leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -314,7 +314,7 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingUniform30DayCal() throws IOException {
     // with calendar = uniform30day, each year should have 360 days (12 months, each with 30 days)
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
@@ -323,12 +323,12 @@ public class TestAggExistingNew {
     // in this NcML agg, one file uses uniform30day calendar, the other uses 360_day calendar, but
     // those are equivalent, so we let it slide. Otherwise, identical to the ncml agg used in
     // testNcmlAggExistingUniform30DayCal()
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
   private void testNcmlAggExisting30DayCals(String filename) throws IOException {
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -355,9 +355,9 @@ public class TestAggExistingNew {
   public void testNcmlAggExistingJulienCal() throws IOException {
     // with calendar = Julian, 4 October 1582 was followed by 5 October 1582 (unlike gregorian, where 4 October
     // was followed by 15 October).
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -414,9 +414,9 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingGregorianCal() throws IOException {
     // with calendar = gregorian, 4 October 1582 was followed by 15 October 1582
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -480,9 +480,9 @@ public class TestAggExistingNew {
   public void testNcmlAggExistingProlepticGregorianCal() throws IOException {
     // with calendar = proleptic_gregorian, 1582 and 1583 should each have 365 days
     // (for a gregorian calendar, 1852 would only have 355
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExistingPromote.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggExistingPromote.java
@@ -17,7 +17,7 @@ import ucar.ma2.InvalidRangeException;
 import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.nc2.write.Ncdump;
 
 /** Test promoting an attribute to a variable. */
@@ -26,7 +26,7 @@ public class TestAggExistingPromote {
 
   @Test
   public void testWithDateFormatMark() throws Exception {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingPromote.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingPromote.ncml";
 
     String aggExistingPromote = "<?xml version='1.0' encoding='UTF-8'?>\n" // leavit
         + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" // leavit
@@ -36,7 +36,7 @@ public class TestAggExistingPromote {
         + "  </aggregation>\n" // leavit
         + "</netcdf>"; // leavit
 
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(aggExistingPromote), filename, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(aggExistingPromote), filename, null).build();
     System.out.println(" TestNcmlAggExisting.open " + filename + "\n" + ncfile);
 
     // the promoted var
@@ -144,7 +144,7 @@ public class TestAggExistingPromote {
    */
   @Test
   public void testNotOne() throws IOException, InvalidRangeException {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingPromote2.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingPromote2.ncml";
 
     String aggExistingPromote2 = "<?xml version='1.0' encoding='UTF-8'?>\n"
         + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" // leavit
@@ -164,7 +164,7 @@ public class TestAggExistingPromote {
         + "</netcdf>"; // leavit
 
 
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(aggExistingPromote2), filename, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(aggExistingPromote2), filename, null).build();
     Dimension dim = ncfile.findDimension("time");
 
     // the promoted var

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggMisc.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggMisc.java
@@ -16,7 +16,7 @@ import ucar.ma2.InvalidRangeException;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDatasets;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.nc2.write.Ncdump;
 import ucar.unidata.util.test.TestDir;
 
@@ -46,7 +46,7 @@ public class TestAggMisc {
 
     String location = "testNestedValues.ncml";
 
-    try (NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(ncml), location, null).build()) {
+    try (NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(ncml), location, null).build()) {
       TestDir.readAllData(ncfile);
 
       Variable v = ncfile.findVariable("time");
@@ -72,7 +72,7 @@ public class TestAggMisc {
 
   @Test
   public void testNestedScan() throws IOException, InvalidRangeException, InterruptedException {
-    String filename = "file:./" + TestNcMLRead.topDir + "nested/TestNestedDirs.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "nested/TestNestedDirs.ncml";
 
     try (NetcdfFile ncfile = NetcdfDatasets.openFile(filename, null)) {
       TestDir.readAllData(ncfile);

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggModify.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggModify.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 
 /** Test TestNcml - modifications aggregation features. */
 public class TestAggModify {
@@ -29,8 +29,8 @@ public class TestAggModify {
   @Test
   public void testWithDateFormatMark() throws Exception {
     System.out.printf("ncml=%s%n", ncml);
-    String filename = "file:" + TestNcMLRead.topDir + "testAggModify.ncml";
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(ncml), filename, null).build();
+    String filename = "file:" + TestNcmlRead.topDir + "testAggModify.ncml";
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(ncml), filename, null).build();
     System.out.println(" TestNcmlAggExisting.open " + filename + "\n" + ncfile);
 
     Variable v = ncfile.findVariable("T");

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggPromote.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggPromote.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 import ucar.ma2.InvalidRangeException;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 
 /** Test promoteGlobalAttribute */
 public class TestAggPromote {
@@ -30,9 +30,9 @@ public class TestAggPromote {
         + "  </aggregation>\n" // leavit
         + "</netcdf>"; // leavit
 
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting1.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting1.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(xml), null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(xml), null, null).build();
     System.out.println(" TestNcmlAggExisting.open " + filename);
 
     Variable times = ncfile.findVariable("times");

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggSynthetic.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggSynthetic.java
@@ -22,7 +22,7 @@ import ucar.nc2.Attribute;
 import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.unidata.util.test.Assert2;
 
 /** Test netcdf dataset in the JUnit framework. */
@@ -31,8 +31,8 @@ public class TestAggSynthetic {
 
   @Test
   public void test1() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynthetic.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynthetic.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     Variable v = ncfile.findVariable("time");
     assert v != null;
@@ -51,8 +51,8 @@ public class TestAggSynthetic {
 
   @Test
   public void test2() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynthetic2.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynthetic2.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     testDimensions(ncfile);
     testCoordVar(ncfile);
@@ -65,8 +65,8 @@ public class TestAggSynthetic {
 
   @Test
   public void test3() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynthetic3.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynthetic3.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     testDimensions(ncfile);
     testCoordVar(ncfile);
@@ -79,8 +79,8 @@ public class TestAggSynthetic {
 
   @Test
   public void testNoCoord() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynNoCoord.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynNoCoord.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     testDimensions(ncfile);
     testCoordVar(ncfile);
@@ -93,8 +93,8 @@ public class TestAggSynthetic {
 
   @Test
   public void testNoCoordDir() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynNoCoordsDir.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynNoCoordsDir.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     testDimensions(ncfile);
     testCoordVar(ncfile);
@@ -107,8 +107,8 @@ public class TestAggSynthetic {
 
   @Test
   public void testJoinNewScalarCoord() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggJoinNewScalarCoord.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggJoinNewScalarCoord.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
 
     Variable v = ncfile.findVariable("time");
     assert v != null;
@@ -136,8 +136,8 @@ public class TestAggSynthetic {
         + "  </aggregation>\n" // leavit
         + "</netcdf>"; // leavit
 
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggSynRename.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(xml), null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggSynRename.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(xml), null, null).build();
 
     testDimensions(ncfile);
     testCoordVar(ncfile);
@@ -159,8 +159,8 @@ public class TestAggSynthetic {
         + "    <scan location='src/test/data/ncml/nc/' suffix='Dir.nc' subdirs='false'/>\n" + "  </aggregation>\n"
         + "</netcdf>";
 
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynScan.xml";
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(xml), null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynScan.xml";
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(xml), null, null).build();
 
     testDimensions(ncfile);
     testCoordVar(ncfile);

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggUnion.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggUnion.java
@@ -20,7 +20,7 @@ import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.VariableDS;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.unidata.util.test.Assert2;
 
 /**
@@ -128,8 +128,8 @@ public class TestAggUnion {
   public static void setUp() throws IOException {
     if (ncfile != null)
       return;
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnion.xml";
-    ncfile = NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnion.xml";
+    ncfile = NcmlReader.readNcml(filename, null, null).build();
   }
 
   @AfterClass

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggUnionSimple.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggUnionSimple.java
@@ -25,7 +25,7 @@ import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dataset.VariableDS;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.nc2.util.CompareNetcdf2;
 import ucar.unidata.util.test.Assert2;
 
@@ -132,7 +132,7 @@ public class TestAggUnionSimple {
   public static void setUp() throws IOException {
     if (ncfile != null)
       return;
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnionSimple.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnionSimple.xml";
     ncfile = NetcdfDatasets.openDataset(filename, false, null);
   }
 
@@ -300,7 +300,7 @@ public class TestAggUnionSimple {
    */
   @Test
   public void testScan() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnionScan.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnionScan.xml";
     try (NetcdfDataset scanFile = NetcdfDatasets.openDataset(filename, false, null)) {
       Assert.assertTrue(CompareNetcdf2.compareFiles(ncfile, scanFile, new Formatter(), true, false, false));
     }
@@ -308,7 +308,7 @@ public class TestAggUnionSimple {
 
   @Test
   public void testRename() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnionRename.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnionRename.xml";
     try (NetcdfDataset scanFile = NetcdfDatasets.openDataset(filename, false, null)) {
       Variable v = scanFile.findVariable("LavaFlow");
       assert v != null;

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggUnsignedByte.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestAggUnsignedByte.java
@@ -20,7 +20,7 @@ import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Section;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 
 /** Test AggExisting with Unsigned Byte */
 
@@ -35,9 +35,9 @@ public class TestAggUnsignedByte {
 
   @Before
   public void prepAggDataset() {
-    String filename = "file:./" + TestNcMLRead.topDir + AGG_FILENAME;
+    String filename = "file:./" + TestNcmlRead.topDir + AGG_FILENAME;
     try {
-      ncfile = NcmlReader.readNcML(filename, null, null).build();
+      ncfile = NcmlReader.readNcml(filename, null, null).build();
       v = ncfile.findVariable(UBYTE_VAR_NAME);
     } catch (IOException e) {
       e.printStackTrace();

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlEquals.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlEquals.java
@@ -13,18 +13,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 import ucar.nc2.ncml.TestNcmlReadersCompare;
 import ucar.nc2.util.CompareNetcdf2;
 
 /** Test netcdf dataset in the JUnit framework. */
-public class TestNcMLequals {
+public class TestNcmlEquals {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
   public void testEquals() throws IOException {
-    testEquals("file:" + TestNcMLRead.topDir + "testEquals.xml");
-    testEnhanceEquals("file:" + TestNcMLRead.topDir + "testEqualsEnhance.xml");
+    testEquals("file:" + TestNcmlRead.topDir + "testEquals.xml");
+    testEnhanceEquals("file:" + TestNcmlRead.topDir + "testEqualsEnhance.xml");
   }
 
   public void problem() throws IOException {
@@ -36,7 +36,7 @@ public class TestNcMLequals {
   }
 
   private void testEquals(String ncmlLocation) throws IOException {
-    try (NetcdfDataset ncd = NcmlReader.readNcML(ncmlLocation, null, null).build()) {
+    try (NetcdfDataset ncd = NcmlReader.readNcml(ncmlLocation, null, null).build()) {
       String locref = ncd.getReferencedFile().getLocation();
       try (NetcdfDataset ncdref = NetcdfDatasets.openDataset(locref, false, null)) {
         Formatter f = new Formatter();
@@ -49,7 +49,7 @@ public class TestNcMLequals {
   }
 
   private void testEnhanceEquals(String ncmlLocation) throws IOException {
-    try (NetcdfDataset ncd = NcmlReader.readNcML(ncmlLocation, null, null).build()) {
+    try (NetcdfDataset ncd = NcmlReader.readNcml(ncmlLocation, null, null).build()) {
       String locref = ncd.getReferencedFile().getLocation();
       try (NetcdfDataset ncdref = NetcdfDatasets.openDataset(locref, true, null)) {
         Formatter f = new Formatter();

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyVars.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyVars.java
@@ -20,19 +20,19 @@ import ucar.nc2.Attribute;
 import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 
-public class TestNcMLModifyVars {
+public class TestNcmlModifyVars {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static NetcdfFile ncfile = null;
 
   @BeforeClass
   public static void setUp() {
-    String filename = "file:" + TestNcMLRead.topDir + "modifyVars.xml";
+    String filename = "file:" + TestNcmlRead.topDir + "modifyVars.xml";
 
     try {
-      ncfile = NcmlReader.readNcML(filename, null, null).build();
+      ncfile = NcmlReader.readNcml(filename, null, null).build();
     } catch (java.net.MalformedURLException e) {
       System.out.println("bad URL error = " + e);
     } catch (IOException e) {

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRead.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRead.java
@@ -4,81 +4,81 @@
  */
 package ucar.nc2.internal.ncml;
 
+import static ucar.nc2.util.Misc.nearlyEquals;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.IndexIterator;
-import ucar.ma2.InvalidRangeException;
 import ucar.nc2.Attribute;
 import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.constants.CDM;
-import ucar.nc2.ncml.TestNcMLRead;
-import ucar.unidata.util.test.Assert2;
+import ucar.unidata.util.test.TestDir;
 
-public class TestNcMLModifyAtts {
+@RunWith(Parameterized.class)
+public class TestNcmlRead {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  public static String topDir = TestDir.cdmLocalTestDataDir + "ncml/";
 
-  private static NetcdfFile ncfile = null;
-
-  @BeforeClass
-  public static void setUp() throws IOException {
-    String filename = "file:" + TestNcMLRead.topDir + "modifyAtts.xml";
-    ncfile = NcmlReader.readNcML(filename, null, null).build();
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> getTestParameters() {
+    Collection<Object[]> filenames = new ArrayList<>();
+    filenames.add(new Object[] {"testRead.xml"});
+    filenames.add(new Object[] {"readMetadata.xml"});
+    filenames.add(new Object[] {"testReadHttps.xml"});
+    return filenames;
   }
 
-  @AfterClass
-  public static void tearDown() throws IOException {
+  private String ncmlLocation;
+  private NetcdfFile ncfile;
+
+  public TestNcmlRead(String filename) {
+    this.ncmlLocation = "file:" + topDir + filename;
+    try {
+      ncfile = NcmlReader.readNcml(ncmlLocation, null, null).build();
+    } catch (java.net.MalformedURLException e) {
+      System.out.println("bad URL error = " + e);
+    } catch (IOException e) {
+      System.out.println("IO error = " + e);
+      e.printStackTrace();
+    }
+  }
+
+  @After
+  public void tearDown() throws IOException {
     ncfile.close();
   }
 
   @Test
-  public void testGlobalAtt() {
-    Attribute att = ncfile.findGlobalAttribute("Conventions");
+  public void testStructure() {
+    System.out.println("ncfile opened = " + ncmlLocation + "\n" + ncfile);
+
+    Attribute att = ncfile.findGlobalAttribute("title");
     assert null != att;
     assert !att.isArray();
     assert att.isString();
     assert att.getDataType() == DataType.STRING;
-    assert att.getStringValue().equals("Metapps");
+    assert att.getStringValue().equals("Example Data");
     assert att.getNumericValue() == null;
     assert att.getNumericValue(3) == null;
-  }
 
-  @Test
-  public void testVarAtt() {
-    Variable v = ncfile.findVariable("rh");
-    assert null != v;
-
-    Attribute att = v.findAttribute(CDM.LONG_NAME);
-    assert null == att;
-
-    att = v.findAttribute("units");
+    att = ncfile.findGlobalAttribute("testFloat");
     assert null != att;
-    assert att.getStringValue().equals("percent");
-
-    att = v.findAttribute("UNITS");
-    assert null != att;
-    assert att.getStringValue().equals("percent");
-
-    att = v.findAttribute("longer_name");
-    assert null != att;
-    assert !att.isArray();
-    assert att.isString();
-    assert att.getDataType() == DataType.STRING;
-    assert att.getStringValue().equals("Abe said what?");
-  }
-
-  @Test
-  public void testStructure() {
-    Attribute att = ncfile.findGlobalAttribute("title");
-    assert null == att;
+    assert att.isArray();
+    assert !att.isString();
+    assert att.getDataType() == DataType.FLOAT;
+    assert att.getStringValue() == null;
+    assert att.getNumericValue().equals(1.0f);
+    assert att.getNumericValue(3).equals(4.0f);
 
     Dimension latDim = ncfile.findDimension("lat");
     assert null != latDim;
@@ -94,7 +94,7 @@ public class TestNcMLModifyAtts {
   }
 
   @Test
-  public void testReadCoordvar() throws IOException {
+  public void testReadCoordvar() {
     Variable lat = ncfile.findVariable("lat");
     assert null != lat;
     assert lat.getShortName().equals("lat");
@@ -116,20 +116,24 @@ public class TestNcMLModifyAtts {
     assert att.getNumericValue() == null;
     assert att.getNumericValue(3) == null;
 
-    Array data = lat.read();
-    assert data.getRank() == 1;
-    assert data.getSize() == 3;
-    assert data.getShape()[0] == 3;
-    assert data.getElementType() == float.class;
+    try {
+      Array data = lat.read();
+      assert data.getRank() == 1;
+      assert data.getSize() == 3;
+      assert data.getShape()[0] == 3;
+      assert data.getElementType() == float.class;
 
-    IndexIterator dataI = data.getIndexIterator();
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 41.0);
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 40.0);
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 39.0);
+      IndexIterator dataI = data.getIndexIterator();
+      assert nearlyEquals(dataI.getDoubleNext(), 41.0);
+      assert nearlyEquals(dataI.getDoubleNext(), 40.0);
+      assert nearlyEquals(dataI.getDoubleNext(), 39.0);
+    } catch (IOException io) {
+    }
+
   }
 
   @Test
-  public void testReadData() throws IOException {
+  public void testReadData() throws Exception {
     Variable v = ncfile.findVariable("rh");
     assert null != v;
     assert v.getShortName().equals("rh");
@@ -146,6 +150,15 @@ public class TestNcMLModifyAtts {
     assert v.getDimension(0) == ncfile.findDimension("time");
     assert v.getDimension(1) == ncfile.findDimension("lat");
     assert v.getDimension(2) == ncfile.findDimension("lon");
+
+    Attribute att = v.findAttribute("units");
+    assert null != att;
+    assert !att.isArray();
+    assert att.isString();
+    assert att.getDataType() == DataType.STRING;
+    assert att.getStringValue().equals("percent");
+    assert att.getNumericValue() == null;
+    assert att.getNumericValue(3) == null;
 
     Array data = v.read();
     assert data.getRank() == 3;
@@ -164,7 +177,7 @@ public class TestNcMLModifyAtts {
   }
 
   @Test
-  public void testReadSlice() throws IOException, InvalidRangeException {
+  public void testReadSlice() throws Exception {
     Variable v = ncfile.findVariable("rh");
     int[] origin = new int[3];
     int[] shape = {2, 3, 1};
@@ -187,7 +200,7 @@ public class TestNcMLModifyAtts {
   }
 
   @Test
-  public void testReadSlice2() throws IOException, InvalidRangeException {
+  public void testReadSlice2() throws Exception {
     Variable v = ncfile.findVariable("rh");
     int[] origin = new int[3];
     int[] shape = {2, 1, 3};
@@ -206,14 +219,12 @@ public class TestNcMLModifyAtts {
     assert dataI.getIntNext() == 21;
     assert dataI.getIntNext() == 22;
     assert dataI.getIntNext() == 23;
+
   }
 
   @Test
-  public void testReadData2() throws IOException {
-    Variable v = ncfile.findVariable("Temperature");
-    assert null == v;
-
-    v = ncfile.findVariable("T");
+  public void testReadDataAlias() throws Exception {
+    Variable v = ncfile.findVariable("T");
     assert null != v;
     assert v.getShortName().equals("T");
     assert v.getRank() == 3;
@@ -234,7 +245,7 @@ public class TestNcMLModifyAtts {
     assert null != att;
     assert !att.isArray();
     assert att.isString();
-    assert att.getDataType() == DataType.STRING;
+    assert att.getDataType() == DataType.STRING : att.getDataType();
     assert att.getStringValue().equals("degC");
     assert att.getNumericValue() == null;
     assert att.getNumericValue(3) == null;
@@ -248,10 +259,11 @@ public class TestNcMLModifyAtts {
     assert data.getElementType() == double.class;
 
     IndexIterator dataI = data.getIndexIterator();
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 1.0);
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 2.0);
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 3.0);
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 4.0);
-    Assert2.assertNearlyEquals(dataI.getDoubleNext(), 2.0);
+    assert nearlyEquals(dataI.getDoubleNext(), 1.0);
+    assert nearlyEquals(dataI.getDoubleNext(), 2.0);
+    assert nearlyEquals(dataI.getDoubleNext(), 3.0);
+    assert nearlyEquals(dataI.getDoubleNext(), 4.0);
+    assert nearlyEquals(dataI.getDoubleNext(), 2.0);
   }
+
 }

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReadOverride.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReadOverride.java
@@ -18,9 +18,9 @@ import ucar.ma2.IndexIterator;
 import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 
-public class TestNcMLReadOverride {
+public class TestNcmlReadOverride {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   static NetcdfFile ncfile = null;
@@ -29,10 +29,10 @@ public class TestNcMLReadOverride {
   public static void setUp() {
     if (ncfile != null)
       return;
-    String filename = "file:./" + TestNcMLRead.topDir + "testReadOverride.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "testReadOverride.xml";
 
     try {
-      ncfile = NcmlReader.readNcML(filename, null, null).build();
+      ncfile = NcmlReader.readNcml(filename, null, null).build();
     } catch (java.net.MalformedURLException e) {
       System.out.println("bad URL error = " + e);
     } catch (IOException e) {

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRenameVar.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRenameVar.java
@@ -20,18 +20,18 @@ import ucar.nc2.Attribute;
 import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 
-public class TestNcMLRenameVar {
+public class TestNcmlRenameVar {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   static NetcdfFile ncfile = null;
-  static String filename = "file:./" + TestNcMLRead.topDir + "renameVar.xml";
+  static String filename = "file:./" + TestNcmlRead.topDir + "renameVar.xml";
 
   @BeforeClass
   public static void setUp() {
     try {
-      ncfile = NcmlReader.readNcML(filename, null, null).build();
+      ncfile = NcmlReader.readNcml(filename, null, null).build();
     } catch (java.net.MalformedURLException e) {
       System.out.println("bad URL error = " + e);
     } catch (IOException e) {

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlValues.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlValues.java
@@ -22,7 +22,7 @@ import ucar.nc2.Variable;
 
 /** Test ncml value element in the JUnit framework. */
 
-public class TestNcMLValues {
+public class TestNcmlValues {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   NetcdfFile ncfile = null;
@@ -79,7 +79,7 @@ public class TestNcMLValues {
     }
 
     try {
-      ncfile = NcmlReader.readNcML(new StringReader(ncml), null, null).build();
+      ncfile = NcmlReader.readNcml(new StringReader(ncml), null, null).build();
     } catch (IOException e) {
       System.out.println("IO error = " + e);
       e.printStackTrace();

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestValuesFromAttribute.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestValuesFromAttribute.java
@@ -15,7 +15,7 @@ import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
-import ucar.nc2.ncml.TestNcMLRead;
+import ucar.nc2.ncml.TestNcmlRead;
 
 /** Test reading and processing NcML attributes */
 public class TestValuesFromAttribute {
@@ -35,9 +35,9 @@ public class TestValuesFromAttribute {
 
   @Test
   public void testValuesFromAttribute() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "TestValuesFromAttribute.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "TestValuesFromAttribute.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(new StringReader(ncml), filename, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(ncml), filename, null).build();
     System.out.println(" TestNcmlAggExisting.open " + filename + "\n" + ncfile);
 
     Variable newVar = ncfile.findVariable("titleAsVariable");

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExisting.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExisting.java
@@ -34,7 +34,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDirect() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -50,7 +50,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDataset() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDataset.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -65,7 +65,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilename() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDataset.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -83,7 +83,7 @@ public class TestAggExisting {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDataset.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -101,7 +101,7 @@ public class TestAggExisting {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDataset.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -116,7 +116,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetNoProtocolInNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDataset.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -131,7 +131,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilenameOrNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDataset.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -146,7 +146,7 @@ public class TestAggExisting {
 
   @Test
   public void testNcmlDatasetWcoords() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingWcoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingWcoords.xml";
 
     NetcdfFile ncfile = NetcdfDataset.openDataset(filename, true, null);
     logger.debug(" testNcmlDatasetWcoords.open {}", filename);
@@ -163,7 +163,7 @@ public class TestAggExisting {
   // remove test - now we get a coordinate initialized to missing data, but at least testCoordsAdded works!
   // @Test
   public void testNoCoords() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoords.xml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -184,7 +184,7 @@ public class TestAggExisting {
   // LOOK this test expects an Exception, but it seems to work. Why isnt this test failing in travis?
   // @Test
   public void testNoCoordsDir() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
 
     try (NetcdfDataset ncd = NetcdfDataset.openDataset(filename, true, null)) {
       System.out.printf("testNoCoordsDir supposed to fail = %s", ncd);
@@ -197,7 +197,7 @@ public class TestAggExisting {
 
   @Test
   public void testCoordsAdded() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingAddCoord.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingAddCoord.ncml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -213,14 +213,14 @@ public class TestAggExisting {
   @Test(expected = UnsupportedOperationException.class)
   public void testNcmlAggInequivalentCals() throws IOException {
     // Tests that an aggregation with inequivalent calendars across the individual datasets will fail
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
     NcMLReader.readNcML(filename, null);
   }
 
   @Test
   public void testNcmlAggExistingNoCal() throws IOException {
     // no calendar attribute in the aggregation, which should default to using proleptic_gregorian
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -254,7 +254,7 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingNoLeapCal() throws IOException {
     // with calendar = noleap, each year should have 365 days, even in a leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -282,7 +282,7 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingAllLeapCal() throws IOException {
     // with calendar = all_leap, each year should have 366 days, even in non-leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -310,7 +310,7 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingUniform30DayCal() throws IOException {
     // with calendar = uniform30day, each year should have 360 days (12 months, each with 30 days)
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
@@ -319,7 +319,7 @@ public class TestAggExisting {
     // in this NcML agg, one file uses uniform30day calendar, the other uses 360_day calendar, but
     // those are equivalent, so we let it slide. Otherwise, identical to the ncml agg used in
     // testNcmlAggExistingUniform30DayCal()
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
@@ -351,7 +351,7 @@ public class TestAggExisting {
   public void testNcmlAggExistingJulienCal() throws IOException {
     // with calendar = Julian, 4 October 1582 was followed by 5 October 1582 (unlike gregorian, where 4 October
     // was followed by 15 October).
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -410,7 +410,7 @@ public class TestAggExisting {
   @Test
   public void testNcmlAggExistingGregorianCal() throws IOException {
     // with calendar = gregorian, 4 October 1582 was followed by 15 October 1582
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -476,7 +476,7 @@ public class TestAggExisting {
   public void testNcmlAggExistingProlepticGregorianCal() throws IOException {
     // with calendar = proleptic_gregorian, 1582 and 1583 should each have 365 days
     // (for a gregorian calendar, 1852 would only have 355
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingCoordVars.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingCoordVars.java
@@ -35,7 +35,7 @@ public class TestAggExistingCoordVars extends TestCase {
   }
 
   public void testType1() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting1.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting1.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -79,7 +79,7 @@ public class TestAggExistingCoordVars extends TestCase {
       + "</netcdf>";
 
   public void testType2() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting2.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting2.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(aggExisting2), filename, null);
     logger.debug(" TestNcmlAggExisting.open {}\n{}", filename, ncfile);
@@ -115,7 +115,7 @@ public class TestAggExistingCoordVars extends TestCase {
   }
 
   public void testType3() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}\n{}", filename, ncfile);
@@ -150,7 +150,7 @@ public class TestAggExistingCoordVars extends TestCase {
   }
 
   public void testType4() throws IOException {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExisting4.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExisting4.ncml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
@@ -184,7 +184,7 @@ public class TestAggExistingCoordVars extends TestCase {
   }
 
   public void testWithDateFormatMark() throws Exception {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingOne.xml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingOne.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
@@ -221,7 +221,7 @@ public class TestAggExistingCoordVars extends TestCase {
   }
 
   public void oldTestWithDateFormatMark() throws Exception {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingOne.xml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingOne.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
@@ -264,7 +264,7 @@ public class TestAggExistingCoordVars extends TestCase {
   }
 
   public void testClimatologicalDate() throws IOException {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExisting5.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExisting5.ncml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingNew.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingNew.java
@@ -37,9 +37,9 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDirect() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
 
     testDimensions(ncfile);
@@ -53,7 +53,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDataset() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -68,7 +68,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilename() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -86,7 +86,7 @@ public class TestAggExistingNew {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -104,7 +104,7 @@ public class TestAggExistingNew {
     // if using an absolute path in the NcML file location attr of the element netcdf, then
     // you must prepend file:
     // this should fail with an IOException
-    String filename = "./" + TestNcMLRead.topDir + "exclude/aggExisting6.xml";
+    String filename = "./" + TestNcmlRead.topDir + "exclude/aggExisting6.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -119,7 +119,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetNoProtocolInNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -134,7 +134,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetNoProtocolInFilenameOrNcmlRelPath() throws IOException, InvalidRangeException {
-    String filename = "./" + TestNcMLRead.topDir + "aggExisting7.xml";
+    String filename = "./" + TestNcmlRead.topDir + "aggExisting7.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" TestNcmlAggExisting.open {}", filename);
@@ -149,7 +149,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testNcmlDatasetWcoords() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingWcoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingWcoords.xml";
 
     NetcdfFile ncfile = NetcdfDatasets.openDataset(filename, true, null);
     logger.debug(" testNcmlDatasetWcoords.open {}", filename);
@@ -166,7 +166,7 @@ public class TestAggExistingNew {
   // remove test - now we get a coordinate initialized to missing data, but at least testCoordsAdded works!
   // @Test
   public void testNoCoords() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoords.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoords.xml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -187,7 +187,7 @@ public class TestAggExistingNew {
   // LOOK this test expects an Exception, but it seems to work. Why isnt this test failing in travis?
   // @Test
   public void testNoCoordsDir() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggExistingNoCoordsDir.xml";
 
     try (NetcdfDataset ncd = NetcdfDatasets.openDataset(filename, true, null)) {
       System.out.printf("testNoCoordsDir supposed to fail = %s", ncd);
@@ -200,7 +200,7 @@ public class TestAggExistingNew {
 
   @Test
   public void testCoordsAdded() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExistingAddCoord.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExistingAddCoord.ncml";
     logger.debug("{}", filename);
     NetcdfDataset ncd = null;
 
@@ -216,16 +216,16 @@ public class TestAggExistingNew {
   @Test(expected = UnsupportedOperationException.class)
   public void testNcmlAggInequivalentCals() throws IOException {
     // Tests that an aggregation with inequivalent calendars across the individual datasets will fail
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
-    NcmlReader.readNcML(filename, null, null).build();
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingInequivalentCals.xml";
+    NcmlReader.readNcml(filename, null, null).build();
   }
 
   @Test
   public void testNcmlAggExistingNoCal() throws IOException {
     // no calendar attribute in the aggregation, which should default to using proleptic_gregorian
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoCal.xml";
 
-    Builder netcdfFileBuilder = NcmlReader.readNcML(filename, null, null);
+    Builder netcdfFileBuilder = NcmlReader.readNcml(filename, null, null);
     NetcdfFile ncfile = netcdfFileBuilder.build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
@@ -258,9 +258,9 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingNoLeapCal() throws IOException {
     // with calendar = noleap, each year should have 365 days, even in a leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingNoLeapCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -286,9 +286,9 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingAllLeapCal() throws IOException {
     // with calendar = all_leap, each year should have 366 days, even in non-leap years
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingAllLeapCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -314,7 +314,7 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingUniform30DayCal() throws IOException {
     // with calendar = uniform30day, each year should have 360 days (12 months, each with 30 days)
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingUniform30DayCal.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
@@ -323,12 +323,12 @@ public class TestAggExistingNew {
     // in this NcML agg, one file uses uniform30day calendar, the other uses 360_day calendar, but
     // those are equivalent, so we let it slide. Otherwise, identical to the ncml agg used in
     // testNcmlAggExistingUniform30DayCal()
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingEquivalentUniform30DayCals.xml";
     testNcmlAggExisting30DayCals(filename);
   }
 
   private void testNcmlAggExisting30DayCals(String filename) throws IOException {
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -355,9 +355,9 @@ public class TestAggExistingNew {
   public void testNcmlAggExistingJulienCal() throws IOException {
     // with calendar = Julian, 4 October 1582 was followed by 5 October 1582 (unlike gregorian, where 4 October
     // was followed by 15 October).
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingJulienCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -414,9 +414,9 @@ public class TestAggExistingNew {
   @Test
   public void testNcmlAggExistingGregorianCal() throws IOException {
     // with calendar = gregorian, 4 October 1582 was followed by 15 October 1582
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingGregorianCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;
@@ -480,9 +480,9 @@ public class TestAggExistingNew {
   public void testNcmlAggExistingProlepticGregorianCal() throws IOException {
     // with calendar = proleptic_gregorian, 1582 and 1583 should each have 365 days
     // (for a gregorian calendar, 1852 would only have 355
-    String filename = "file:./" + TestNcMLRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "agg_with_calendar/aggExistingProlepticGregorianCal.xml";
 
-    NetcdfFile ncfile = NcmlReader.readNcML(filename, null, null).build();
+    NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build();
     logger.debug(" TestNcmlAggExisting.open {}", filename);
     Variable timeVar = ncfile.findVariable("time");
     assert timeVar != null;

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingPromote.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggExistingPromote.java
@@ -27,7 +27,7 @@ public class TestAggExistingPromote extends TestCase {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public void testWithDateFormatMark() throws Exception {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingPromote.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingPromote.ncml";
 
     String aggExistingPromote = "<?xml version='1.0' encoding='UTF-8'?>\n"
         + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n"
@@ -143,7 +143,7 @@ public class TestAggExistingPromote extends TestCase {
    * </netcdf>
    */
   public void testNotOne() throws IOException, InvalidRangeException {
-    String filename = "file:" + TestNcMLRead.topDir + "aggExistingPromote2.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "aggExistingPromote2.ncml";
 
     String aggExistingPromote2 = "<?xml version='1.0' encoding='UTF-8'?>\n"
         + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n"

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggFmrc.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggFmrc.java
@@ -7,7 +7,6 @@ package ucar.nc2.ncml;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -51,11 +50,11 @@ public class TestAggFmrc {
    */
   @Before
   public void prepAggDataset() {
-    String filenameScan = "file:./" + TestNcMLRead.topDir + "fmrc/" + FILENAME_SCAN;
-    String filenameExplicit = "file:./" + TestNcMLRead.topDir + "fmrc/" + FILENAME_EXPLICIT;
-    String filenameA = "file:./" + TestNcMLRead.topDir + "fmrc/" + FILENAME_A;
-    String filenameB = "file:./" + TestNcMLRead.topDir + "fmrc/" + FILENAME_B;
-    String filenameC = "file:./" + TestNcMLRead.topDir + "fmrc/" + FILENAME_C;
+    String filenameScan = "file:./" + TestNcmlRead.topDir + "fmrc/" + FILENAME_SCAN;
+    String filenameExplicit = "file:./" + TestNcmlRead.topDir + "fmrc/" + FILENAME_EXPLICIT;
+    String filenameA = "file:./" + TestNcmlRead.topDir + "fmrc/" + FILENAME_A;
+    String filenameB = "file:./" + TestNcmlRead.topDir + "fmrc/" + FILENAME_B;
+    String filenameC = "file:./" + TestNcmlRead.topDir + "fmrc/" + FILENAME_C;
     try {
 
       fmrcScan = Fmrc.open(filenameScan, null);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggMisc.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggMisc.java
@@ -95,7 +95,7 @@ public class TestAggMisc {
 
   @Test
   public void testNestedScan() throws IOException, InvalidRangeException, InterruptedException {
-    String filename = "file:./" + TestNcMLRead.topDir + "nested/TestNestedDirs.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "nested/TestNestedDirs.ncml";
 
     try (NetcdfFile ncfile = NetcdfDataset.openFile(filename, null)) {
       TestDir.readAllData(ncfile);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggModify.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggModify.java
@@ -33,15 +33,10 @@
 package ucar.nc2.ncml;
 
 import junit.framework.TestCase;
-import java.io.IOException;
 import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.InvalidRangeException;
-import ucar.ma2.DataType;
-import ucar.ma2.Array;
-import ucar.ma2.IndexIterator;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 
@@ -66,7 +61,7 @@ public class TestAggModify extends TestCase {
 
   public void testWithDateFormatMark() throws Exception {
     System.out.printf("ncml=%s%n", ncml);
-    String filename = "file:" + TestNcMLRead.topDir + "testAggModify.ncml";
+    String filename = "file:" + TestNcmlRead.topDir + "testAggModify.ncml";
     NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(ncml), filename, null);
     System.out.println(" TestNcmlAggExisting.open " + filename + "\n" + ncfile);
 

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggPromote.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggPromote.java
@@ -36,7 +36,7 @@ public class TestAggPromote extends TestCase {
         + "    <scan dateFormatMark='CG#yyyyDDD_HHmmss' location='src/test/data/ncml/nc/cg/' suffix='.nc' subdirs='false' />\n"
         + "  </aggregation>\n" + "</netcdf>";
 
-    String filename = "file:./" + TestNcMLRead.topDir + "aggExisting1.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggExisting1.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(xml), null);
     System.out.println(" TestNcmlAggExisting.open " + filename);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggSynGrid.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggSynGrid.java
@@ -23,7 +23,7 @@ public class TestAggSynGrid {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   static GridDataset gds = null;
-  static final String filename = "file:./" + TestNcMLRead.topDir + "aggSynGrid.xml";
+  static final String filename = "file:./" + TestNcmlRead.topDir + "aggSynGrid.xml";
 
   @BeforeClass
   public static void setUp() throws IOException {

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggSynthetic.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggSynthetic.java
@@ -22,7 +22,7 @@ public class TestAggSynthetic {
 
   @Test
   public void test1() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynthetic.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynthetic.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
     Variable v = ncfile.findVariable("time");
@@ -42,7 +42,7 @@ public class TestAggSynthetic {
 
   @Test
   public void test2() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynthetic2.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynthetic2.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
     testDimensions(ncfile);
@@ -56,7 +56,7 @@ public class TestAggSynthetic {
 
   @Test
   public void test3() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynthetic3.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynthetic3.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
     testDimensions(ncfile);
@@ -70,7 +70,7 @@ public class TestAggSynthetic {
 
   @Test
   public void testNoCoord() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynNoCoord.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynNoCoord.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
     testDimensions(ncfile);
@@ -84,7 +84,7 @@ public class TestAggSynthetic {
 
   @Test
   public void testNoCoordDir() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynNoCoordsDir.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynNoCoordsDir.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
     testDimensions(ncfile);
@@ -98,7 +98,7 @@ public class TestAggSynthetic {
 
   @Test
   public void testJoinNewScalarCoord() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggJoinNewScalarCoord.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggJoinNewScalarCoord.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
 
     Variable v = ncfile.findVariable("time");
@@ -125,7 +125,7 @@ public class TestAggSynthetic {
         + "    <scan location='src/test/data/ncml/nc/' suffix='Dir.nc' subdirs='false'/>\n" + "  </aggregation>\n"
         + "</netcdf>";
 
-    String filename = "file:./" + TestNcMLRead.topDir + "exclude/aggSynRename.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "exclude/aggSynRename.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(xml), null);
 
     testDimensions(ncfile);
@@ -148,7 +148,7 @@ public class TestAggSynthetic {
         + "    <scan location='src/test/data/ncml/nc/' suffix='Dir.nc' subdirs='false'/>\n" + "  </aggregation>\n"
         + "</netcdf>";
 
-    String filename = "file:./" + TestNcMLRead.topDir + "aggSynScan.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggSynScan.xml";
     NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(xml), null);
 
     testDimensions(ncfile);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggTiled.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggTiled.java
@@ -29,7 +29,7 @@ public class TestAggTiled extends TestCase {
   }
 
   public void testTiled4() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "tiled/testAggTiled.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "tiled/testAggTiled.ncml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", ncfile);
@@ -68,7 +68,7 @@ public class TestAggTiled extends TestCase {
   }
 
   public void testStride() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "tiled/testAggTiled.ncml";
+    String filename = "file:./" + TestNcmlRead.topDir + "tiled/testAggTiled.ncml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(filename, null);
     logger.debug(" TestNcmlAggExisting.open {}", ncfile);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggUnion.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggUnion.java
@@ -122,7 +122,7 @@ public class TestAggUnion extends TestCase {
   public void setUp() throws IOException {
     if (ncfile != null)
       return;
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnion.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnion.xml";
     ncfile = NcMLReader.readNcML(filename, null);
   }
 

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggUnionSimple.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggUnionSimple.java
@@ -126,7 +126,7 @@ public class TestAggUnionSimple {
   public static void setUp() throws IOException {
     if (ncfile != null)
       return;
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnionSimple.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnionSimple.xml";
     ncfile = NetcdfDataset.openDataset(filename, false, null);
   }
 
@@ -293,7 +293,7 @@ public class TestAggUnionSimple {
    */
   @Test
   public void testScan() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnionScan.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnionScan.xml";
     try (NetcdfDataset scanFile = NetcdfDatasets.openDataset(filename, false, null)) {
       Assert.assertTrue(CompareNetcdf2.compareFiles(ncfile, scanFile, new Formatter(), true, false, false));
     }
@@ -301,7 +301,7 @@ public class TestAggUnionSimple {
 
   @Test
   public void testRename() throws IOException {
-    String filename = "file:./" + TestNcMLRead.topDir + "aggUnionRename.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "aggUnionRename.xml";
     try (NetcdfDataset scanFile = NetcdfDatasets.openDataset(filename, false, null)) {
       Variable v = scanFile.findVariable("LavaFlow");
       assert v != null;

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggUnsignedByte.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggUnsignedByte.java
@@ -32,7 +32,7 @@ public class TestAggUnsignedByte {
    */
   @Before
   public void prepAggDataset() {
-    String filename = "file:./" + TestNcMLRead.topDir + AGG_FILENAME;
+    String filename = "file:./" + TestNcmlRead.topDir + AGG_FILENAME;
     try {
       ncfile = NcMLReader.readNcML(filename, null);
       v = ncfile.findVariable(UBYTE_VAR_NAME);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLModifyAtts.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLModifyAtts.java
@@ -26,7 +26,7 @@ public class TestNcMLModifyAtts extends TestCase {
   NetcdfFile ncfile = null;
 
   public void setUp() throws IOException {
-    String filename = "file:" + TestNcMLRead.topDir + "modifyAtts.xml";
+    String filename = "file:" + TestNcmlRead.topDir + "modifyAtts.xml";
     ncfile = NcMLReader.readNcML(filename, null);
   }
 

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLModifyVars.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLModifyVars.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.*;
 import ucar.nc2.*;
-import ucar.nc2.ncml.NcMLReader;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
@@ -25,7 +24,7 @@ public class TestNcMLModifyVars extends TestCase {
   NetcdfFile ncfile = null;
 
   public void setUp() {
-    String filename = "file:" + TestNcMLRead.topDir + "modifyVars.xml";
+    String filename = "file:" + TestNcmlRead.topDir + "modifyVars.xml";
 
     try {
       ncfile = NcMLReader.readNcML(filename, null);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLReadOverride.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLReadOverride.java
@@ -26,7 +26,7 @@ public class TestNcMLReadOverride extends TestCase {
   public void setUp() {
     if (ncfile != null)
       return;
-    String filename = "file:./" + TestNcMLRead.topDir + "testReadOverride.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "testReadOverride.xml";
 
     try {
       ncfile = NcMLReader.readNcML(filename, null);

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLRenameVar.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLRenameVar.java
@@ -22,7 +22,7 @@ public class TestNcMLRenameVar extends TestCase {
   }
 
   NetcdfFile ncfile = null;
-  String filename = "file:./" + TestNcMLRead.topDir + "renameVar.xml";
+  String filename = "file:./" + TestNcmlRead.topDir + "renameVar.xml";
 
   public void setUp() {
     try {

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLequals.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcMLequals.java
@@ -20,8 +20,8 @@ public class TestNcMLequals {
 
   @Test
   public void testEquals() throws IOException {
-    testEquals("file:" + TestNcMLRead.topDir + "testEquals.xml");
-    testEnhanceEquals("file:" + TestNcMLRead.topDir + "testEquals.xml");
+    testEquals("file:" + TestNcmlRead.topDir + "testEquals.xml");
+    testEnhanceEquals("file:" + TestNcmlRead.topDir + "testEquals.xml");
   }
 
   public void problem() throws IOException {

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlRead.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlRead.java
@@ -15,11 +15,11 @@ import ucar.unidata.util.test.TestDir;
 
 /** Test netcdf dataset in the JUnit framework. */
 
-public class TestNcMLRead extends TestCase {
+public class TestNcmlRead extends TestCase {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   public static String topDir = TestDir.cdmLocalTestDataDir + "ncml/";
 
-  public TestNcMLRead(String name) {
+  public TestNcmlRead(String name) {
     super(name);
   }
 
@@ -254,7 +254,7 @@ public class TestNcMLRead extends TestCase {
     return Math.abs((d1 - d2) / d1) < 1.0e-5;
   }
 
-  static public class TestRead2 extends TestNcMLRead {
+  static public class TestRead2 extends TestNcmlRead {
 
     // equivalent dataset using "readMetadata"
     public TestRead2(String name) {
@@ -264,7 +264,7 @@ public class TestNcMLRead extends TestCase {
     }
   }
 
-  static public class TestReadHttps extends TestNcMLRead {
+  static public class TestReadHttps extends TestNcmlRead {
 
     // equivalent dataset using "readMetadata"
     public TestReadHttps(String name) {

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlReaderProblems.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlReaderProblems.java
@@ -24,7 +24,7 @@ public class TestNcmlReaderProblems {
     // This used to fail in NcmlReader. Succeeds in NcmlReaderNew, but doesnt get the time coordinates right.
     // compare("file:" + TestNcMLRead.topDir + "exclude/aggExistingNoCoordsDir.xml");
 
-    compare("file:" + TestNcMLRead.topDir + "aggUbyte.ncml");
+    compare("file:" + TestNcmlRead.topDir + "aggUbyte.ncml");
   }
 
   private void compare(String ncmlLocation) throws IOException {
@@ -32,8 +32,8 @@ public class TestNcmlReaderProblems {
     logger.info("TestNcmlReaders on {}%n", ncmlLocation);
     try (NetcdfDataset org = NcMLReader.readNcML(ncmlLocation, null)) {
       System.out.printf("NcMLReader == %s%n", org);
-      try (NetcdfDataset withBuilder = NcmlReader.readNcML(ncmlLocation, null, null).build()) {
-        System.out.printf("NcMLReaderNew == %s%n", withBuilder);
+      try (NetcdfDataset withBuilder = NcmlReader.readNcml(ncmlLocation, null, null).build()) {
+        System.out.printf("NcmlReaderNew == %s%n", withBuilder);
         Formatter f = new Formatter();
         CompareNetcdf2 compare = new CompareNetcdf2(f, true, true, true);
         boolean ok = compare.compare(org, withBuilder, new TestNcmlReadersCompare.CoordsObjFilter());

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlReadersCompare.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlReadersCompare.java
@@ -36,7 +36,7 @@ public class TestNcmlReadersCompare {
   public static Collection<Object[]> getTestParameters() {
     Collection<Object[]> filenames = new ArrayList<>();
     try {
-      TestDir.actOnAllParameterized(TestNcMLRead.topDir, new NcmlFilter(), filenames, true);
+      TestDir.actOnAllParameterized(TestNcmlRead.topDir, new NcmlFilter(), filenames, true);
     } catch (IOException e) {
       filenames.add(new Object[] {e.getMessage()});
     }
@@ -54,7 +54,7 @@ public class TestNcmlReadersCompare {
     logger.info("TestNcmlReaders on {}%n", ncmlLocation);
     System.out.printf("Compare %s%n", ncmlLocation);
     try (NetcdfDataset org = NcMLReader.readNcML(ncmlLocation, null)) {
-      try (NetcdfDataset withBuilder = NcmlReader.readNcML(ncmlLocation, null, null).build()) {
+      try (NetcdfDataset withBuilder = NcmlReader.readNcml(ncmlLocation, null, null).build()) {
         Formatter f = new Formatter();
         CompareNetcdf2 compare = new CompareNetcdf2(f, false, false, true);
         if (!compare.compare(org, withBuilder, new CoordsObjFilter())) {

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestValuesFromAttribute.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestValuesFromAttribute.java
@@ -60,7 +60,7 @@ public class TestValuesFromAttribute extends TestCase {
       + "     <values fromAttribute='time@actual_range'/>\n" + "   </variable>\n" + "</netcdf>";
 
   public void testValuesFromAttribute() throws IOException, InvalidRangeException {
-    String filename = "file:./" + TestNcMLRead.topDir + "TestValuesFromAttribute.xml";
+    String filename = "file:./" + TestNcmlRead.topDir + "TestValuesFromAttribute.xml";
 
     NetcdfFile ncfile = NcMLReader.readNcML(new StringReader(ncml), filename, null);
     System.out.println(" TestNcmlAggExisting.open " + filename + "\n" + ncfile);


### PR DESCRIPTION
New deprecation in NcmlCollectionReader (readNcML -> readNcml)

![kamel time?](https://media1.tenor.com/images/28f90ddc824f6ec38ff6c8a696e6f6d1/tenor.gif)