### PR TITLE
Add Java 11 to the test matrix

### DIFF
--- a/.github/workflows/netcdf-java.yml
+++ b/.github/workflows/netcdf-java.yml
@@ -4,12 +4,16 @@ jobs:
   tests-zulu:
     name: netCDF-Java Tests (Zulu JDK)
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # test against latest 8 and 11
+        java: [ 8, 11 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Zulu JDK 1.8
+      - name: Setup java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: ${{ matrix.java }}
           architecture: x64
       - name: Install netCDF-C
         run: sudo apt update && sudo apt-get install libnetcdf-dev
@@ -23,10 +27,10 @@ jobs:
         run: ./gradlew --info --stacktrace testAll
         env:
           TRAVIS: 'true'
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: netCDF-Java_JUnit_Results_${{ github.sha }}_Zulu-JDK-8
+          name: netCDF-Java_JUnit_Results_${{ github.sha }}_Zulu-JDK-${{ matrix.java }}
           path: build/reports/allTests
 
   tests-adpotopenjdk-hs-8:
@@ -56,10 +60,43 @@ jobs:
         run: ./gradlew --info --stacktrace testAll
         env:
           TRAVIS: 'true'
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: netCDF-Java_JUnit_Results_${{ github.sha }}_AdoptOpenJDK-HS-8
+          path: build/reports/allTests
+
+  tests-adpotopenjdk-hs-11:
+    name: netCDF-Java Tests (AdoptOpenJDK-HS 11)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch latest AdoptOpenJDK 11 (hotspot) built for linux"
+        run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk11-hs.tar.gz
+      - name: Setup Latest AdoptOpenJDK (hotspot) 11
+        uses: actions/setup-java@master
+        with:
+          java-version: 11
+          architecture: x64
+          jdkFile: ./aojdk11-hs.tar.gz
+      - name: Print java version
+        run: java -version
+      - name: Install netCDF-C
+        run: sudo apt update && sudo apt-get install libnetcdf-dev
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and test with Gradle
+        run: ./gradlew --info --stacktrace testAll
+        env:
+          TRAVIS: 'true'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: netCDF-Java_JUnit_Results_${{ github.sha }}_AdoptOpenJDK-HS-11
           path: build/reports/allTests
 
   spotless:

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/AlbersEqualArea.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/AlbersEqualArea.java
@@ -21,6 +21,10 @@ public class AlbersEqualArea extends AbstractProjection {
   private final double falseEasting, falseNorthing;
   private final double earth_radius; // radius in km
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _lat0, _lon0;
+
   /** constants from Snyder's equations */
   private final double n, C, rho0, lon0Degrees;
 
@@ -84,6 +88,9 @@ public class AlbersEqualArea extends AbstractProjection {
   public AlbersEqualArea(double lat0, double lon0, double par1, double par2, double falseEasting, double falseNorthing,
       double earth_radius) {
     super("AlbersEqualArea", false);
+
+    this._lat0 = lat0;
+    this._lon0 = lon0;
 
     this.lon0Degrees = lon0;
     this.lat0 = Math.toRadians(lat0);
@@ -208,21 +215,21 @@ public class AlbersEqualArea extends AbstractProjection {
   }
 
   /**
-   * Get the origin longitude.
+   * Get the origin longitude in degrees.
    *
-   * @return the origin longitude.
+   * @return the origin longitude in degrees.
    */
   public double getOriginLon() {
-    return Math.toDegrees(lon0);
+    return _lon0;
   }
 
   /**
-   * Get the origin latitude.
+   * Get the origin latitude in degrees.
    *
-   * @return the origin latitude.
+   * @return the origin latitude in degrees.
    */
   public double getOriginLat() {
-    return Math.toDegrees(lat0);
+    return _lat0;
   }
 
   /**
@@ -264,7 +271,7 @@ public class AlbersEqualArea extends AbstractProjection {
 
   @Override
   public String toString() {
-    return "AlbersEqualArea{" + "lat0=" + lat0 + ", lon0=" + lon0 + ", par1=" + par1 + ", par2=" + par2
+    return "AlbersEqualArea{" + "lat0=" + _lat0 + ", lon0=" + _lon0 + ", par1=" + par1 + ", par2=" + par2
         + ", falseEasting=" + falseEasting + ", falseNorthing=" + falseNorthing + ", earth_radius=" + earth_radius
         + '}';
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/FlatEarth.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/FlatEarth.java
@@ -28,6 +28,10 @@ public class FlatEarth extends AbstractProjection {
   private final double rotAngle, radius;
   private final double lat0, lon0; // center lat/lon in radians
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _lat0, _lon0;
+
   private final double cosRot, sinRot;
 
   @Override
@@ -60,6 +64,9 @@ public class FlatEarth extends AbstractProjection {
    */
   public FlatEarth(double lat0, double lon0, double rotAngle, double radius) {
     super("FlatEarth", false);
+
+    this._lat0 = lat0;
+    this._lon0 = lon0;
 
     this.lat0 = Math.toRadians(lat0);
     this.lon0 = Math.toRadians(lon0);
@@ -114,21 +121,21 @@ public class FlatEarth extends AbstractProjection {
   // bean properties
 
   /**
-   * Get the origin longitude.
+   * Get the origin longitude in degrees.
    *
-   * @return the origin longitude.
+   * @return the origin longitude in degrees.
    */
   public double getOriginLon() {
-    return Math.toDegrees(lon0);
+    return _lon0;
   }
 
   /**
-   * Get the origin latitude.
+   * Get the origin latitude in degrees.
    *
-   * @return the origin latitude.
+   * @return the origin latitude in degrees.
    */
   public double getOriginLat() {
-    return Math.toDegrees(lat0);
+    return _lat0;
   }
 
   /**
@@ -152,7 +159,7 @@ public class FlatEarth extends AbstractProjection {
 
   @Override
   public String toString() {
-    return "FlatEarth{" + "rotAngle=" + rotAngle + ", radius=" + radius + ", lat0=" + lat0 + ", lon0=" + lon0 + '}';
+    return "FlatEarth{" + "rotAngle=" + rotAngle + ", radius=" + radius + ", lat0=" + _lat0 + ", lon0=" + _lon0 + '}';
   }
 
   @Override

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertAzimuthalEqualArea.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertAzimuthalEqualArea.java
@@ -24,8 +24,12 @@ public class LambertAzimuthalEqualArea extends AbstractProjection {
   /** constants from Snyder's equations */
   private final double R, sinLat0, cosLat0, lon0Degrees;
 
-  private final double lat0, lon0; // center lat/lon in degrees
+  private final double lat0, lon0; // center lat/lon in radians
   private final double falseEasting, falseNorthing;
+
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _lat0;
 
   @Override
   public Projection constructCopy() {
@@ -62,6 +66,8 @@ public class LambertAzimuthalEqualArea extends AbstractProjection {
   public LambertAzimuthalEqualArea(double lat0, double lon0, double false_easting, double false_northing,
       double earthRadius) {
     super("LambertAzimuthalEqualArea", false);
+
+    this._lat0 = lat0;
 
     this.lat0 = Math.toRadians(lat0);
     this.lon0 = Math.toRadians(lon0);
@@ -132,21 +138,21 @@ public class LambertAzimuthalEqualArea extends AbstractProjection {
   // bean properties
 
   /**
-   * Get the origin longitude.
+   * Get the origin longitude in degrees.
    *
-   * @return the origin longitude.
+   * @return the origin longitude in degrees.
    */
   public double getOriginLon() {
-    return Math.toDegrees(lon0);
+    return lon0Degrees;
   }
 
   /**
-   * Get the origin latitude.
+   * Get the origin latitude in degrees.
    *
-   * @return the origin latitude.
+   * @return the origin latitude in degrees.
    */
   public double getOriginLat() {
-    return Math.toDegrees(lat0);
+    return _lat0;
   }
 
   /**
@@ -188,7 +194,7 @@ public class LambertAzimuthalEqualArea extends AbstractProjection {
   @Override
   public String toString() {
     return "LambertAzimuthalEqualArea{" + "falseNorthing=" + falseNorthing + ", falseEasting=" + falseEasting
-        + ", lon0=" + lon0 + ", lat0=" + lat0 + ", R=" + R + '}';
+        + ", lon0=" + lon0Degrees + ", lat0=" + _lat0 + ", R=" + R + '}';
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
@@ -25,6 +25,10 @@ public class LambertConformal extends AbstractProjection {
   private final double par1, par2; // standard parallel 1 and 2 degrees
   private final double falseEasting, falseNorthing;
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _lat0, _lon0;
+
   private final double n, F, rho; // constants from Snyder's equations
   private final double earthRadiusTimesF;// Earth's radius time F
   private final double lon0Degrees; // lon naught ??
@@ -91,6 +95,9 @@ public class LambertConformal extends AbstractProjection {
       double false_northing, double earth_radius) {
 
     super("LambertConformal", false);
+
+    this._lat0 = lat0;
+    this._lon0 = lon0;
 
     this.lon0Degrees = lon0;
     this.lat0 = Math.toRadians(lat0);
@@ -234,19 +241,19 @@ public class LambertConformal extends AbstractProjection {
   /**
    * Get the origin longitude in degrees
    *
-   * @return the origin longitude.
+   * @return the origin longitude in degrees.
    */
   public double getOriginLon() {
-    return Math.toDegrees(lon0);
+    return _lon0;
   }
 
   /**
    * Get the origin latitude in degrees
    *
-   * @return the origin latitude.
+   * @return the origin latitude in degrees.
    */
   public double getOriginLat() {
-    return Math.toDegrees(lat0);
+    return _lat0;
   }
 
   /**
@@ -287,9 +294,8 @@ public class LambertConformal extends AbstractProjection {
 
   @Override
   public String toString() {
-    return "LambertConformal{" + "earth_radius=" + earth_radius + ", lat0=" + Math.toDegrees(lat0) + ", lon0="
-        + Math.toDegrees(lon0) + ", par1=" + par1 + ", par2=" + par2 + ", falseEasting=" + falseEasting
-        + ", falseNorthing=" + falseNorthing + '}';
+    return "LambertConformal{" + "earth_radius=" + earth_radius + ", lat0=" + _lat0 + ", lon0=" + _lon0 + ", par1="
+        + par1 + ", par2=" + par2 + ", falseEasting=" + falseEasting + ", falseNorthing=" + falseNorthing + '}';
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Orthographic.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Orthographic.java
@@ -22,6 +22,10 @@ public class Orthographic extends AbstractProjection {
   private double lon0Degrees;
   private double cosLat0, sinLat0;
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private double _lat0;
+
   @Override
   public Projection constructCopy() {
     return new Orthographic(getOriginLat(), getOriginLon(), R);
@@ -52,6 +56,7 @@ public class Orthographic extends AbstractProjection {
   public Orthographic(double lat0, double lon0, double earthRadius) {
     super("Orthographic", false);
 
+    this._lat0 = lat0;
     this.lon0Degrees = lon0;
     this.lat0 = Math.toRadians(lat0);
     this.lon0 = Math.toRadians(lon0);
@@ -105,7 +110,7 @@ public class Orthographic extends AbstractProjection {
    * @return the origin longitude.
    */
   public double getOriginLon() {
-    return Math.toDegrees(lon0);
+    return lon0Degrees;
   }
 
   /**
@@ -114,7 +119,7 @@ public class Orthographic extends AbstractProjection {
    * @return the origin latitude.
    */
   public double getOriginLat() {
-    return Math.toDegrees(lat0);
+    return _lat0;
   }
 
   @Override
@@ -129,7 +134,7 @@ public class Orthographic extends AbstractProjection {
 
   @Override
   public String toString() {
-    return "Orthographic{" + "lat0=" + lat0 + ", lon0=" + lon0 + ", R=" + R + '}';
+    return "Orthographic{" + "lat0=" + _lat0 + ", lon0=" + lon0Degrees + ", R=" + R + '}';
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Stereographic.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Stereographic.java
@@ -42,6 +42,12 @@ public class Stereographic extends AbstractProjection {
   private boolean isNorth;
   private boolean isPolar;
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _latts;
+  private final double _latt;
+  private final double _lont;
+
   @Override
   public Projection constructCopy() {
     return new Stereographic(getTangentLat(), getTangentLon(), getScale(), getFalseEasting(), getFalseNorthing(),
@@ -89,6 +95,10 @@ public class Stereographic extends AbstractProjection {
   public Stereographic(double lat_ts_deg, double latt_deg, double lont_deg, boolean north) {
     super("PolarStereographic", false);
 
+    this._latts = lat_ts_deg;
+    this._latt = latt_deg;
+    this._lont = lont_deg;
+
     this.latts = Math.toRadians(lat_ts_deg);
     this.latt = Math.toRadians(latt_deg);
     this.lont = Math.toRadians(lont_deg);
@@ -123,6 +133,10 @@ public class Stereographic extends AbstractProjection {
   public Stereographic(double latt, double lont, double scale, double false_easting, double false_northing,
       double radius) {
     super("Stereographic", false);
+
+    this._latts = 0.0;
+    this._latt = latt;
+    this._lont = lont;
 
     this.latt = Math.toRadians(latt);
     this.lont = Math.toRadians(lont);
@@ -187,30 +201,30 @@ public class Stereographic extends AbstractProjection {
   }
 
   /**
-   * Get the latitude at natural origin
+   * Get the latitude at natural origin in degrees
    *
    * @return latitude at natural origin
    */
   public double getNaturalOriginLat() {
-    return Math.toDegrees(latts);
+    return _latts;
   }
 
   /**
    * Get the tangent longitude in degrees
    *
-   * @return the origin longitude.
+   * @return the origin longitude in degrees.
    */
   public double getTangentLon() {
-    return Math.toDegrees(lont);
+    return _lont;
   }
 
   /**
    * Get the tangent latitude in degrees
    *
-   * @return the origin latitude.
+   * @return the origin latitude in degrees.
    */
   public double getTangentLat() {
-    return Math.toDegrees(latt);
+    return _latt;
   }
 
   public double getEarthRadius() {
@@ -235,7 +249,7 @@ public class Stereographic extends AbstractProjection {
   @Override
   public String toString() {
     return "Stereographic{" + "falseEasting=" + falseEasting + ", falseNorthing=" + falseNorthing + ", scale=" + scale
-        + ", earthRadius=" + earthRadius + ", latt=" + latt + ", lont=" + lont + '}';
+        + ", earthRadius=" + earthRadius + ", latt=" + _latt + ", lont=" + _lont + '}';
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/TransverseMercator.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/TransverseMercator.java
@@ -24,6 +24,10 @@ public class TransverseMercator extends AbstractProjection {
   private final double lat0, lon0, scale, earthRadius;
   private final double falseEasting, falseNorthing;
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _lat0, _lon0, _scale;
+
   @Override
   public AbstractProjection constructCopy() {
     return new TransverseMercator(getOriginLat(), getTangentLon(), getScale(), getFalseEasting(), getFalseNorthing(),
@@ -74,6 +78,10 @@ public class TransverseMercator extends AbstractProjection {
   public TransverseMercator(double lat0, double tangentLon, double scale, double east, double north, double radius) {
     super("TransverseMercator", false);
 
+    this._lon0 = tangentLon;
+    this._lat0 = lat0;
+    this._scale = scale;
+
     this.lat0 = Math.toRadians(lat0);
     this.lon0 = Math.toRadians(tangentLon);
     this.earthRadius = radius;
@@ -102,26 +110,26 @@ public class TransverseMercator extends AbstractProjection {
    * @return the scale
    */
   public double getScale() {
-    return scale / earthRadius;
+    return _scale;
   }
 
 
   /**
    * Get the tangent longitude in degrees
    *
-   * @return the origin longitude.
+   * @return the origin longitude in degrees.
    */
   public double getTangentLon() {
-    return Math.toDegrees(lon0);
+    return _lon0;
   }
 
   /**
    * Get the origin latitude in degrees
    *
-   * @return the origin latitude.
+   * @return the origin latitude in degrees.
    */
   public double getOriginLat() {
-    return Math.toDegrees(lat0);
+    return _lat0;
   }
 
   /**
@@ -167,7 +175,7 @@ public class TransverseMercator extends AbstractProjection {
 
   @Override
   public String toString() {
-    return "TransverseMercator{" + "lat0=" + lat0 + ", lon0=" + lon0 + ", scale=" + scale + ", earthRadius="
+    return "TransverseMercator{" + "lat0=" + _lat0 + ", lon0=" + _lon0 + ", scale=" + _scale + ", earthRadius="
         + earthRadius + ", falseEasting=" + falseEasting + ", falseNorthing=" + falseNorthing + '}';
   }
 

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/PolyconicProjection.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/PolyconicProjection.java
@@ -72,6 +72,10 @@ public class PolyconicProjection extends AbstractProjection {
   private final double falseNorthing;
   private final double totalScale;
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _lat0, _lon0;
+
   public PolyconicProjection() {
     this(23.56, 76.54);
   }
@@ -86,6 +90,9 @@ public class PolyconicProjection extends AbstractProjection {
 
   public PolyconicProjection(double lat0, double lon0, double falseEasting, double falseNorthing, Earth ellipsoid) {
     super("Polyconic", false);
+
+    this._lat0 = lat0;
+    this._lon0 = lon0;
 
     // Initialization
     this.projectionLatitude = Math.toRadians(lat0);
@@ -280,7 +287,7 @@ public class PolyconicProjection extends AbstractProjection {
    * @return the origin longitude in degrees
    */
   public double getOriginLatitude() {
-    return Math.toDegrees(projectionLatitude);
+    return _lat0;
   }
 
   /**
@@ -289,7 +296,7 @@ public class PolyconicProjection extends AbstractProjection {
    * @return the origin longitude in degrees
    */
   public double getOriginLongitude() {
-    return Math.toDegrees(projectionLongitude);
+    return _lon0;
   }
 
   /**
@@ -327,8 +334,7 @@ public class PolyconicProjection extends AbstractProjection {
   @Override
   public String paramsToString() {
     Formatter f = new Formatter();
-    f.format("origin lat=%f, origin lon=%f earth=%s", Math.toDegrees(projectionLatitude),
-        Math.toDegrees(projectionLongitude), ellipsoid);
+    f.format("origin lat=%f, origin lon=%f earth=%s", _lat0, _lon0, ellipsoid);
     return f.toString();
   }
 

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/StereographicAzimuthalProjection.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/StereographicAzimuthalProjection.java
@@ -39,6 +39,12 @@ public class StereographicAzimuthalProjection extends AbstractProjection {
   private static final int OBLIQUE = 4;
   private static final double TOL = 1.e-8;
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _latt;
+  private final double _lont;
+  private final double _trueScaleLat;
+
   // projection parameters
   private final double projectionLatitude, projectionLongitude; // origin in radian
   private final double n; // Math.sin(projectionLatitude)
@@ -72,6 +78,10 @@ public class StereographicAzimuthalProjection extends AbstractProjection {
   public StereographicAzimuthalProjection(double latt, double lont, double scale, double trueScaleLat,
       double false_easting, double false_northing, Earth earth) {
     super("StereographicAzimuthalProjection", false);
+
+    _latt = latt;
+    _lont = lont;
+    _trueScaleLat = trueScaleLat;
 
     projectionLatitude = Math.toRadians(latt);
     n = Math.abs(Math.sin(projectionLatitude));
@@ -340,15 +350,14 @@ public class StereographicAzimuthalProjection extends AbstractProjection {
 
   @Override
   public Projection constructCopy() {
-    return new StereographicAzimuthalProjection(Math.toDegrees(projectionLatitude), Math.toDegrees(projectionLongitude),
-        scaleFactor, Math.toDegrees(trueScaleLatitude), falseEasting, falseNorthing, earth);
+    return new StereographicAzimuthalProjection(_latt, _lont, scaleFactor, _trueScaleLat, falseEasting, falseNorthing,
+        earth);
   }
 
   @Override
   public String paramsToString() {
     Formatter f = new Formatter();
-    f.format("origin lat,lon=%f,%f scale,trueScaleLat=%f,%f earth=%s", Math.toDegrees(projectionLatitude),
-        Math.toDegrees(projectionLongitude), scaleFactor, Math.toDegrees(trueScaleLatitude), earth);
+    f.format("origin lat,lon=%f,%f scale,trueScaleLat=%f,%f earth=%s", _latt, _lont, scaleFactor, _trueScaleLat, earth);
     return f.toString();
   }
 

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/TransverseMercatorProjection.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/TransverseMercatorProjection.java
@@ -79,6 +79,11 @@ public class TransverseMercatorProjection extends AbstractProjection {
   private final double totalScale; // scale to convert cartesian coords in km
   private final boolean spherical;
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private final double _lat0;
+  private final double _lon0;
+
   public TransverseMercatorProjection() {
     this(EarthEllipsoid.WGS84, 0, 0, 0.9996, 0, 0);
   }
@@ -94,6 +99,10 @@ public class TransverseMercatorProjection extends AbstractProjection {
   public TransverseMercatorProjection(Earth ellipsoid, double lon_0_deg, double lat_0_deg, double k, double falseEast,
       double falseNorth) {
     super("TransverseMercatorProjection", false);
+
+    this._lat0 = lat_0_deg;
+    this._lon0 = lon_0_deg;
+
     this.ellipsoid = ellipsoid;
     projectionLongitude = Math.toRadians(lon_0_deg);
     projectionLatitude = Math.toRadians(lat_0_deg);
@@ -217,15 +226,14 @@ public class TransverseMercatorProjection extends AbstractProjection {
 
   @Override
   public Projection constructCopy() {
-    return new TransverseMercatorProjection(ellipsoid, Math.toDegrees(projectionLongitude),
-        Math.toDegrees(projectionLatitude), scaleFactor, falseEasting, falseNorthing);
+    return new TransverseMercatorProjection(ellipsoid, _lon0, _lat0, scaleFactor, falseEasting, falseNorthing);
   }
 
   @Override
   public String paramsToString() {
     Formatter f = new Formatter();
-    f.format("origin lat,lon=%f,%f scale=%f earth=%s falseEast/North=%f,%f", Math.toDegrees(projectionLatitude),
-        Math.toDegrees(projectionLongitude), scaleFactor, ellipsoid, falseEasting, falseNorthing);
+    f.format("origin lat,lon=%f,%f scale=%f earth=%s falseEast/North=%f,%f", _lat0, _lon0, scaleFactor, ellipsoid,
+        falseEasting, falseNorthing);
     return f.toString();
   }
 

--- a/gradle/root/sonarqube.gradle
+++ b/gradle/root/sonarqube.gradle
@@ -26,7 +26,7 @@ apply plugin: 'org.sonarqube'
 
 apply from: "$rootDir/gradle/any/properties.gradle"  // For SonarQube user token.
 
-def grgit = Grgit.open()
+def grgit = Grgit.open(currentDir: project.rootDir)
 def branchName = grgit.branch.current.name
 grgit.close()
 


### PR DESCRIPTION
Even though we require Java 8, since we've upgraded Gradle, we can now start testing on Java 11. Let's see how this goes.