### PR TITLE
Publish javadoc set with deprecations

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -21,15 +21,36 @@ gradle.projectsEvaluated {  // Several statements below rely upon all subproject
     SourceSet cdmCoreSourceSet = rootProject.project(':cdm:cdm-core').sourceSets.main
     source cdmCoreSourceSet.allJava
 
-    SourceSet cdmImageSourceSet = rootProject.project(':cdm:cdm-image').sourceSets.main
-    source cdmImageSourceSet.allJava
+    classpath = files([cdmCoreSourceSet.compileClasspath, cdmCoreSourceSet.output])
 
-    SourceSet cdmRadialSourceSet = rootProject.project(':cdm:cdm-radial').sourceSets.main
-    source cdmRadialSourceSet.allJava
+    // This is the public interface. Future changes to the API will attempt to remain backwards compatible with it.
+    include 'thredds/client/catalog/*.java'
+    include 'thredds/client/catalog/builder/*.java'
+    include 'ucar/ma2/*.java'
+    include 'ucar/nc2/*.java'
+    include 'ucar/nc2/constants/*.java'
+    include 'ucar/nc2/dataset/*.java'
+    include 'ucar/nc2/dataset/spi/*.java'
+    include 'ucar/nc2/iosp/*.java'
+    include 'ucar/nc2/time/*.java'
+    include 'ucar/nc2/units/*.java'
+    include 'ucar/nc2/util/*.java'
+    include 'ucar/nc2/write/*.java'
+    include 'ucar/unidata/geoloc/*.java'
+    include 'ucar/unidata/io/*.java'
+    include 'ucar/unidata/io/spi/*.java'
+  }
 
-    classpath = files([cdmCoreSourceSet.compileClasspath, cdmCoreSourceSet.output,
-                       cdmImageSourceSet.compileClasspath, cdmImageSourceSet.output,
-                       cdmRadialSourceSet.compileClasspath, cdmRadialSourceSet.output])
+  task buildJavadocPublicApiWithDeps(type: Javadoc) {
+    description = 'Generate Javadoc for the CDM subproject - included deprecated classes and methods.'
+
+    title = "NetCDF-Java CDM Public API v${version} - with deprecations"
+    destinationDir = file("$buildDir/javadocCdmWithDeps/")
+
+    SourceSet cdmCoreSourceSet = rootProject.project(':cdm:cdm-core').sourceSets.main
+    source cdmCoreSourceSet.allJava
+
+    classpath = files([cdmCoreSourceSet.compileClasspath, cdmCoreSourceSet.output])
 
     // This is the public interface. Future changes to the API will attempt to remain backwards compatible with it.
     include 'thredds/client/catalog/*.java'
@@ -121,6 +142,20 @@ gradle.projectsEvaluated {
     destPath = 'netcdf-java/current/javadoc/'
   }
 
+  task publishAsVersionedJavadocPublicApiWithDeps(type: PublishToRawRepoTask, dependsOn: buildJavadocPublicApiWithDeps) {
+    description = 'Publish Javadoc for the CDM subproject to Nexus under /major.minor/.'
+
+    publishSrc = tasks.buildJavadocPublicApiWithDeps.destinationDir
+    destPath = "netcdf-java/$project.docVersion/javadoc-with-deprecations/"
+  }
+
+  task publishAsCurrentJavadocPublicApiWithDeps(type: PublishToRawRepoTask, dependsOn: buildJavadocPublicApiWithDeps) {
+    description = 'Publish Javadoc for the CDM subproject to Nexus under /current/.'
+
+    publishSrc = tasks.buildJavadocPublicApiWithDeps.destinationDir
+    destPath = 'netcdf-java/current/javadoc-with-deprecations/'
+  }
+
   task publishAsVersionedJavadocAll(type: PublishToRawRepoTask, dependsOn: buildJavadocAll) {
     description = 'Publish Javadoc for all Java subprojects to Nexus under /major.minor/.'
 
@@ -142,14 +177,16 @@ gradle.projectsEvaluated {
     description = 'Publish user guide and both Javadoc sets to Nexus under /major.minor/.'
 
     // Aggregates the individual "publish*" tasks.
-    dependsOn publishAsVersionedUserGuide, publishAsVersionedJavadocPublicApi, publishAsVersionedJavadocAll
+    dependsOn publishAsVersionedUserGuide, publishAsVersionedJavadocPublicApi,
+        publishAsVersionedJavadocPublicApiWithDeps, publishAsVersionedJavadocAll
   }
 
   task publishAllDocsAsCurrent(group: 'Documentation') {
     description = 'Publish user guide and both Javadoc sets to Nexus under /current/.'
 
     // Aggregates the individual "publish*" tasks.
-    dependsOn publishAsCurrentUserGuide, publishAsCurrentJavadocPublicApi, publishAsCurrentJavadocAll
+    dependsOn publishAsCurrentUserGuide, publishAsCurrentJavadocPublicApi, publishAsCurrentJavadocPublicApiWithDeps,
+        publishAsCurrentJavadocAll
   }
 }
 

--- a/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
+++ b/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
@@ -282,7 +282,3 @@ entries:
     - title: Unidata Defined System Properties
       url: /systemproperties.html
       output: web, pdf
-
-    - title: 5.0 Changes
-      url: /upgrade_to_50.html
-      output: web, pdf

--- a/docs/src/public/userguide/_data/topnav.yml
+++ b/docs/src/public/userguide/_data/topnav.yml
@@ -34,6 +34,8 @@ topnav_dropdowns:
       folderitems:
         - title: netCDF-Java Public Javadocs
           external_url: ../javadoc/
+        - title: netCDF-Java Public Javadocs (including deprecations)
+          external_url: ../javadoc-with-deprecations/
 
     - title: External Docs
       folderitems:

--- a/docs/src/public/userguide/pages/netcdfJava/UpgradeTo50.md
+++ b/docs/src/public/userguide/pages/netcdfJava/UpgradeTo50.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading to netCDF-Java version 5.x
-last_updated: 2019-12-31
+last_updated: 2020-07-20
 sidebar: netcdfJavaTutorial_sidebar
 toc: false
 permalink: upgrade_to_50.html
@@ -299,6 +299,9 @@ For more information, see the [DatasetUrl](dataset_urls.html#object-stores) docu
 
 ## netCDF-Java API Changes (5.4.x)
 
-List of GitHub commits since 5.3.2 release ([link](https://github.com/Unidata/netcdf-java/compare/v5.3.2...master){:target="_blank"})
+List of GitHub commits since 5.3.3 release ([link](https://github.com/Unidata/netcdf-java/compare/v5.3.3...master){:target="_blank"})
 
-Lots of work on establishing a public API. For more information about these efforts and why this work is being done, please visit https://www.unidata.ucar.edu/blogs/developer/en/entry/netcdf-java-looking-ahead.
+Much of the work in 5.4.x is focused on establishing a public API.
+We now publish two sets of javadocs - [with](../javadoc-with-deprecations/){:target="_blank"} and [without deprecations](../javadoc/){:target="_blank"}.
+For more information about these efforts and why this work is being done, please visit <https://www.unidata.ucar.edu/blogs/developer/en/entry/netcdf-java-looking-ahead>.
+Only those classes and methods outlined in the javadocs [without deprecations](../javadoc/) will exist in the next major release of netCDF-Java (`v6.0`).


### PR DESCRIPTION
5.4.x will act as a bridge to the new public api in version 6. It will be helpful to publish a javadoc set with only the new api along-side a javadoc set that includes the deprecated classes and methods. This PR makes it so.