### PR TITLE
Several gradle fixes

### DIFF
--- a/bufr/build.gradle
+++ b/bufr/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 

--- a/cdm-test-utils/build.gradle
+++ b/cdm-test-utils/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 internalProjects.add(project)
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 

--- a/cdm-test/build.gradle
+++ b/cdm-test/build.gradle
@@ -9,7 +9,7 @@ apply from: "$rootDir/gradle/any/test-only-projects.gradle"
 // cdm-test is not published
 
 dependencies {
-  testImplementation platform(project(':netcdf-java-platform'))
+  testImplementation enforcedPlatform(project(':netcdf-java-platform'))
 
   testImplementation project(':cdm:cdm-core')
   testImplementation project(':cdm:cdm-s3')

--- a/cdm/core/build.gradle
+++ b/cdm/core/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply plugin: 'groovy'  // For Spock tests.
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   compile project(':udunits')
   compile project(':httpservices')

--- a/cdm/image/build.gradle
+++ b/cdm/image/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 

--- a/cdm/misc/build.gradle
+++ b/cdm/misc/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply plugin: 'groovy'  // For Spock tests.
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   compile project(':udunits')
   compile project(':cdm:cdm-core')

--- a/cdm/radial/build.gradle
+++ b/cdm/radial/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply plugin: 'groovy'  // For Spock tests.
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   compile project(':udunits')
   compile project(':cdm:cdm-core')

--- a/cdm/s3/build.gradle
+++ b/cdm/s3/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply plugin: 'groovy'  // For Spock tests.
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   compile project(':cdm:cdm-core')
   compile 'org.slf4j:slf4j-api'

--- a/dap4/d4cdm/build.gradle
+++ b/dap4/d4cdm/build.gradle
@@ -2,7 +2,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   compile project(':dap4:d4core')
   compile project(':dap4:d4lib')

--- a/dap4/d4lib/build.gradle
+++ b/dap4/d4lib/build.gradle
@@ -2,7 +2,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   compile project(':dap4:d4core')
   compile project(':httpservices')

--- a/dap4/d4tests/build.gradle
+++ b/dap4/d4tests/build.gradle
@@ -4,7 +4,7 @@ apply from: "$rootDir/gradle/any/gretty.gradle"
 
 dependencies {
   // I bet some of these dependencies could be in the testRuntimeOnly config, not testImplementation.
-  compile platform(project(':netcdf-java-platform'))
+  compile enforcedPlatform(project(':netcdf-java-platform'))
 
   testImplementation project(':dap4:d4core')
   testImplementation project(':dap4:d4lib')

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,8 @@
 # note that we used to set some things here, specifically turning off the gradle daemon,
 # but don't need to currently (used to be recomended in gradle 3.x, but no longer).
 # Keeping this for future reference, and maybe we will need it again in the future.
+
+# gradle 6 began publishing maven-metadata.xml files using 256 and 512 sha checksums, but nexus 3 does not
+# support that yet (although nexus 2 does) - see https://issues.sonatype.org/browse/NEXUS-23603
+# until it does, we need to set this property as our current snapshots are unusable
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -57,10 +57,10 @@ gretty {
 farm {
   jvmArgs = ["-Dlog4j.configurationFile=$rootDir/gradle/gretty/log4j2Config.xml"]
   // used by :dap4 test
-  webapp 'edu.ucar:d4ts:5.0.0-SNAPSHOT', contextPath: '/d4ts'
+  webapp 'edu.ucar:d4ts:5.0.0-SNAPSHOT@war', contextPath: '/d4ts'
 
   // :opendap and :httpservices test.
-  webapp 'edu.ucar:dtswar:5.0.0-SNAPSHOT', contextPath: '/dts'
+  webapp 'edu.ucar:dtswar:5.0.0-SNAPSHOT@war', contextPath: '/dts'
   integrationTestTask = 'test'
 
   // Enable TLS

--- a/gradle/any/java-library.gradle
+++ b/gradle/any/java-library.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java-library'
 apply from: "$rootDir/gradle/any/javadoc.gradle"
 apply from: "$rootDir/gradle/any/testing.gradle"
 apply from: "$rootDir/gradle/any/archiving.gradle"
+apply from: "$rootDir/gradle/any/coverage.gradle"
 apply from: "$rootDir/gradle/any/publishing.gradle"
 apply from: "$rootDir/gradle/any/spotless.gradle"
 

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -1,4 +1,4 @@
-if (name != 'netcdf-java') {
+if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -16,7 +16,7 @@ buildscript {
   }
 }
 
-if (name != 'netcdf-java') {
+if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -36,7 +36,7 @@ configurations {
 }
 
 dependencies {
-  ncIdv platform(project(':netcdf-java-platform'))
+  ncIdv enforcedPlatform(project(':netcdf-java-platform'))
   ncIdv project(':cdm:cdm-core')
   ncIdv project(':cdm:cdm-image')
   ncIdv project(':cdm:cdm-radial')
@@ -50,7 +50,7 @@ dependencies {
   ncIdv project(':httpservices')
   ncIdv project(':legacy')
 
-  netcdfAll platform(project(':netcdf-java-platform'))
+  netcdfAll enforcedPlatform(project(':netcdf-java-platform'))
   netcdfAll project(':cdm:cdm-core')
   netcdfAll project(':cdm:cdm-image')
   netcdfAll project(':cdm:cdm-radial')
@@ -62,11 +62,11 @@ dependencies {
   netcdfAll project(':httpservices')
   netcdfAll project(':visad:cdm-mcidas')
 
-  toolsUI platform(project(':netcdf-java-platform'))
+  toolsUI enforcedPlatform(project(':netcdf-java-platform'))
   toolsUI project(':uicdm')
   toolsUI 'ch.qos.logback:logback-classic'
 
-  dap4lib platform(project(':netcdf-java-platform'))
+  dap4lib enforcedPlatform(project(':netcdf-java-platform'))
   dap4lib project(':dap4:d4core')
   dap4lib project(':dap4:d4lib')
   dap4lib 'ch.qos.logback:logback-classic'

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -1,4 +1,4 @@
-if (name != 'netcdf-java') {
+if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 

--- a/gradle/root/sonarqube.gradle
+++ b/gradle/root/sonarqube.gradle
@@ -14,7 +14,7 @@ buildscript {
   }
 }
 
-if (name != 'netcdf-java') {
+if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 

--- a/gradle/root/spotless.gradle
+++ b/gradle/root/spotless.gradle
@@ -1,4 +1,4 @@
-if (name != 'netcdf-java') {
+if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 

--- a/gradle/root/testing.gradle
+++ b/gradle/root/testing.gradle
@@ -1,4 +1,4 @@
-if (name != 'netcdf-java') {
+if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 

--- a/grib/build.gradle
+++ b/grib/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 

--- a/httpservices/build.gradle
+++ b/httpservices/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply from: "$rootDir/gradle/any/gretty.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
   api 'com.google.guava:guava'
   api 'org.apache.httpcomponents:httpclient'
   api 'org.apache.httpcomponents:httpcore'

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply plugin: 'groovy'  // For Spock tests.
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 

--- a/netcdf-java-bom/build.gradle
+++ b/netcdf-java-bom/build.gradle
@@ -12,7 +12,7 @@ javaPlatform {
 }
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
   constraints {
     api project(':bufr')
     api project(':cdm:cdm-core')

--- a/netcdf4/build.gradle
+++ b/netcdf4/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'groovy'  // For Spock tests.
 apply plugin: 'jacoco'
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   compile project(':cdm:cdm-core')
   compile 'net.java.dev.jna:jna'

--- a/opendap/build.gradle
+++ b/opendap/build.gradle
@@ -12,7 +12,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply from: "$rootDir/gradle/any/gretty.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
   api project(':httpservices')

--- a/udunits/build.gradle
+++ b/udunits/build.gradle
@@ -10,7 +10,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   implementation 'com.google.code.findbugs:jsr305'
 

--- a/uibase/build.gradle
+++ b/uibase/build.gradle
@@ -6,7 +6,7 @@ apply from: "$rootDir/gradle/any/java-library.gradle"
 apply plugin: 'groovy'  // For Spock tests.
 
 dependencies {
-  compile platform(project(':netcdf-java-platform'))
+  compile enforcedPlatform(project(':netcdf-java-platform'))
 
   compile 'org.jdom:jdom2'
   compile 'com.google.protobuf:protobuf-java'

--- a/uicdm/build.gradle
+++ b/uicdm/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  compile platform(project(':netcdf-java-platform'))
+  compile enforcedPlatform(project(':netcdf-java-platform'))
 
   // todo: a lot of these could probably be runtimeOnly
   compile project(':cdm:cdm-core')

--- a/visad/mcidas/build.gradle
+++ b/visad/mcidas/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 

--- a/visad/vis5d/build.gradle
+++ b/visad/vis5d/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 

--- a/waterml/build.gradle
+++ b/waterml/build.gradle
@@ -5,7 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-library.gradle"
 
 dependencies {
-  api platform(project(':netcdf-java-platform'))
+  api enforcedPlatform(project(':netcdf-java-platform'))
 
   api project(':cdm:cdm-core')
 


### PR DESCRIPTION
This PR contains several gradle fixes that were uncovered as part of upgrading the TDS to use gradle 6. The biggest is that the artifacts we've been producing for netCDF-Java have been unusable due to a limitation in the nexus server. Gradle 6 began publishing maven-metadata.xml files using 256 and 512 checksums, but nexus 3 does not support those yet. See https://issues.sonatype.org/browse/NEXUS-23603. We also need to specify the war extension for artifacts produced by the gradle 6 build of the TDS going forward - we use these artifacts when testing  opendap, dap4 and httpservices (this PR has that change as well). This is the for the `5.x` branch. I will port these to `develop` next. Once these are in, I will make the PR to get TDS up and running on gradle 6. Whew.