### PR TITLE
A few minor tweaks to our gradle pubs

### DIFF
--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -76,7 +76,7 @@ if (project in publishedProjects) {
   // ain't nobody got time for that
   publishing {
     publications {
-      mavenJava(MavenPublication) {
+      mavenSources(MavenPublication) {
         pom.withXml {
           Node pomNode = asNode()
           pomNode.dependencies.'*'.findAll() {

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     // apache httpclient
     api 'org.apache.httpcomponents:httpclient:4.5.12'
     api 'org.apache.httpcomponents:httpmime:4.5.12'
+    // version of httpcore matches the one used by httpclient
+    // so if updating httpclient, look in its pom for the version of http core to use
+    api 'org.apache.httpcomponents:httpcore:4.4.13'
     api "org.slf4j:jcl-over-slf4j:${depVersion.slf4j}"
 
     // waterml xml beans


### PR DESCRIPTION
I ran into a few issues with our maven publications when migrating
threddsIso to use the new netcdf-java-bom artifact. Two things:

1. Make sure httpcore is included in the bom (needs to be matched to
   the version used by httpclient)
2. When using gretty, the runtime classpath of the project is modified,
   and this messes with what ends up in the pom (e.g. httpservices does
   not need a runtime dependency on jetty...). We were already modifying
   a pom to remove the inserted dependencies. However, now we modify the
   pom of projects using gretty as opposed to publishing a new artifact
   with the modified pom. Oops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/459)
<!-- Reviewable:end -->
