### PR TITLE
Break up large data requests into multiple messages in CdmrServer, and recombine on the client (CdmrNetcdfFile).

### DIFF
--- a/cdm/core/src/main/java/ucar/ma/Array.java
+++ b/cdm/core/src/main/java/ucar/ma/Array.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Range;
+import ucar.ma2.Section;
+
+/** Superclass for implementations of multidimensional arrays. */
+public abstract class Array<T> implements Iterable<T> {
+
+  public static <T> Array<T> factoryCopy(DataType dataType, int[] shape, List<Array> dataArrays) {
+    if (dataArrays.size() == 1) {
+      return factory(dataType, shape, dataArrays.get(0).getPrimitiveArray());
+    }
+    Object dataArray = combine(dataType, shape, dataArrays);
+    return factory(dataType, shape, dataArray);
+  }
+
+  private static Object combine(DataType dataType, int[] shape, List<Array> dataArrays) {
+    Section section = new Section(shape);
+    long size = section.getSize();
+    if (size > Integer.MAX_VALUE) {
+      throw new OutOfMemoryError();
+    }
+
+    switch (dataType) {
+      case FLOAT: {
+        float[] all = new float[(int) size];
+        int start = 0;
+        for (Array<?> result : dataArrays) {
+          float[] array = (float[]) result.getPrimitiveArray();
+          System.arraycopy(array, 0, all, start, array.length);
+          start += array.length;
+        }
+        return all;
+      }
+      case DOUBLE: {
+        double[] all = new double[(int) size];
+        int start = 0;
+        for (Array<?> result : dataArrays) {
+          double[] array = (double[]) result.getPrimitiveArray();
+          System.arraycopy(array, 0, all, start, array.length);
+          start += array.length;
+        }
+        return all;
+      }
+      default:
+        throw new RuntimeException(" DataType " + dataType);
+    }
+  }
+
+  // The only advantage over copying AFAICT is that it can handle arrays > 2G. as long as its broken up into
+  // multiple arrays < 2G.
+  public static <T> Array<T> factoryArrays(DataType dataType, int[] shape, List<Array> dataArrays) {
+    if (dataArrays.size() == 1) {
+      return factory(dataType, shape, dataArrays.get(0).getPrimitiveArray());
+    }
+
+    switch (dataType) {
+      case DOUBLE:
+        Storage<Double> storageD = Storage.factoryArrays(dataType, dataArrays);
+        return (Array<T>) new ArrayDouble(shape, storageD);
+      case FLOAT:
+        Storage<Float> storageF = Storage.factoryArrays(dataType, dataArrays);
+        return (Array<T>) new ArrayFloat(shape, storageF);
+      default:
+        throw new RuntimeException();
+    }
+  }
+
+  public static <T> Array<T> factory(DataType dataType, int[] shape, Object dataArray) {
+    switch (dataType) {
+      case DOUBLE:
+        Storage<Double> storageD = Storage.factory(dataType, dataArray);
+        return (Array<T>) new ArrayDouble(shape, storageD);
+      case FLOAT:
+        Storage<Float> storageF = Storage.factory(dataType, dataArray);
+        return (Array<T>) new ArrayFloat(shape, storageF);
+      default:
+        throw new RuntimeException();
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////
+  final DataType dataType;
+  final Strides indexCalc;
+  final int rank;
+
+  Array(DataType dataType, int[] shape) {
+    this.dataType = dataType;
+    this.rank = shape.length;
+    this.indexCalc = Strides.builder(shape).build();
+  }
+
+  Array(DataType dataType, Strides shape) {
+    this.dataType = dataType;
+    this.rank = shape.getRank();
+    this.indexCalc = shape;
+  }
+
+  @Override
+  public abstract Iterator<T> iterator();
+
+  public abstract Iterator<T> fastIterator();
+
+  // Something to touch every element
+  public abstract T sum();
+
+  public abstract T get();
+
+  public abstract T get(int v0);
+
+  public abstract T get(int v0, int v1);
+
+  public abstract T get(int v0, int v1, int v2);
+
+  public abstract T get(int v0, int v1, int v2, int v3);
+
+  public abstract T get(int v0, int v1, int v2, int v3, int v4);
+
+  public abstract T get(int[] element);
+
+  public abstract T get(Index index);
+
+  /**
+   * Get underlying primitive array storage.
+   * Exposed for efficiency, use at your own risk.
+   *
+   * @return underlying primitive array storage
+   */
+  abstract Object getPrimitiveArray();
+
+  /** Return the datatype for this array */
+  public DataType getDataType() {
+    return this.dataType;
+  }
+
+  /** An Index that can be used instead of int[] */
+  public Index getIndex() {
+    return new Index(this.rank);
+  }
+
+  /** Get the number of dimensions of the array. */
+  public int getRank() {
+    return rank;
+  }
+
+  /** Get the shape: length of array in each dimension. */
+  public int[] getShape() {
+    return indexCalc.getShape();
+  }
+
+  /** Get the total number of elements in the array. */
+  public long getSize() {
+    return indexCalc.getSize();
+  }
+
+  /** Get the total number of bytes in the array. */
+  public long getSizeBytes() {
+    return indexCalc.getSize() * dataType.getSize();
+  }
+
+  /**
+   * Find whether the underlying data should be interpreted as unsigned.
+   * Only affects byte, short, int, and long.
+   * When true, conversions to wider types are handled correctly.
+   *
+   * @return true if the data is an unsigned integer type.
+   */
+  public boolean isUnsigned() {
+    return dataType.isUnsigned();
+  }
+
+  public boolean isVlen() {
+    return indexCalc.isVlen();
+  }
+
+  /**
+   * create new Array with given Index and the same backing store
+   *
+   * @param index use this Index
+   * @return a view of the Array using the given Index
+   */
+  abstract Array<T> createView(Strides index);
+
+  /**
+   * Create a new Array using same backing store as this Array, by
+   * flipping the index so that it runs from shape[index]-1 to 0.
+   *
+   * @param dim dimension to flip
+   * @return the new Array
+   */
+  public Array<T> flip(int dim) {
+    return createView(indexCalc.flip(dim));
+  }
+
+  /**
+   * Create a new Array using same backing store as this Array, by
+   * permuting the indices.
+   *
+   * @param dims the old index dims[k] becomes the new kth index.
+   * @return the new Array
+   * @throws IllegalArgumentException: wrong rank or dim[k] not valid
+   */
+  public Array<T> permute(int[] dims) {
+    return createView(indexCalc.permute(dims));
+  }
+
+  /**
+   * Create a new Array using same backing store with given shape
+   *
+   * @param shape the new shape
+   * @return the new Array
+   * @throws IllegalArgumentException new shape is not conformable
+   */
+  public Array<T> reshape(int[] shape) {
+    return createView(indexCalc.reshape(shape));
+  }
+
+  /**
+   * Create a new Array using same backing store as this Array, by
+   * eliminating any dimensions with length one.
+   *
+   * @return the new Array, or the same array if no reduction was done
+   */
+  public Array<T> reduce() {
+    Strides ri = indexCalc.reduce();
+    if (ri == indexCalc)
+      return this;
+    return createView(ri);
+  }
+
+  /**
+   * Create a new Array using same backing store as this Array, by
+   * eliminating the specified dimension.
+   *
+   * @param dim dimension to eliminate: must be of length one, else IllegalArgumentException
+   * @return the new Array
+   */
+  public Array<T> reduce(int dim) {
+    return createView(indexCalc.reduce(dim));
+  }
+
+  /**
+   * Create a new Array as a subsection of this Array, with rank reduction.
+   * No data is moved, so the new Array references the same backing store as the original.
+   *
+   * @param ranges list of Ranges that specify the array subset.
+   *        Must be same rank as original Array.
+   *        A particular Range: 1) may be a subset, or 2) may be null, meaning use entire Range.
+   *        If Range[dim].length == 1, then the rank of the resulting Array is reduced at that dimension.
+   * @return the new Array
+   * @throws InvalidRangeException if ranges is invalid
+   */
+  public Array<T> section(List<Range> ranges) throws InvalidRangeException {
+    return createView(indexCalc.section(ranges));
+  }
+
+  /**
+   * Create a new Array as a subsection of this Array, with rank reduction.
+   * No data is moved, so the new Array references the same backing store as the original.
+   * <p/>
+   *
+   * @param origin int array specifying the starting index. Must be same rank as original Array.
+   * @param shape int array specifying the extents in each dimension.
+   *        This becomes the shape of the returned Array. Must be same rank as original Array.
+   *        If shape[dim] == 1, then the rank of the resulting Array is reduced at that dimension.
+   * @return the new Array
+   * @throws InvalidRangeException if ranges is invalid
+   */
+  public Array<T> section(int[] origin, int[] shape) throws InvalidRangeException {
+    return section(origin, shape, null);
+  }
+
+  /**
+   * Create a new Array as a subsection of this Array, with rank reduction.
+   * No data is moved, so the new Array references the same backing store as the original.
+   * <p/>
+   *
+   * @param origin int array specifying the starting index. Must be same rank as original Array.
+   * @param shape int array specifying the extents in each dimension.
+   *        This becomes the shape of the returned Array. Must be same rank as original Array.
+   *        If shape[dim] == 1, then the rank of the resulting Array is reduced at that dimension.
+   * @param stride int array specifying the strides in each dimension. If null, assume all ones.
+   * @return the new Array
+   * @throws InvalidRangeException if ranges is invalid
+   */
+  public Array<T> section(int[] origin, int[] shape, int[] stride) throws InvalidRangeException {
+    List<Range> ranges = new ArrayList<>(origin.length);
+    if (stride == null) {
+      stride = new int[origin.length];
+      Arrays.fill(stride, 1);
+    }
+    for (int i = 0; i < origin.length; i++) {
+      ranges.add(new Range(origin[i], origin[i] + stride[i] * shape[i] - 1, stride[i]));
+    }
+    return createView(indexCalc.section(ranges));
+  }
+
+  /**
+   * Create a new Array as a subsection of this Array, without rank reduction.
+   * No data is moved, so the new Array references the same backing store as the original.
+   * Vlen is transferred over unchanged.
+   *
+   * @param ranges list of Ranges that specify the array subset.
+   *        Must be same rank as original Array.
+   *        A particular Range: 1) may be a subset, or 2) may be null, meaning use entire Range.
+   * @return the new Array
+   * @throws InvalidRangeException if ranges is invalid
+   */
+  public Array<T> sectionNoReduce(List<Range> ranges) throws InvalidRangeException {
+    return createView(indexCalc.sectionNoReduce(ranges));
+  }
+
+  /**
+   * Create a new Array as a subsection of this Array, without rank reduction.
+   * No data is moved, so the new Array references the same backing store as the original.
+   *
+   * @param origin int array specifying the starting index. Must be same rank as original Array.
+   * @param shape int array specifying the extents in each dimension.
+   *        This becomes the shape of the returned Array. Must be same rank as original Array.
+   * @param stride int array specifying the strides in each dimension. If null, assume all ones.
+   * @return the new Array
+   * @throws InvalidRangeException if ranges is invalid
+   */
+  public Array<T> sectionNoReduce(int[] origin, int[] shape, int[] stride) throws InvalidRangeException {
+    List<Range> ranges = new ArrayList<>(origin.length);
+    if (stride == null) {
+      stride = new int[origin.length];
+      Arrays.fill(stride, 1);
+    }
+    for (int i = 0; i < origin.length; i++) {
+      if (shape[i] < 0) // VLEN
+        ranges.add(Range.VLEN);
+      else
+        ranges.add(new Range(origin[i], origin[i] + stride[i] * shape[i] - 1, stride[i]));
+    }
+    return createView(indexCalc.sectionNoReduce(ranges));
+  }
+
+  /**
+   * Create a new Array using same backing store as this Array, by
+   * fixing the specified dimension at the specified index value. This reduces rank by 1.
+   *
+   * @param dim which dimension to fix
+   * @param value at what index value
+   * @return a new Array
+   */
+  public Array<T> slice(int dim, int value) {
+    int[] origin = new int[rank];
+    int[] shape = getShape();
+    origin[dim] = value;
+    shape[dim] = 1;
+    try {
+      return sectionNoReduce(origin, shape, null).reduce(dim); // preserve other dim 1
+    } catch (InvalidRangeException e) {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  /**
+   * Create a new Array using same backing store as this Array, by
+   * transposing two of the indices.
+   *
+   * @param dim1 transpose these two indices
+   * @param dim2 transpose these two indices
+   * @return the new Array
+   */
+  public Array<T> transpose(int dim1, int dim2) {
+    return createView(indexCalc.transpose(dim1, dim2));
+  }
+
+}
+

--- a/cdm/core/src/main/java/ucar/ma/ArrayDouble.java
+++ b/cdm/core/src/main/java/ucar/ma/ArrayDouble.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Streams;
+import java.util.Iterator;
+import ucar.ma2.DataType;
+
+/**
+ * Concrete implementation of Array specialized for doubles.
+ * Data storage is with 1D java array of doubles.
+ */
+public class ArrayDouble extends ucar.ma.Array<Double> {
+
+  private final Storage<Double> storageD;
+
+  /** Create an empty Array of type double and the given shape. */
+  public ArrayDouble(int[] shape) {
+    super(DataType.DOUBLE, shape);
+    storageD = Storage.factory(DataType.DOUBLE, new double[(int) indexCalc.getSize()]);
+  }
+
+  /** Create an Array of type double and the given shape and storage. */
+  public ArrayDouble(int[] shape, Storage<Double> storageD) {
+    super(DataType.DOUBLE, shape);
+    Preconditions.checkArgument(indexCalc.getSize() == storageD.getLength());
+    this.storageD = storageD;
+  }
+
+  /** Create an Array of type double and the given shape and storage. */
+  private ArrayDouble(Strides shape, Storage<Double> storageD) {
+    super(DataType.DOUBLE, shape);
+    this.storageD = storageD;
+  }
+
+  @Override
+  public Iterator<Double> fastIterator() {
+    return storageD.iterator();
+  }
+
+  @Override
+  public Iterator<Double> iterator() {
+    return indexCalc.isCanonicalOrder() ? fastIterator() : new CanonicalIterator();
+  }
+
+  public Double sum() {
+    return Streams.stream(() -> fastIterator()).mapToDouble(d -> d).sum();
+  }
+
+  @Override
+  public Double get() {
+    Preconditions.checkArgument(this.rank == 0);
+    return storageD.get(0);
+  }
+
+  @Override
+  public Double get(int v0) {
+    Preconditions.checkArgument(this.rank == 1);
+    return storageD.get(indexCalc.get(v0));
+  }
+
+  @Override
+  public Double get(int v0, int v1) {
+    Preconditions.checkArgument(this.rank == 2);
+    return storageD.get(indexCalc.get(v0, v1));
+  }
+
+  @Override
+  public Double get(int v0, int v1, int v2) {
+    Preconditions.checkArgument(this.rank == 3);
+    return storageD.get(indexCalc.get(v0, v1, v2));
+  }
+
+  @Override
+  public Double get(int v0, int v1, int v2, int v3) {
+    Preconditions.checkArgument(this.rank == 4);
+    return storageD.get(indexCalc.get(v0, v1, v2, v3));
+  }
+
+  @Override
+  public Double get(int v0, int v1, int v2, int v3, int v4) {
+    Preconditions.checkArgument(this.rank == 5);
+    return storageD.get(indexCalc.get(v0, v1, v2, v3, v4));
+  }
+
+  @Override
+  public Double get(int[] element) {
+    Preconditions.checkArgument(this.rank == element.length);
+    return storageD.get(indexCalc.get(element));
+  }
+
+  @Override
+  public Double get(Index index) {
+    return get(index.getCurrentIndex());
+  }
+
+  Object getPrimitiveArray() {
+    return storageD.getPrimitiveArray();
+  }
+
+  /** create new Array with given indexImpl and the same backing store */
+  @Override
+  protected ArrayDouble createView(Strides index) {
+    return new ArrayDouble(index, storageD);
+  }
+
+  private class CanonicalIterator implements Iterator<Double> {
+    // used when the data is not in canonical order
+    private final Iterator<Integer> iter = indexCalc.iterator();
+
+    @Override
+    public boolean hasNext() {
+      return iter.hasNext();
+    }
+
+    @Override
+    public Double next() {
+      return storageD.get(iter.next());
+    }
+  }
+
+}

--- a/cdm/core/src/main/java/ucar/ma/ArrayFloat.java
+++ b/cdm/core/src/main/java/ucar/ma/ArrayFloat.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Streams;
+import java.util.Iterator;
+import ucar.ma2.DataType;
+
+/**
+ * Concrete implementation of Array specialized for doubles.
+ * Data storage is with 1D java array of doubles.
+ */
+public class ArrayFloat extends Array<Float> {
+
+  private final Storage<Float> storageF;
+
+  /** Create an empty Array of type double and the given shape. */
+  public ArrayFloat(int[] shape) {
+    super(DataType.FLOAT, shape);
+    storageF = Storage.factory(DataType.FLOAT, new float[(int) indexCalc.getSize()]);
+  }
+
+  /** Create an Array of type double and the given shape and storage. */
+  public ArrayFloat(int[] shape, Storage<Float> storageF) {
+    super(DataType.DOUBLE, shape);
+    Preconditions.checkArgument(indexCalc.getSize() == storageF.getLength());
+    this.storageF = storageF;
+  }
+
+  /** Create an Array of type double and the given shape and storage. */
+  private ArrayFloat(Strides shape, Storage<Float> storageF) {
+    super(DataType.FLOAT, shape);
+    this.storageF = storageF;
+  }
+
+  @Override
+  public Iterator<Float> fastIterator() {
+    return storageF.iterator();
+  }
+
+  @Override
+  public Iterator<Float> iterator() {
+    return indexCalc.isCanonicalOrder() ? fastIterator() : new CanonicalIterator();
+  }
+
+  public Float sum() {
+    return (float) Streams.stream(() -> fastIterator()).mapToDouble(d -> d).sum();
+  }
+
+  @Override
+  public Float get() {
+    Preconditions.checkArgument(this.rank == 0);
+    return storageF.get(0);
+  }
+
+  @Override
+  public Float get(int v0) {
+    Preconditions.checkArgument(this.rank == 1);
+    return storageF.get(indexCalc.get(v0));
+  }
+
+  @Override
+  public Float get(int v0, int v1) {
+    Preconditions.checkArgument(this.rank == 2);
+    return storageF.get(indexCalc.get(v0, v1));
+  }
+
+  @Override
+  public Float get(int v0, int v1, int v2) {
+    Preconditions.checkArgument(this.rank == 3);
+    return storageF.get(indexCalc.get(v0, v1, v2));
+  }
+
+  @Override
+  public Float get(int v0, int v1, int v2, int v3) {
+    Preconditions.checkArgument(this.rank == 4);
+    return storageF.get(indexCalc.get(v0, v1, v2, v3));
+  }
+
+  @Override
+  public Float get(int v0, int v1, int v2, int v3, int v4) {
+    Preconditions.checkArgument(this.rank == 5);
+    return storageF.get(indexCalc.get(v0, v1, v2, v3, v4));
+  }
+
+  @Override
+  public Float get(int[] element) {
+    Preconditions.checkArgument(this.rank == element.length);
+    return storageF.get(indexCalc.get(element));
+  }
+
+  @Override
+  public Float get(Index index) {
+    return get(index.getCurrentIndex());
+  }
+
+  Object getPrimitiveArray() {
+    return storageF.getPrimitiveArray();
+  }
+
+  /** create new Array with given indexImpl and the same backing store */
+  @Override
+  protected ArrayFloat createView(Strides index) {
+    return new ArrayFloat(index, storageF);
+  }
+
+  private class CanonicalIterator implements Iterator<Float> {
+    // used when the data is not in canonical order
+    private final Iterator<Integer> iter = indexCalc.iterator();
+
+    @Override
+    public boolean hasNext() {
+      return iter.hasNext();
+    }
+
+    @Override
+    public Float next() {
+      return storageF.get(iter.next());
+    }
+  }
+
+}

--- a/cdm/core/src/main/java/ucar/ma/Index.java
+++ b/cdm/core/src/main/java/ucar/ma/Index.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Indexes for Multidimensional arrays. An Index refers to a particular element of an array.
+ * This is a generalization of index as int[].
+ */
+public class Index {
+  private final int[] current; // current element's index
+
+  protected Index(int rank) {
+    current = new int[rank];
+  }
+
+  /** Get the current index as int[] . */
+  public int[] getCurrentIndex() {
+    return current;
+  }
+
+  /**
+   * Set the current element's index.
+   *
+   * @param index set current value to these values
+   * @return this, so you can use A.get(i.set(i))
+   * @throws ArrayIndexOutOfBoundsException if index.length != rank.
+   */
+  public Index set(int[] index) {
+    if (index.length > current.length)
+      throw new ArrayIndexOutOfBoundsException();
+    if (current.length == 0)
+      return this;
+    System.arraycopy(index, 0, current, 0, index.length);
+    return this;
+  }
+
+  /**
+   * set current element at dimension dim to v
+   *
+   * @param dim set this dimension
+   * @param value to this value
+   */
+  public void setDim(int dim, int value) {
+    Preconditions.checkArgument(dim < current.length);
+    current[dim] = value;
+  }
+
+  /** set current element at dimension 0 to v */
+  public Index set0(int v) {
+    setDim(0, v);
+    return this;
+  }
+
+  /** set current element at dimension 1 to v */
+  public Index set1(int v) {
+    setDim(1, v);
+    return this;
+  }
+
+  /** set current element at dimension 2 to v */
+  public Index set2(int v) {
+    setDim(2, v);
+    return this;
+  }
+
+  /** set current element at dimension 3 to v */
+  public Index set3(int v) {
+    setDim(3, v);
+    return this;
+  }
+
+  /** set current element at dimension 4 to v */
+  public Index set4(int v) {
+    setDim(4, v);
+    return this;
+  }
+
+  /** set current element at dimension 5 to v */
+  public Index set5(int v) {
+    setDim(5, v);
+    return this;
+  }
+
+  /** set current element at dimension 6 to v */
+  public Index set6(int v) {
+    setDim(6, v);
+    return this;
+  }
+
+  /** set current element at dimension 0 to v0 */
+  public Index set(int v0) {
+    setDim(0, v0);
+    return this;
+  }
+
+  /** set current element at dimension 0,1 to v0,v1 */
+  public Index set(int v0, int v1) {
+    setDim(0, v0);
+    setDim(1, v1);
+    return this;
+  }
+
+  /** set current element at dimension 0,1,2 to v0,v1,v2 */
+  public Index set(int v0, int v1, int v2) {
+    setDim(0, v0);
+    setDim(1, v1);
+    setDim(2, v2);
+    return this;
+  }
+
+  /** set current element at dimension 0,1,2,3 to v0,v1,v2,v3 */
+  public Index set(int v0, int v1, int v2, int v3) {
+    setDim(0, v0);
+    setDim(1, v1);
+    setDim(2, v2);
+    setDim(3, v3);
+    return this;
+  }
+
+  /** set current element at dimension 0,1,2,3,4 to v0,v1,v2,v3,v4 */
+  public Index set(int v0, int v1, int v2, int v3, int v4) {
+    setDim(0, v0);
+    setDim(1, v1);
+    setDim(2, v2);
+    setDim(3, v3);
+    setDim(4, v4);
+    return this;
+  }
+
+  /** set current element at dimension 0,1,2,3,4,5 to v0,v1,v2,v3,v4,v5 */
+  public Index set(int v0, int v1, int v2, int v3, int v4, int v5) {
+    setDim(0, v0);
+    setDim(1, v1);
+    setDim(2, v2);
+    setDim(3, v3);
+    setDim(4, v4);
+    setDim(5, v5);
+    return this;
+  }
+
+  /** set current element at dimension 0,1,2,3,4,5,6 to v0,v1,v2,v3,v4,v5,v6 */
+  public Index set(int v0, int v1, int v2, int v3, int v4, int v5, int v6) {
+    setDim(0, v0);
+    setDim(1, v1);
+    setDim(2, v2);
+    setDim(3, v3);
+    setDim(4, v4);
+    setDim(5, v5);
+    setDim(6, v6);
+    return this;
+  }
+
+}

--- a/cdm/core/src/main/java/ucar/ma/Storage.java
+++ b/cdm/core/src/main/java/ucar/ma/Storage.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+import ucar.ma2.DataType;
+
+/** Abstraction of using java arrays to store Array data in. Allows multiple java arrays. */
+@Immutable
+abstract class Storage<T> implements Iterable<T> {
+
+  static <T> Storage<T> factoryArrays(DataType dataType, List<Array> dataArrays) {
+    switch (dataType) {
+      case DOUBLE:
+        return (Storage<T>) new StorageDM(dataArrays);
+      case FLOAT:
+        return (Storage<T>) new StorageFM(dataArrays);
+      default:
+        throw new RuntimeException();
+    }
+  }
+
+  static <T> Storage<T> factory(DataType dataType, Object dataArray) {
+    switch (dataType) {
+      case DOUBLE:
+        return (Storage<T>) new StorageD((double[]) dataArray);
+      case FLOAT:
+        return (Storage<T>) new StorageF((float[]) dataArray);
+      default:
+        throw new RuntimeException();
+    }
+  }
+
+  abstract long getLength();
+
+  abstract T get(long elem);
+
+  abstract Object getPrimitiveArray();
+
+  private static class StorageD extends Storage<Double> {
+    private final double[] storage;
+
+    StorageD(double[] storage) {
+      this.storage = storage;
+    }
+
+    @Override
+    long getLength() {
+      return storage.length;
+    }
+
+    @Override
+    public Double get(long elem) {
+      return storage[(int) elem];
+    }
+
+    @Override
+    public Iterator<Double> iterator() {
+      return new StorageDIter();
+    }
+
+    Object getPrimitiveArray() {
+      return storage;
+    }
+
+    private final class StorageDIter implements Iterator<Double> {
+      int count = 0;
+
+      @Override
+      public final boolean hasNext() {
+        return count < storage.length;
+      }
+
+      @Override
+      public final Double next() {
+        return storage[count++];
+      }
+    }
+  }
+
+  private static class StorageDM extends Storage<Double> {
+    private final ImmutableList<double[]> dataArrays;
+    private final long[] arrayEdge;
+    private final long totalLength;
+
+    StorageDM(List<Array> dataArrays) {
+      ImmutableList.Builder<double[]> builder = ImmutableList.builder();
+      List<Long> edge = new ArrayList<>();
+      edge.add(0L);
+      long total = 0L;
+      for (Array<?> dataArray : dataArrays) {
+        builder.add((double[]) dataArray.getPrimitiveArray());
+        total += dataArray.getSize();
+        edge.add(total);
+      }
+      this.dataArrays = builder.build();
+      this.arrayEdge = edge.stream().mapToLong(i -> i).toArray();
+      this.totalLength = total;
+    }
+
+    @Override
+    long getLength() {
+      return totalLength;
+    }
+
+    @Override
+    public Double get(long elem) {
+      int search = Arrays.binarySearch(arrayEdge, elem);
+      int arrayIndex = (search < 0) ? -search - 1 : search;
+      double[] array = dataArrays.get(arrayIndex);
+      return array[(int) (elem - arrayEdge[arrayIndex])];
+    }
+
+    @Override
+    public Iterator<Double> iterator() {
+      return new StorageDMIter();
+    }
+
+    Object getPrimitiveArray() {
+      return dataArrays;
+    }
+
+    private final class StorageDMIter implements Iterator<Double> {
+      int count = 0;
+      int arrayIndex = 0;
+      double[] array = dataArrays.get(0);
+
+      @Override
+      public final boolean hasNext() {
+        return count < totalLength;
+      }
+
+      @Override
+      public final Double next() {
+        if (count >= arrayEdge[arrayIndex + 1]) {
+          arrayIndex++;
+          array = dataArrays.get(arrayIndex);
+        }
+        double val = array[(int) (count - arrayEdge[arrayIndex])];
+        count++;
+        return val;
+      }
+    }
+  }
+
+  private static class StorageF extends Storage<Float> {
+    private final float[] storage;
+
+    StorageF(float[] storage) {
+      this.storage = storage;
+    }
+
+    @Override
+    long getLength() {
+      return storage.length;
+    }
+
+    @Override
+    public Float get(long elem) {
+      return storage[(int) elem];
+    }
+
+    @Override
+    public Iterator<Float> iterator() {
+      return new StorageFIter();
+    }
+
+    Object getPrimitiveArray() {
+      return storage;
+    }
+
+    private final class StorageFIter implements Iterator<Float> {
+      int count = 0;
+
+      @Override
+      public final boolean hasNext() {
+        return count < storage.length;
+      }
+
+      @Override
+      public final Float next() {
+        return storage[count++];
+      }
+    }
+  }
+
+  private static class StorageFM extends Storage<Float> {
+    private final ImmutableList<float[]> dataArrays;
+    private final long[] arrayEdge;
+    private final long totalLength;
+
+    StorageFM(List<Array> dataArrays) {
+      ImmutableList.Builder<float[]> builder = ImmutableList.builder();
+      List<Long> edge = new ArrayList<>();
+      edge.add(0L);
+      long total = 0L;
+      for (Array<?> dataArray : dataArrays) {
+        builder.add((float[]) dataArray.getPrimitiveArray());
+        total += dataArray.getSize();
+        edge.add(total);
+      }
+      this.dataArrays = builder.build();
+      this.arrayEdge = edge.stream().mapToLong(i -> i).toArray();
+      this.totalLength = total;
+    }
+
+    @Override
+    long getLength() {
+      return totalLength;
+    }
+
+    @Override
+    public Float get(long elem) {
+      int search = Arrays.binarySearch(arrayEdge, elem);
+      int arrayIndex = (search < 0) ? -search - 1 : search;
+      float[] array = dataArrays.get(arrayIndex);
+      return array[(int) (elem - arrayEdge[arrayIndex])];
+    }
+
+    @Override
+    public Iterator<Float> iterator() {
+      return new StorageFMIter();
+    }
+
+    Object getPrimitiveArray() {
+      return dataArrays;
+    }
+
+    private final class StorageFMIter implements Iterator<Float> {
+      int count = 0;
+      int arrayIndex = 0;
+      float[] array = dataArrays.get(0);
+
+      @Override
+      public final boolean hasNext() {
+        return count < totalLength;
+      }
+
+      @Override
+      public final Float next() {
+        if (count >= arrayEdge[arrayIndex + 1]) {
+          arrayIndex++;
+          array = dataArrays.get(arrayIndex);
+        }
+        float val = array[(int) (count - arrayEdge[arrayIndex])];
+        count++;
+        return val;
+      }
+    }
+  }
+
+}

--- a/cdm/core/src/main/java/ucar/ma/Strides.java
+++ b/cdm/core/src/main/java/ucar/ma/Strides.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import com.google.common.base.Preconditions;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.concurrent.Immutable;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Range;
+
+/** Strides for Multidimensional arrays. Translate between multidimensional index and 1d arrays. */
+@Immutable
+public class Strides implements Iterable<Integer> {
+
+  /**
+   * Compute total number of elements in the array.
+   * Stop at vlen
+   *
+   * @param shape length of array in each dimension.
+   * @return total number of elements in the array.
+   */
+  public static long computeSize(int[] shape) {
+    long product = 1;
+    for (int aShape : shape) {
+      if (aShape < 0)
+        break; // stop at vlen
+      product *= aShape;
+    }
+    return product;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  public int get(int v0) {
+    Preconditions.checkArgument(this.rank == 1);
+    return offset + v0 * stride[0];
+  }
+
+  public int get(int v0, int v1) {
+    Preconditions.checkArgument(this.rank == 2);
+    return offset + v0 * stride[0] + v1 * stride[1];
+  }
+
+  public int get(int v0, int v1, int v2) {
+    Preconditions.checkArgument(this.rank == 3);
+    return offset + v0 * stride[0] + v1 * stride[1] + v2 * stride[2];
+  }
+
+  public int get(int v0, int v1, int v2, int v3) {
+    Preconditions.checkArgument(this.rank == 4);
+    return offset + v0 * stride[0] + v1 * stride[1] + v2 * stride[2] + v3 * stride[3];
+  }
+
+  public int get(int v0, int v1, int v2, int v3, int v4) {
+    Preconditions.checkArgument(this.rank == 5);
+    return offset + v0 * stride[0] + v1 * stride[1] + v2 * stride[2] + v3 * stride[3] + v4 * stride[4];
+  }
+
+  public int get(int[] element) {
+    Preconditions.checkArgument(this.rank == element.length);
+    int value = offset;
+    for (int ii = 0; ii < rank; ii++) { // general rank
+      if (shape[ii] < 0)
+        break;// vlen
+      value += element[ii] * stride[ii];
+    }
+    return value;
+  }
+
+  /** Get the number of dimensions in the array. */
+  public int getRank() {
+    return rank;
+  }
+
+  /** Get the shape: length of array in each dimension. */
+  public int[] getShape() {
+    int[] result = new int[rank];
+    System.arraycopy(shape, 0, result, 0, rank);
+    return result;
+  }
+
+  /** Get the length of the ith dimension. */
+  public int getShape(int index) {
+    Preconditions.checkArgument(index >= 0 && index < rank);
+    return shape[index];
+  }
+
+  public Iterator<Integer> iterator() {
+    return new IteratorImpl();
+  }
+
+  boolean isCanonicalOrder() {
+    return canonicalOrder;
+  }
+
+  boolean isVlen() {
+    return shape.length > 0 && shape[shape.length - 1] < 0;
+  }
+
+  /** Get the total number of elements in the array. */
+  public long getSize() {
+    return size;
+  }
+
+  /**
+   * Create a new Index based on current one, except
+   * flip the index so that it runs from shape[index]-1 to 0.
+   *
+   * @param index dimension to flip, may not be vlen
+   * @return new index with flipped dimension
+   */
+  Strides flip(int index) {
+    Preconditions.checkArgument(index >= 0 && index < rank);
+    Preconditions.checkArgument(shape[index] >= 0);
+
+    Strides.Builder ib = this.toBuilder();
+    ib.offset += stride[index] * (shape[index] - 1);
+    ib.stride[index] = -stride[index];
+    ib.canonicalOrder = false;
+    return ib.build();
+  }
+
+  /**
+   * create a new Index based on a permutation of the current indices; vlen fails.
+   *
+   * @param dims: the old index dim[k] becomes the new kth index.
+   * @return new Index with permuted indices
+   */
+  Strides permute(int[] dims) {
+    Preconditions.checkArgument(dims.length == shape.length);
+    Set<Integer> used = new HashSet<>();
+    for (int dim : dims) {
+      if ((dim < 0) || (dim >= rank)) {
+        throw new IllegalArgumentException();
+      }
+      if (used.contains(dim)) {
+        throw new IllegalArgumentException();
+      }
+      used.add(dim);
+    }
+
+    boolean isPermuted = false;
+    Strides.Builder newIndex = toBuilder();
+    for (int i = 0; i < dims.length; i++) {
+      newIndex.stride[i] = stride[dims[i]];
+      newIndex.shape[i] = shape[dims[i]];
+      if (i != dims[i]) {
+        isPermuted = true;
+      }
+    }
+
+    newIndex.canonicalOrder = canonicalOrder && !isPermuted; // useful optimization
+    return newIndex.build();
+  }
+
+  Strides reshape(int[] shape) {
+    Preconditions.checkArgument(computeSize(shape) == getSize());
+    return builder(shape).build();
+  }
+
+  /**
+   * create a new Index based on a subsection of this one, with rank reduction if
+   * dimension length == 1.
+   *
+   * @param ranges array of Ranges that specify the array subset.
+   *        Must be same rank as original Array.
+   *        A particular Range: 1) may be a subset; 2) may be null, meaning use entire Range.
+   * @return new Index, with same or smaller rank as original.
+   * @throws InvalidRangeException if ranges dont match current shape
+   */
+  Strides section(List<Range> ranges) throws InvalidRangeException {
+    Preconditions.checkArgument(ranges.size() == rank);
+
+    // check ranges are valid
+    if (ranges.size() != rank)
+      throw new InvalidRangeException("Bad ranges [] length");
+    for (int ii = 0; ii < rank; ii++) {
+      Range r = ranges.get(ii);
+      if (r == null)
+        continue;
+      if (r == Range.VLEN)
+        continue;
+      if ((r.first() < 0) || (r.first() >= shape[ii]))
+        throw new InvalidRangeException("Bad range starting value at index " + ii + " == " + r.first());
+      if ((r.last() < 0) || (r.last() >= shape[ii]))
+        throw new InvalidRangeException("Bad range ending value at index " + ii + " == " + r.last());
+    }
+
+    int reducedRank = rank;
+    for (Range r : ranges) {
+      if ((r != null) && (r.length() == 1))
+        reducedRank--;
+    }
+    Strides.Builder newindex = builder(reducedRank);
+    newindex.offset = offset;
+    int[] newstride = new int[reducedRank];
+
+    // calc shape, size, and index transformations
+    // calc strides into original (backing) store
+    int newDim = 0;
+    for (int ii = 0; ii < rank; ii++) {
+      Range r = ranges.get(ii);
+      if (r == null) { // null range means use the whole original dimension
+        newindex.shape[newDim] = shape[ii];
+        newstride[newDim] = stride[ii];
+        // if (name != null) newindex.name[newDim] = name[ii];
+        newDim++;
+      } else if (r.length() != 1) {
+        newindex.shape[newDim] = r.length();
+        newstride[newDim] = stride[ii] * r.stride();
+        newindex.offset += stride[ii] * r.first();
+        // if (name != null) newindex.name[newDim] = name[ii];
+        newDim++;
+      } else {
+        newindex.offset += stride[ii] * r.first(); // constant due to rank reduction
+      }
+    }
+    newindex.setStride(newstride);
+
+    // if equal, then its not a real subset, so can still use fastIterator
+    newindex.canonicalOrder = canonicalOrder && (computeSize(newindex.shape) == size);
+    return newindex.build();
+  }
+
+  /**
+   * create a new Index based on a subsection of this one, without rank reduction.
+   *
+   * @param ranges list of Ranges that specify the array subset.
+   *        Must be same rank as original Array.
+   *        A particular Range: 1) may be a subset; 2) may be null, meaning use entire Range.
+   * @return new Index, with same rank as original.
+   * @throws InvalidRangeException if ranges dont match current shape
+   */
+  Strides sectionNoReduce(List<Range> ranges) throws InvalidRangeException {
+    Preconditions.checkArgument(ranges.size() == rank);
+
+    // check ranges are valid
+    if (ranges.size() != rank)
+      throw new InvalidRangeException("Bad ranges [] length");
+    for (int ii = 0; ii < rank; ii++) {
+      Range r = ranges.get(ii);
+      if (r == null)
+        continue;
+      if (r == Range.VLEN)
+        continue;
+      if ((r.first() < 0) || (r.first() >= shape[ii]))
+        throw new InvalidRangeException("Bad range starting value at index " + ii + " == " + r.first());
+      if ((r.last() < 0) || (r.last() >= shape[ii]))
+        throw new InvalidRangeException("Bad range ending value at index " + ii + " == " + r.last());
+    }
+
+    // allocate
+    Strides.Builder newindex = builder(rank);
+    newindex.offset = offset;
+    int[] newstride = new int[rank];
+
+    // calc shape, size, and index transformations
+    // calc strides into original (backing) store
+    for (int ii = 0; ii < rank; ii++) {
+      Range r = ranges.get(ii);
+      if (r == null) { // null range means use the whole original dimension
+        newindex.shape[ii] = shape[ii];
+        newstride[ii] = stride[ii];
+      } else {
+        newindex.shape[ii] = r.length();
+        newstride[ii] = stride[ii] * r.stride();
+        newindex.offset += stride[ii] * r.first();
+      }
+    }
+    newindex.setStride(newstride);
+
+    // if equal, then its not a real subset, so can still use fastIterator
+    newindex.canonicalOrder = canonicalOrder && (computeSize(newindex.shape) == size);
+    return newindex.build();
+  }
+
+  /**
+   * Create a new Index based on current one by
+   * eliminating any dimensions with length one.
+   *
+   * @return the new Index
+   */
+  Strides reduce() {
+    Strides c = this;
+    for (int ii = 0; ii < rank; ii++)
+      if (shape[ii] == 1) { // do this on the first one you find
+        Strides newc = c.reduce(ii);
+        return newc.reduce(); // any more to do?
+      }
+    return c;
+  }
+
+  /**
+   * Create a new Index based on current one by
+   * eliminating the specified dimension;
+   *
+   * @param dim: dimension to eliminate: must be of length one, else IllegalArgumentException
+   * @return the new Index
+   */
+  Strides reduce(int dim) {
+    if ((dim < 0) || (dim >= rank))
+      throw new IllegalArgumentException("illegal reduce dim " + dim);
+    if (shape[dim] != 1)
+      throw new IllegalArgumentException("illegal reduce dim " + dim + " : length != 1");
+
+    Strides.Builder newindex = builder(rank - 1);
+    newindex.offset = offset;
+    int[] newstride = new int[rank - 1];
+
+    int count = 0;
+    for (int ii = 0; ii < rank; ii++) {
+      if (ii != dim) {
+        newindex.shape[count] = shape[ii];
+        newstride[count] = stride[ii];
+        count++;
+      }
+    }
+    newindex.setStride(newstride);
+    newindex.canonicalOrder = canonicalOrder;
+    return newindex.build();
+  }
+
+  /**
+   * create a new Index based on current one, except
+   * transpose two of the indices.
+   *
+   * @param index1 transpose these two indices
+   * @param index2 transpose these two indices
+   * @return new Index with transposed indices
+   */
+  Strides transpose(int index1, int index2) {
+    if ((index1 < 0) || (index1 >= rank))
+      throw new IllegalArgumentException();
+    if ((index2 < 0) || (index2 >= rank))
+      throw new IllegalArgumentException();
+    if (index1 == index2)
+      return this;
+
+    Strides.Builder newIndex = toBuilder();
+    newIndex.stride[index1] = stride[index2];
+    newIndex.stride[index2] = stride[index1];
+    newIndex.shape[index1] = shape[index2];
+    newIndex.shape[index2] = shape[index1];
+
+    newIndex.setCanonicalOrder(false);
+    return newIndex.build();
+  }
+
+  public static Builder builder(int rank) {
+    return new Builder(rank);
+  }
+
+  public static Builder builder(int[] shape) {
+    return new Builder(shape.length).setShape(shape);
+  }
+
+  public Builder toBuilder() {
+    return new Builder(rank).setShape(this.shape).setStride(this.stride).setOffset(this.offset)
+        .setCanonicalOrder(this.canonicalOrder);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////
+  private final int[] shape;
+  private final int[] stride;
+  private final int rank;
+
+  private final long size; // total number of elements
+  private final int offset; // element = offset + stride[0]*current[0] + ...
+  private final boolean canonicalOrder; // can use fast iterator if in canonical order
+
+  private Strides(Builder builder) {
+    Preconditions.checkNotNull(builder.shape);
+    this.rank = builder.shape.length;
+
+    this.shape = new int[rank];
+    System.arraycopy(builder.shape, 0, this.shape, 0, rank);
+
+    if (builder.stride == null) {
+      stride = new int[rank];
+      size = computeStrides(shape);
+    } else {
+      Preconditions.checkArgument(builder.stride.length == rank);
+      this.stride = new int[rank];
+      System.arraycopy(builder.stride, 0, this.stride, 0, rank);
+      this.size = computeSize(shape);
+    }
+    this.offset = builder.offset;
+    this.canonicalOrder = builder.canonicalOrder;
+  }
+
+  /** Compute standard strides based on array's shape. Ignore vlen */
+  private long computeStrides(int[] shape) {
+    long product = 1;
+    for (int ii = shape.length - 1; ii >= 0; ii--) {
+      int thisDim = shape[ii];
+      if (thisDim < 0)
+        continue; // ignore vlen
+      this.stride[ii] = (int) product;
+      product *= thisDim;
+    }
+    return product;
+  }
+
+  public static class Builder {
+    int[] shape;
+    int[] stride;
+    int offset = 0;
+    boolean canonicalOrder = true;
+
+    Builder(int rank) {
+      shape = new int[rank];
+    }
+
+    Builder setShape(int[] shape) {
+      Preconditions.checkArgument(shape.length == this.shape.length);
+      System.arraycopy(shape, 0, this.shape, 0, shape.length);
+      return this;
+    }
+
+    Builder setStride(int[] stride) {
+      Preconditions.checkArgument(stride.length == this.shape.length);
+      this.stride = new int[this.shape.length];
+      System.arraycopy(stride, 0, this.stride, 0, stride.length);
+      return this;
+    }
+
+    Builder setOffset(int offset) {
+      this.offset = offset;
+      return this;
+    }
+
+    Builder setCanonicalOrder(boolean canonicalOrder) {
+      this.canonicalOrder = canonicalOrder;
+      return this;
+    }
+
+    public Strides build() {
+      return new Strides(this);
+    }
+  }
+
+  private class IteratorImpl implements Iterator<Integer> {
+    private int count = 0;
+    private final int[] current = new int[rank];
+
+    public boolean hasNext() {
+      return count++ < size;
+    }
+
+    public Integer next() {
+      return incr();
+    }
+
+    private int incr() {
+      int digit = rank - 1;
+      while (digit >= 0) {
+        if (shape[digit] < 0) {
+          current[digit] = -1;
+          continue;
+        } // do not increment vlen
+        current[digit]++;
+        if (current[digit] < shape[digit])
+          break; // normal exit
+        current[digit] = 0; // else, carry
+        digit--;
+      }
+      return get(current);
+    }
+  }
+
+}

--- a/cdm/core/src/main/java/ucar/ma/package.html
+++ b/cdm/core/src/main/java/ucar/ma/package.html
@@ -1,0 +1,9 @@
+<HTML>
+<HEAD>
+<TITLE>package ucar.ma</TITLE>
+</HEAD>
+<BODY>
+Experimental version of multidimensional arrays stored in memory.
+DO NOT USE.
+</BODY>
+</HTML>

--- a/cdm/core/src/main/java/ucar/nc2/Attribute.java
+++ b/cdm/core/src/main/java/ucar/nc2/Attribute.java
@@ -595,8 +595,9 @@ public class Attribute {
       if (DataType.getType(arr) == DataType.OBJECT)
         throw new IllegalArgumentException("Cant set Attribute with type " + arr.getElementType());
 
-      if (arr.getRank() > 1)
+      if (arr.getRank() > 1) {
         arr = arr.reshape(new int[] {(int) arr.getSize()}); // make sure 1D
+      }
 
       this.values = arr;
       this.nelems = (int) arr.getSize();

--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
@@ -500,13 +500,6 @@ public class NetcdfFile implements FileCacheable, Closeable {
       start = System.currentTimeMillis();
     }
 
-    /*
-     * if (unlocked) {
-     * String info = cache.getInfo(this);
-     * throw new IllegalStateException("File is unlocked - cannot use\n" + info);
-     * }
-     */
-
     if (iosp == null) {
       throw new IOException("iosp is null, perhaps file has been closed. Trying to read variable " + v.getFullName());
     }

--- a/cdm/core/src/test/java/ucar/ma/TestArray.java
+++ b/cdm/core/src/test/java/ucar/ma/TestArray.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+import ucar.ma2.DataType;
+
+/** Test {@link Array} */
+public class TestArray {
+
+  private Array<Double> array;
+
+  @Before
+  public void setup() {
+    int[] shape = new int[] {1, 2, 3};
+    double[] data = new double[] {1, 2, 3, 4, 5, 6};
+    array = Array.factory(DataType.DOUBLE, shape, data);
+  }
+
+  @Test
+  public void testArray() {
+    assertThat(array.get(0, 0, 0)).isEqualTo(1);
+    assertThat(array.get(0, 0, 1)).isEqualTo(2);
+    assertThat(array.get(0, 0, 2)).isEqualTo(3);
+    assertThat(array.get(0, 1, 0)).isEqualTo(4);
+    assertThat(array.get(0, 1, 1)).isEqualTo(5);
+    assertThat(array.get(0, 1, 2)).isEqualTo(6);
+
+    int count = 0;
+    for (double val : array) {
+      assertThat(val).isEqualTo(count + 1);
+      count++;
+    }
+
+    // Note that this does fail
+    try {
+      assertThat(array.get(0, 2, 2)).isEqualTo(8);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    }
+
+    try {
+      assertThat(array.get(0, 1)).isEqualTo(4);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  public void testFlip() {
+    Array<Double> flip0 = array.flip(0);
+    assertThat(flip0.get(0, 0, 0)).isEqualTo(1);
+    assertThat(flip0.get(0, 0, 1)).isEqualTo(2);
+    assertThat(flip0.get(0, 0, 2)).isEqualTo(3);
+    assertThat(flip0.get(0, 1, 0)).isEqualTo(4);
+    assertThat(flip0.get(0, 1, 1)).isEqualTo(5);
+    assertThat(flip0.get(0, 1, 2)).isEqualTo(6);
+
+    Array<Double> flip1 = array.flip(1);
+    assertThat(flip1.get(0, 1, 0)).isEqualTo(1);
+    assertThat(flip1.get(0, 1, 1)).isEqualTo(2);
+    assertThat(flip1.get(0, 1, 2)).isEqualTo(3);
+    assertThat(flip1.get(0, 0, 0)).isEqualTo(4);
+    assertThat(flip1.get(0, 0, 1)).isEqualTo(5);
+    assertThat(flip1.get(0, 0, 2)).isEqualTo(6);
+
+    Array<Double> flip2 = array.flip(2);
+    assertThat(flip2.get(0, 0, 2)).isEqualTo(1);
+    assertThat(flip2.get(0, 0, 1)).isEqualTo(2);
+    assertThat(flip2.get(0, 0, 0)).isEqualTo(3);
+    assertThat(flip2.get(0, 1, 2)).isEqualTo(4);
+    assertThat(flip2.get(0, 1, 1)).isEqualTo(5);
+    assertThat(flip2.get(0, 1, 0)).isEqualTo(6);
+  }
+
+  @Test
+  public void testPermute() {
+    int[] permute = new int[] {0, 2, 1};
+    Array<Double> pArray = array.permute(permute);
+    assertThat(pArray.get(0, 0, 0)).isEqualTo(1);
+    assertThat(pArray.get(0, 1, 0)).isEqualTo(2);
+    assertThat(pArray.get(0, 2, 0)).isEqualTo(3);
+    assertThat(pArray.get(0, 0, 1)).isEqualTo(4);
+    assertThat(pArray.get(0, 1, 1)).isEqualTo(5);
+    assertThat(pArray.get(0, 2, 1)).isEqualTo(6);
+
+    permute = new int[] {2, 1, 0};
+    pArray = array.permute(permute);
+    assertThat(pArray.get(0, 0, 0)).isEqualTo(1);
+    assertThat(pArray.get(1, 0, 0)).isEqualTo(2);
+    assertThat(pArray.get(2, 0, 0)).isEqualTo(3);
+    assertThat(pArray.get(0, 1, 0)).isEqualTo(4);
+    assertThat(pArray.get(1, 1, 0)).isEqualTo(5);
+    assertThat(pArray.get(2, 1, 0)).isEqualTo(6);
+
+    permute = new int[] {2, 0, 1};
+    pArray = array.permute(permute);
+    assertThat(pArray.get(0, 0, 0)).isEqualTo(1);
+    assertThat(pArray.get(1, 0, 0)).isEqualTo(2);
+    assertThat(pArray.get(2, 0, 0)).isEqualTo(3);
+    assertThat(pArray.get(0, 0, 1)).isEqualTo(4);
+    assertThat(pArray.get(1, 0, 1)).isEqualTo(5);
+    assertThat(pArray.get(2, 0, 1)).isEqualTo(6);
+
+    try {
+      permute = new int[] {0, 2, 3};
+      array.permute(permute);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    try {
+      permute = new int[] {0, 2, 2};
+      array.permute(permute);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  public void testReshape() {
+    int[] reshape = new int[] {3, 2, 1};
+    Array<Double> pArray = array.reshape(reshape);
+    assertThat(pArray.get(0, 0, 0)).isEqualTo(1);
+    assertThat(pArray.get(0, 1, 0)).isEqualTo(2);
+    assertThat(pArray.get(1, 0, 0)).isEqualTo(3);
+    assertThat(pArray.get(1, 1, 0)).isEqualTo(4);
+    assertThat(pArray.get(2, 0, 0)).isEqualTo(5);
+    assertThat(pArray.get(2, 1, 0)).isEqualTo(6);
+
+    reshape = new int[] {6, 1, 1};
+    pArray = array.reshape(reshape);
+    assertThat(pArray.get(0, 0, 0)).isEqualTo(1);
+    assertThat(pArray.get(1, 0, 0)).isEqualTo(2);
+    assertThat(pArray.get(2, 0, 0)).isEqualTo(3);
+    assertThat(pArray.get(3, 0, 0)).isEqualTo(4);
+    assertThat(pArray.get(4, 0, 0)).isEqualTo(5);
+    assertThat(pArray.get(5, 0, 0)).isEqualTo(6);
+
+    reshape = new int[] {2, 3, 1};
+    pArray = array.reshape(reshape);
+    assertThat(pArray.get(0, 0, 0)).isEqualTo(1);
+    assertThat(pArray.get(0, 1, 0)).isEqualTo(2);
+    assertThat(pArray.get(0, 2, 0)).isEqualTo(3);
+    assertThat(pArray.get(1, 0, 0)).isEqualTo(4);
+    assertThat(pArray.get(1, 1, 0)).isEqualTo(5);
+    assertThat(pArray.get(1, 2, 0)).isEqualTo(6);
+
+    try {
+      reshape = new int[] {2, 2, 2};
+      array.reshape(reshape);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+}

--- a/cdm/core/src/test/java/ucar/ma/TestArrayDouble.java
+++ b/cdm/core/src/test/java/ucar/ma/TestArrayDouble.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import ucar.ma2.DataType;
+
+/** Test {@link ArrayDouble} */
+public class TestArrayDouble {
+
+  @Test
+  public void testArrayDouble() {
+    int[] shape = new int[] {1, 2, 3};
+    Storage<Double> store = Storage.factory(DataType.DOUBLE, new double[] {1, 2, 3, 4, 5, 6});
+    ArrayDouble array = new ArrayDouble(shape, store);
+
+    assertThat(array.get(0, 0, 0)).isEqualTo(1);
+    assertThat(array.get(0, 0, 1)).isEqualTo(2);
+    assertThat(array.get(0, 0, 2)).isEqualTo(3);
+    assertThat(array.get(0, 1, 0)).isEqualTo(4);
+    assertThat(array.get(0, 1, 1)).isEqualTo(5);
+    assertThat(array.get(0, 1, 2)).isEqualTo(6);
+
+    int count = 0;
+    for (double val : array) {
+      assertThat(val).isEqualTo(count + 1);
+      count++;
+    }
+
+    // Note that this does fail
+    try {
+      assertThat(array.get(0, 2, 2)).isEqualTo(8);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    }
+
+    try {
+      assertThat(array.get(0, 1)).isEqualTo(4);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+
+  }
+
+}

--- a/cdm/core/src/test/java/ucar/ma/TestStorage.java
+++ b/cdm/core/src/test/java/ucar/ma/TestStorage.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import ucar.ma2.DataType;
+
+/** Test {@link Storage} */
+public class TestStorage {
+
+  @Test
+  public void testStorage() {
+    Storage<Double> store = Storage.factory(DataType.DOUBLE, new double[] {1, 2, 3});
+    assertThat(store.get(0)).isEqualTo(1);
+    assertThat(store.get(1)).isEqualTo(2);
+    assertThat(store.get(2)).isEqualTo(3);
+
+    try {
+      assertThat(store.get(3)).isEqualTo(4);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    }
+
+    for (Double val : store) {
+      System.out.printf("%s%n", val);
+    }
+  }
+
+}

--- a/cdm/core/src/test/java/ucar/ma/TestStrides.java
+++ b/cdm/core/src/test/java/ucar/ma/TestStrides.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.ma;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/** Test {@link Strides} */
+public class TestStrides {
+
+  @Test
+  public void testIndex() {
+    int[] shape = new int[] {1, 2, 3};
+    Strides index = Strides.builder(shape).build();
+    assertThat(index.getShape()).isEqualTo(shape);
+    assertThat(index.getSize()).isEqualTo(6);
+
+    assertThat(index.get(0, 0, 0)).isEqualTo(0);
+    assertThat(index.get(0, 0, 2)).isEqualTo(2);
+    assertThat(index.get(0, 1, 2)).isEqualTo(5);
+
+    // Note that this doesnt fail, though is out of bounds.
+    assertThat(index.get(0, 2, 2)).isEqualTo(8);
+
+    try {
+      assertThat(index.get(0, 1)).isEqualTo(4);
+      fail();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+
+  }
+
+}

--- a/cdmr/src/main/java/ucar/cdmr/CdmrDataToMa.java
+++ b/cdmr/src/main/java/ucar/cdmr/CdmrDataToMa.java
@@ -1,0 +1,522 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.cdmr;
+
+import static ucar.nc2.iosp.IospHelper.convertByteToChar;
+import com.google.protobuf.ByteString;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import ucar.cdmr.CdmRemoteProto.Data;
+import ucar.ma.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Range;
+import ucar.ma2.Section;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.EnumTypedef;
+import ucar.nc2.Group;
+import ucar.nc2.Sequence;
+import ucar.nc2.Structure;
+import ucar.nc2.Variable;
+
+/** Convert between CdmRemote Protos and Netcdf objects. */
+public class CdmrDataToMa {
+
+  private static Dimension decodeDim(CdmRemoteProto.Dimension dim) {
+    String name = (dim.getName().isEmpty() ? null : dim.getName());
+    int dimLen = dim.getIsVlen() ? -1 : (int) dim.getLength();
+    return Dimension.builder().setName(name).setIsShared(!dim.getIsPrivate()).setIsUnlimited(dim.getIsUnlimited())
+        .setIsVariableLength(dim.getIsVlen()).setLength(dimLen).build();
+  }
+
+  public static void decodeGroup(CdmRemoteProto.Group proto, Group.Builder g) {
+
+    for (CdmRemoteProto.Dimension dim : proto.getDimsList())
+      g.addDimension(CdmrDataToMa.decodeDim(dim)); // always added to group? what if private ??
+
+    for (CdmRemoteProto.Attribute att : proto.getAttsList())
+      g.addAttribute(CdmrDataToMa.decodeAtt(att));
+
+    for (CdmRemoteProto.EnumTypedef enumType : proto.getEnumTypesList())
+      g.addEnumTypedef(CdmrDataToMa.decodeEnumTypedef(enumType));
+
+    for (CdmRemoteProto.Variable var : proto.getVarsList())
+      g.addVariable(CdmrDataToMa.decodeVariable(var));
+
+    for (CdmRemoteProto.Structure s : proto.getStructsList())
+      g.addVariable(CdmrDataToMa.decodeStructure(s));
+
+    for (CdmRemoteProto.Group gp : proto.getGroupsList()) {
+      Group.Builder ng = Group.builder().setName(gp.getName());
+      g.addGroup(ng);
+      decodeGroup(gp, ng);
+    }
+  }
+
+  private static EnumTypedef decodeEnumTypedef(CdmRemoteProto.EnumTypedef enumType) {
+    List<CdmRemoteProto.EnumTypedef.EnumType> list = enumType.getMapList();
+    Map<Integer, String> map = new HashMap<>(2 * list.size());
+    for (CdmRemoteProto.EnumTypedef.EnumType et : list) {
+      map.put(et.getCode(), et.getValue());
+    }
+    DataType basetype = convertDataType(enumType.getBaseType());
+    return new EnumTypedef(enumType.getName(), map, basetype);
+  }
+
+  public static Attribute decodeAtt(CdmRemoteProto.Attribute attp) {
+    return new Attribute("name", "bvalue");
+  }
+
+  public static Variable.Builder<?> decodeVariable(CdmRemoteProto.Variable var) {
+    DataType varType = convertDataType(var.getDataType());
+    Variable.Builder<?> ncvar = Variable.builder().setName(var.getName()).setDataType(varType);
+
+    if (varType.isEnum()) {
+      ncvar.setEnumTypeName(var.getEnumType());
+    }
+
+    // The Dimensions are stored redunantly in the Variable.
+    // If shared, they must also exist in a parent Group. However, we dont yet have the Groups wired together,
+    // so that has to wait until build().
+    List<Dimension> dims = new ArrayList<>(6);
+    ucar.ma2.Section.Builder section = ucar.ma2.Section.builder();
+    for (CdmRemoteProto.Dimension dim : var.getShapeList()) {
+      dims.add(decodeDim(dim));
+      section.appendRange((int) dim.getLength());
+    }
+    ncvar.addDimensions(dims);
+
+    for (CdmRemoteProto.Attribute att : var.getAttsList())
+      ncvar.addAttribute(decodeAtt(att));
+
+    return ncvar;
+  }
+
+  public static ucar.ma2.Section decodeSection(CdmRemoteProto.Variable var) {
+    ucar.ma2.Section.Builder section = ucar.ma2.Section.builder();
+    for (CdmRemoteProto.Dimension dim : var.getShapeList()) {
+      section.appendRange((int) dim.getLength());
+    }
+    return section.build();
+  }
+
+  private static Structure.Builder<?> decodeStructure(CdmRemoteProto.Structure s) {
+    Structure.Builder<?> ncvar =
+        (s.getDataType() == CdmRemoteProto.DataType.SEQUENCE) ? Sequence.builder() : Structure.builder();
+
+    ncvar.setName(s.getName()).setDataType(convertDataType(s.getDataType()));
+
+    List<Dimension> dims = new ArrayList<>(6);
+    for (CdmRemoteProto.Dimension dim : s.getShapeList()) {
+      dims.add(decodeDim(dim));
+    }
+    ncvar.addDimensions(dims);
+
+    for (CdmRemoteProto.Attribute att : s.getAttsList()) {
+      ncvar.addAttribute(decodeAtt(att));
+    }
+
+    for (CdmRemoteProto.Variable vp : s.getVarsList()) {
+      ncvar.addMemberVariable(decodeVariable(vp));
+    }
+
+    for (CdmRemoteProto.Structure sp : s.getStructsList()) {
+      ncvar.addMemberVariable(decodeStructure(sp));
+    }
+
+    return ncvar;
+  }
+
+  @Nonnull
+  public static Section decodeSection(CdmRemoteProto.Section proto) {
+    Section.Builder section = Section.builder();
+
+    for (CdmRemoteProto.Range pr : proto.getRangeList()) {
+      try {
+        long stride = pr.getStride();
+        if (stride == 0)
+          stride = 1; // default in protobuf2 was 1, but protobuf3 is 0, luckily 0 is illegal
+        if (pr.getSize() == 0)
+          section.appendRange(Range.EMPTY); // used for scalars LOOK really used ??
+        else {
+          // this.last = first + (this.length-1) * stride;
+          section.appendRange((int) pr.getStart(), (int) (pr.getStart() + (pr.getSize() - 1) * stride), (int) stride);
+        }
+
+      } catch (InvalidRangeException e) {
+        throw new RuntimeException("Bad Section in CdmRemote", e);
+      }
+    }
+    return section.build();
+  }
+
+  // Note that this converts to Objects, so not very efficient ??
+  public static Array<?> decodeData(Data data, CdmRemoteProto.Section proto) {
+    Section section = decodeSection(proto);
+    DataType dataType = convertDataType(data.getDataType());
+    int[] shape = section.getShape();
+    switch (dataType) {
+      case CHAR: {
+        byte[] array = data.getBdata(0).toByteArray();
+        return Array.factory(dataType, shape, convertByteToChar(array));
+      }
+      case ENUM1:
+      case UBYTE:
+      case BYTE: {
+        byte[] array = data.getBdata(0).toByteArray();
+        return Array.factory(dataType, shape, array);
+      }
+      case SHORT: {
+        int i = 0;
+        short[] array = new short[data.getIdataCount()];
+        for (int val : data.getIdataList()) {
+          array[i++] = (short) val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case INT: {
+        int i = 0;
+        int[] array = new int[data.getIdataCount()];
+        for (int val : data.getIdataList()) {
+          array[i++] = val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case ENUM2:
+      case USHORT: {
+        int i = 0;
+        short[] array = new short[data.getUidataCount()];
+        for (int val : data.getUidataList()) {
+          array[i++] = (short) val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case ENUM4:
+      case UINT: {
+        int i = 0;
+        int[] array = new int[data.getUidataCount()];
+        for (int val : data.getUidataList()) {
+          array[i++] = val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case LONG: {
+        int i = 0;
+        long[] array = new long[data.getLdataCount()];
+        for (long val : data.getLdataList()) {
+          array[i++] = val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case ULONG: {
+        int i = 0;
+        long[] array = new long[data.getUldataCount()];
+        for (long val : data.getUldataList()) {
+          array[i++] = val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case FLOAT: {
+        int i = 0;
+        float[] array = new float[data.getFdataCount()];
+        for (float val : data.getFdataList()) {
+          array[i++] = val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case DOUBLE: {
+        int i = 0;
+        double[] array = new double[data.getDdataCount()];
+        for (double val : data.getDdataList()) {
+          array[i++] = val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      case STRING: {
+        int i = 0;
+        Object[] array = new Object[data.getSdataCount()];
+        for (String val : data.getSdataList()) {
+          array[i++] = val;
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      /*
+       * case SEQUENCE:
+       * case STRUCTURE: {
+       * return decodeArrayStructureData(data, new Section(shape));
+       * }
+       */
+      case OPAQUE: {
+        int i = 0;
+        Object[] array = new Object[data.getBdataCount()];
+        for (ByteString val : data.getBdataList()) {
+          array[i++] = ByteBuffer.wrap(val.toByteArray());
+        }
+        return Array.factory(dataType, shape, array);
+      }
+      default:
+        throw new IllegalStateException("Unkown datatype " + dataType);
+    }
+  }
+
+  /*
+   * public static Array decodeVlenData(Data data, Section section) {
+   * Preconditions.checkArgument(data.getVlenCount() > 0);
+   * int[] shape = section.toBuilder().removeLast().build().getShape();
+   * int length = (int) Index.computeSize(shape);
+   * Preconditions.checkArgument(length == data.getVlenCount());
+   * Array[] storage = new Array[length];
+   * DataType dataType = convertDataType(data.getDataType());
+   * 
+   * int innerStart = 0;
+   * for (int index = 0; index < length; index++) {
+   * int innerLength = data.getVlen(index);
+   * int innerEnd = innerStart + innerLength;
+   * int[] innerShape = new int[] {innerLength};
+   * switch (dataType) {
+   * case CHAR: {
+   * byte[] array = data.getBdata(index).toByteArray();
+   * storage[index] = Array.factory(dataType, innerShape, convertByteToChar(array));
+   * break;
+   * }
+   * case ENUM1:
+   * case UBYTE:
+   * case BYTE: {
+   * byte[] array = data.getBdata(index).toByteArray();
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case SHORT: {
+   * int i = 0;
+   * short[] array = new short[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = (short) data.getIdata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case INT: {
+   * int i = 0;
+   * int[] array = new int[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = data.getIdata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case ENUM2:
+   * case USHORT: {
+   * int i = 0;
+   * short[] array = new short[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = (short) data.getUidata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case ENUM4:
+   * case UINT: {
+   * int i = 0;
+   * int[] array = new int[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = data.getUidata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case LONG: {
+   * int i = 0;
+   * long[] array = new long[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = data.getLdata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case ULONG: {
+   * int i = 0;
+   * long[] array = new long[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = data.getUldata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case FLOAT: {
+   * int i = 0;
+   * float[] array = new float[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = data.getFdata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case DOUBLE: {
+   * int i = 0;
+   * double[] array = new double[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = data.getDdata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case STRING: {
+   * int i = 0;
+   * Object[] array = new Object[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * array[i++] = data.getSdata(innerIndex);
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * case OPAQUE: {
+   * int i = 0;
+   * Object[] array = new Object[innerLength];
+   * for (int innerIndex = innerStart; innerIndex < innerEnd; innerIndex++) {
+   * ByteString val = data.getBdata(innerIndex);
+   * array[i++] = ByteBuffer.wrap(val.toByteArray());
+   * }
+   * storage[index] = Array.factory(dataType, innerShape, array);
+   * break;
+   * }
+   * default:
+   * throw new IllegalStateException("Unkown datatype " + dataType);
+   * }
+   * innerStart = innerEnd;
+   * }
+   * return Array.makeVlenArray(shape, storage);
+   * }
+   */
+
+  ////////////////////////////////////////////////////////////////
+
+  public static CdmRemoteProto.DataType convertDataType(DataType dtype) {
+    switch (dtype) {
+      case CHAR:
+        return CdmRemoteProto.DataType.CHAR;
+      case BYTE:
+        return CdmRemoteProto.DataType.BYTE;
+      case SHORT:
+        return CdmRemoteProto.DataType.SHORT;
+      case INT:
+        return CdmRemoteProto.DataType.INT;
+      case LONG:
+        return CdmRemoteProto.DataType.LONG;
+      case FLOAT:
+        return CdmRemoteProto.DataType.FLOAT;
+      case DOUBLE:
+        return CdmRemoteProto.DataType.DOUBLE;
+      case STRING:
+        return CdmRemoteProto.DataType.STRING;
+      case STRUCTURE:
+        return CdmRemoteProto.DataType.STRUCTURE;
+      case SEQUENCE:
+        return CdmRemoteProto.DataType.SEQUENCE;
+      case ENUM1:
+        return CdmRemoteProto.DataType.ENUM1;
+      case ENUM2:
+        return CdmRemoteProto.DataType.ENUM2;
+      case ENUM4:
+        return CdmRemoteProto.DataType.ENUM4;
+      case OPAQUE:
+        return CdmRemoteProto.DataType.OPAQUE;
+      case UBYTE:
+        return CdmRemoteProto.DataType.UBYTE;
+      case USHORT:
+        return CdmRemoteProto.DataType.USHORT;
+      case UINT:
+        return CdmRemoteProto.DataType.UINT;
+      case ULONG:
+        return CdmRemoteProto.DataType.ULONG;
+    }
+    throw new IllegalStateException("illegal data type " + dtype);
+  }
+
+  public static DataType convertDataType(CdmRemoteProto.DataType dtype) {
+    switch (dtype) {
+      case CHAR:
+        return DataType.CHAR;
+      case BYTE:
+        return DataType.BYTE;
+      case SHORT:
+        return DataType.SHORT;
+      case INT:
+        return DataType.INT;
+      case LONG:
+        return DataType.LONG;
+      case FLOAT:
+        return DataType.FLOAT;
+      case DOUBLE:
+        return DataType.DOUBLE;
+      case STRING:
+        return DataType.STRING;
+      case STRUCTURE:
+        return DataType.STRUCTURE;
+      case SEQUENCE:
+        return DataType.SEQUENCE;
+      case ENUM1:
+        return DataType.ENUM1;
+      case ENUM2:
+        return DataType.ENUM2;
+      case ENUM4:
+        return DataType.ENUM4;
+      case OPAQUE:
+        return DataType.OPAQUE;
+      case UBYTE:
+        return DataType.UBYTE;
+      case USHORT:
+        return DataType.USHORT;
+      case UINT:
+        return DataType.UINT;
+      case ULONG:
+        return DataType.ULONG;
+    }
+    throw new IllegalStateException("illegal data type " + dtype);
+  }
+
+  /*
+   * public static ArrayStructure decodeArrayStructureData(Data arrayStructureProto, Section section) {
+   * int nrows = arrayStructureProto.getRowsCount();
+   * Preconditions.checkArgument(nrows > 0);
+   * Preconditions.checkArgument(section.getSize() == nrows);
+   * 
+   * StructureMembers.Builder membersb = StructureMembers.builder();
+   * for (StructureMemberProto memberProto : arrayStructureProto.getMembersList()) {
+   * MemberBuilder memberb = StructureMembers.memberBuilder();
+   * memberb.setName(memberProto.getName());
+   * memberb.setDataType(convertDataType(memberProto.getDataType()));
+   * memberb.setShape(Ints.toArray(memberProto.getShapeList()));
+   * membersb.addMember(memberb);
+   * }
+   * StructureMembers members = membersb.build();
+   * 
+   * ArrayStructureW result = new ArrayStructureW(members, section.getShape());
+   * // row oriented
+   * int index = 0;
+   * for (CdmRemoteProto.StructureDataProto row : arrayStructureProto.getRowsList()) {
+   * result.setStructureData(decodeStructureData(row, members), index);
+   * index++;
+   * }
+   * return result;
+   * }
+   * 
+   * public static StructureData decodeStructureData(CdmRemoteProto.StructureDataProto structDataProto,
+   * StructureMembers members) {
+   * StructureDataW sdata = new StructureDataW(members);
+   * for (int i = 0; i < structDataProto.getStructDataCount(); i++) {
+   * Data data = structDataProto.getStructData(i);
+   * Member member = members.getMember(i);
+   * sdata.setMemberData(member, decodeData(data, new Section(member.getShape())));
+   * }
+   * return sdata;
+   * }
+   */
+
+}

--- a/cdmr/src/main/java/ucar/cdmr/server/CdmrServer.java
+++ b/cdmr/src/main/java/ucar/cdmr/server/CdmrServer.java
@@ -1,8 +1,13 @@
 package ucar.cdmr.server;
 
 import com.google.common.base.Stopwatch;
+import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +41,10 @@ public class CdmrServer {
   private void start() throws IOException {
     /* The port on which the server should run */
     int port = 16111;
-    server = ServerBuilder.forPort(port).addService(new CdmRemoteImpl()).build().start();
+    server = ServerBuilder.forPort(port) //
+        .addService(new CdmRemoteImpl()) //
+        // .intercept(new MyServerInterceptor())
+        .build().start();
     logger.info("Server started, listening on " + port);
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -72,6 +80,19 @@ public class CdmrServer {
     final CdmrServer server = new CdmrServer();
     server.start();
     server.blockUntilShutdown();
+  }
+
+  static class MyServerInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata requestHeaders,
+        ServerCallHandler<ReqT, RespT> next) {
+      System.out.printf("***ServerCall %s%n", call);
+      System.out.printf("   Attributes %s%n", call.getAttributes());
+      System.out.printf("   MethodDesc %s%n", call.getMethodDescriptor());
+      System.out.printf("   Authority %s%n", call.getAuthority());
+      System.out.printf("   Metadata %s%n", requestHeaders);
+      return next.startCall(call, requestHeaders);
+    }
   }
 
   static class CdmRemoteImpl extends CdmRemoteImplBase {

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblemNeeds.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblemNeeds.java
@@ -4,6 +4,7 @@
  */
 package ucar.cdmr.client;
 
+import com.google.common.base.Stopwatch;
 import java.util.Formatter;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,6 +33,7 @@ public class TestCdmrProblemNeeds {
   @Test
   public void doOne() throws Exception {
     System.out.printf("TestCdmrProblem %s%n", filename);
+    Stopwatch stopwatch = Stopwatch.createStarted();
     try (NetcdfFile ncfile = NetcdfDatasets.openFile(filename, null);
         CdmrNetcdfFile cdmrFile = CdmrNetcdfFile.builder().setRemoteURI(cdmrUrl).build()) {
 
@@ -42,5 +44,6 @@ public class TestCdmrProblemNeeds {
       }
       Assert.assertTrue(ok);
     }
+    System.out.printf("*** That took %s%n", stopwatch.stop());
   }
 }


### PR DESCRIPTION
An alternative way of handling multiple messages is to change Array to allow multiple primitive arrays in a single Array. Ive added an experimental package (ucar.ma) to try that out. CdmrClient uses it, to test performance. At the moment, doesnt appear to help much, over the current method of concatenating arrays together.

ucar.ma is probably the start of a (much needed) rewrite of ucar.ma2, but will not use it until maybe version 7?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/469)
<!-- Reviewable:end -->
