### PR TITLE
cdm-lite infrastructure work

### DIFF
--- a/cdm-lite/build.gradle
+++ b/cdm-lite/build.gradle
@@ -15,8 +15,6 @@ dependencies {
   api project(':httpservices')
   api project(':opendap')
 
-  implementation 'com.google.guava:guava'
-
   compile 'com.google.guava:guava'
   compile 'org.jdom:jdom2'
   compile 'com.google.code.findbugs:jsr305'
@@ -67,4 +65,24 @@ war {
     into 'docs'
     expand properties
   }
+}
+
+// make the cdm-lite server available for tests
+import org.akhikhl.gretty.AppBeforeIntegrationTestTask
+import org.akhikhl.gretty.AppAfterIntegrationTestTask
+
+task('AppWarBeforeIntegrationTest', type: AppBeforeIntegrationTestTask) {
+  inplace = false
+  integrationTestTask 'test'
+}
+task('AppWarAfterIntegrationTest', type: AppAfterIntegrationTestTask) {
+  integrationTestTask 'test'
+}
+
+AppWarBeforeIntegrationTest.dependsOn assemble
+AppWarAfterIntegrationTest.mustRunAfter AppWarBeforeIntegrationTest
+
+gretty {
+  httpPort = 8080
+  contextPath = '/'
 }

--- a/cdm-lite/src/main/java/thredds/server/opendap/GetHTMLInterfaceHandler2.java
+++ b/cdm-lite/src/main/java/thredds/server/opendap/GetHTMLInterfaceHandler2.java
@@ -39,11 +39,11 @@ public class GetHTMLInterfaceHandler2 {
   private static final boolean _Debug = false;
   private String helpLocation = "http://www.opendap.org/online_help_files/";
 
-  @Autowired
+  // @Autowired
   private String serverContactName = "UNKNOWN";
-  @Autowired
+  // @Autowired
   private String serverContactEmail = "UNKNOWN";
-  @Autowired
+  // @Autowired
   private String odapSupportEmail = "support@opendap.org";
 
   /**

--- a/cdm-lite/src/main/java/thredds/server/opendap/OpendapServlet.java
+++ b/cdm-lite/src/main/java/thredds/server/opendap/OpendapServlet.java
@@ -31,6 +31,7 @@ import opendap.dap.DString;
 import opendap.dap.DStructure;
 import opendap.dap.NoSuchTypeException;
 import opendap.dap.parsers.ParseException;
+import org.springframework.beans.factory.InitializingBean;
 import thredds.server.opendap.servers.CEEvaluator;
 import thredds.server.opendap.servers.SDArray;
 import thredds.server.opendap.servers.ServerDDS;
@@ -56,23 +57,23 @@ import ucar.nc2.internal.util.EscapeStrings;
 /** THREDDS opendap server. */
 @Controller
 @RequestMapping("/dods")
-public class OpendapServlet extends AbstractServlet {
+public class OpendapServlet extends AbstractServlet implements InitializingBean {
   static public org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OpendapServlet.class);
   static org.slf4j.Logger logServerStartup = org.slf4j.LoggerFactory.getLogger("serverStartup");
 
-  @Autowired
+  // @Autowired
   int opendapAscLimit = 50; // MB
 
-  @Autowired
+  // @Autowired
   int opendapBinLimit = 500; // MB
 
-  @Autowired
+  // @Autowired
   String opendapVersionString = "opendap/3.7";
 
-  @Autowired
+  // @Autowired
   private String serverContactName = "UNKNOWN";
 
-  @Autowired
+  // @Autowired
   private String serverContactEmail = "UNKNOWN";
 
   private boolean allowSessions = false;
@@ -82,7 +83,7 @@ public class OpendapServlet extends AbstractServlet {
   private boolean debugSession = false;
 
   // TODO removed @PostConstruct, what replaces it? probably not override HttpServlet?
-  public void init() {
+  public void afterPropertiesSet() {
     logServerStartup.info(getClass().getName() + " initialization start");
     logServerStartup.info(getClass().getName() + " version= " + opendapVersionString + " ascLimit = " + opendapAscLimit
         + " binLimit = " + opendapBinLimit);

--- a/cdm-lite/src/main/java/thredds/server/opendap/servlet/AbstractServlet.java
+++ b/cdm-lite/src/main/java/thredds/server/opendap/servlet/AbstractServlet.java
@@ -121,7 +121,7 @@ public abstract class AbstractServlet extends HttpServlet {
   }
 
   /** path to the root of the servlet in tomcat webapps directory */
-  @Autowired
+  // @Autowired
   String servletRootPath = "";
 
   protected boolean allowDeflate = true;

--- a/cdm-lite/src/main/webapp/WEB-INF/app-Context.xml
+++ b/cdm-lite/src/main/webapp/WEB-INF/app-Context.xml
@@ -20,21 +20,21 @@
 
     <!-- Properties -->
     <!-- tell spring that tds.properties gets read in first and overrides anything else -->
-    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+    <!--bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"-->
         <!-- Check system properties before looking in tds.properties. -->
-        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE"/>
+        <!--property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE"/-->
 
         <!-- Default is "false": An exception will be thrown if a placeholder fails to resolve.
         Switch this flag to "true" in order to preserve the placeholder String as-is in such a case,
         leaving it up to other placeholder configurers to resolve it. -->
-        <property name="ignoreUnresolvablePlaceholders" value="true"/>
+        <!--property name="ignoreUnresolvablePlaceholders" value="true"/-->
 
-        <property name="locations">
+        <!--property name="locations">
             <list>
                 <value>classpath:thredds/server/tds.properties</value>
             </list>
-        </property>
-    </bean>
+        </property-->
+    <!--/bean-->
 
     <util:map id="dataRootLocationAliasExpanders" map-class="java.util.HashMap">
         <entry key="cdmUnitTest" value="${unidata.testdata.path}/cdmUnitTest"/>

--- a/cdm-lite/src/main/webapp/WEB-INF/web.xml
+++ b/cdm-lite/src/main/webapp/WEB-INF/web.xml
@@ -16,7 +16,7 @@
 
   <context-param>
     <param-name>contextConfigLocation</param-name>
-    <param-value>/WEB-INF/app-context.xml</param-value>
+    <param-value>/WEB-INF/app-Context.xml</param-value>
   </context-param>
 
   <servlet>

--- a/cdm-lite/src/test/java/thredds/server/opendap/OpendapServletTest.java
+++ b/cdm-lite/src/test/java/thredds/server/opendap/OpendapServletTest.java
@@ -35,7 +35,7 @@ import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 public class OpendapServletTest {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  @Autowired
+  // @Autowired
   private ServletConfig servletConfig;
 
   private OpendapServlet opendapServlet;


### PR DESCRIPTION
This PR does some work to `cdm-lite` to enable running a server, both through IntelliJ and using gradle + gretty. Details on how to do that below. A few things were needed to do this:

* Disable `@Autowire` of beans
 * `tds.properties` not included in the `cdm-lite` project, so could not do the `@Autowire` magic. However, we should think about the role of a `tds.properties` in a `cdm-lite`, and maybe even get rid of it all together?
* Fixed a typo in the name of the application context (was `app-context.xml`, but is really called `app-Context.xml`).
* Not critical for getting a server up-and-running, but replaced `@PostConstruct` with Spring's `InitializingBean` (if needed down the road).

Finally, this adds the machinery to have gradle spin up a local `cdm-lite` server prior to running the `cdm-lite` tests. What we should do is add a new source set, say `cdm-lite/fullServerTests`, in which all tests that need a local server spun up will live (and things like unit tests or mock tests can live in `cdm-lite/test`). That way, if we want to run a mock test, we don't have to wait for gretty to spin up a server that ultimately goes unused. Once we have a few tests going, I can come back and do the gradle magic to make that happen. Side note: this is something we should think about for other subprojects as well, like the `opendap` client and `httpservices`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/475)
<!-- Reviewable:end -->
