### PR TITLE
Correctly handle GINI negative calibration values

### DIFF
--- a/cdm/image/build.gradle
+++ b/cdm/image/build.gradle
@@ -12,6 +12,6 @@ dependencies {
   compile 'org.slf4j:slf4j-api'
 
   testImplementation project(':cdm-test-utils')
-
   testImplementation 'junit:junit'
+  testImplementation 'com.google.truth:truth'
 }

--- a/cdm/image/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
+++ b/cdm/image/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
@@ -607,7 +607,7 @@ class Giniheader {
           // According to https://github.com/Unidata/gempak/blob/master/gempak/source/gemlib/mv/Linux/mvitob.c,
           // which is used when writing gini files, if the first bit is set, that indicates that we have a negative
           // value and need to do a bit more work.
-          // Check if left-most bit is 1. Left shift bit pattern of value 31 times. This will make all bits 0, or
+          // Check if left-most bit is 1. Right shift bit pattern of value 31 times. This will make all bits 0, or
           // all bits 1. If all 0, then the result will equal zero. If all 1's, then the result will equal -1, and
           // that's how we know we need to do more work.
           if ((mind >> 31) == -1) {
@@ -615,7 +615,7 @@ class Giniheader {
             // 0x7FFFFFFF -> left-most bit is zero, all the rest are 1's.
             // The bit-wise & results in flipping the first bit of "mind" (because we know it is 1 at this point, and
             // 1 & 0 -> 0) while retaining the rest of the pattern of mind (because 0 & 1 -> 0, 1 & 1 -> 1).
-            // To negate, just use the negative sign...we could do (mind & 0x7FFFFFFF) + 1, but let's not hang out
+            // To negate, just use the negative sign...we could do ~(mind & 0x7FFFFFFF) + 1, but let's not hang out
             // in bit operator land longer than we need to.
             mind = -(mind & 0x7FFFFFFF);
           }

--- a/cdm/image/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
+++ b/cdm/image/src/main/java/ucar/nc2/iosp/gini/Giniheader.java
@@ -28,6 +28,11 @@ import java.nio.*;
  */
 
 class Giniheader {
+  // Unidata Gini table:
+  // https://github.com/Unidata/gempak/blob/master/gempak/tables/unidata/nex2gini.tbl
+  // Special instructions for handling negative numbers
+  // https://github.com/Unidata/gempak/blob/master/gempak/source/gemlib/mv/Linux/mvitob.c
+  //
   private static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Giniheader.class);
 
   private static final int GINI_PIB_LEN = 21; // gini product identification block
@@ -494,6 +499,7 @@ class Giniheader {
     xaxis.setDataType(DataType.DOUBLE);
     xaxis.setDimensions("x");
     xaxis.addAttribute(new Attribute(CDM.LONG_NAME, "projection x coordinate"));
+    xaxis.addAttribute(new Attribute(CF.STANDARD_NAME, "projection_x_coordinate"));
     xaxis.addAttribute(new Attribute(CDM.UNITS, "km"));
     xaxis.addAttribute(new Attribute(_Coordinate.AxisType, "GeoX"));
     double[] data = new double[nx];
@@ -524,6 +530,7 @@ class Giniheader {
     yaxis.setDataType(DataType.DOUBLE);
     yaxis.setDimensions("y");
     yaxis.addAttribute(new Attribute(CDM.LONG_NAME, "projection y coordinate"));
+    yaxis.addAttribute(new Attribute(CF.STANDARD_NAME, "projection_y_coordinate"));
     yaxis.addAttribute(new Attribute(CDM.UNITS, "km"));
     yaxis.addAttribute(new Attribute(_Coordinate.AxisType, "GeoY"));
     data = new double[ny];
@@ -589,10 +596,35 @@ class Giniheader {
         for (int i = 0; i < calcod; i++) {
 
           bos.position(56 + i * 16);
+          // We expect these to always be positive, so just read the int as-is
           int minb = bos.getInt() / 10000; /* min brightness values */
           int maxb = bos.getInt() / 10000; /* max brightness values */
+
+          // Since these are data values, we need to consider the case of them being positive or negative
+          // Careful though, it's not that easy. Step one is to read the 32-bits like before...
           int mind = bos.getInt(); /* min data values */
+          // Now for the fun.
+          // According to https://github.com/Unidata/gempak/blob/master/gempak/source/gemlib/mv/Linux/mvitob.c,
+          // which is used when writing gini files, if the first bit is set, that indicates that we have a negative
+          // value and need to do a bit more work.
+          // Check if left-most bit is 1. Left shift bit pattern of value 31 times. This will make all bits 0, or
+          // all bits 1. If all 0, then the result will equal zero. If all 1's, then the result will equal -1, and
+          // that's how we know we need to do more work.
+          if ((mind >> 31) == -1) {
+            // Set the first bit to zero, and negate the value (again, described in mvitob.c from gempak)
+            // 0x7FFFFFFF -> left-most bit is zero, all the rest are 1's.
+            // The bit-wise & results in flipping the first bit of "mind" (because we know it is 1 at this point, and
+            // 1 & 0 -> 0) while retaining the rest of the pattern of mind (because 0 & 1 -> 0, 1 & 1 -> 1).
+            // To negate, just use the negative sign...we could do (mind & 0x7FFFFFFF) + 1, but let's not hang out
+            // in bit operator land longer than we need to.
+            mind = -(mind & 0x7FFFFFFF);
+          }
+
+          // same thing as above
           int maxd = bos.getInt(); /* max data values */
+          if ((maxd >> 31) == -1) {
+            maxd = -(maxd & 0x7FFFFFFF);
+          }
 
           int idscal = 1;
           while (mind % idscal == 0 && maxd % idscal == 0) {

--- a/cdm/image/src/test/java/ucar/nc2/iosp/gini/TestGiniNegativeCalibrationValues.java
+++ b/cdm/image/src/test/java/ucar/nc2/iosp/gini/TestGiniNegativeCalibrationValues.java
@@ -1,0 +1,36 @@
+package ucar.nc2.iosp.gini;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import ucar.ma2.Array;
+import ucar.ma2.MAMath;
+import ucar.ma2.MAMath.MinMax;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+@Category(NeedsCdmUnitTest.class)
+public class TestGiniNegativeCalibrationValues {
+
+  @Test
+  public void testMinMaxValues() throws IOException {
+    try (NetcdfFile ncfile =
+        NetcdfFiles.open(TestDir.cdmUnitTestDir + "formats/gini/images_sat_NEXRCOMP_1km_n0r_n0r_20200907_0740")) {
+      Variable variable = ncfile.findVariable("Reflectivity");
+      Array array = variable.read();
+      MinMax minMax = MAMath.getMinMax(array);
+      // If the bug reported in https://github.com/Unidata/netcdf-java/issues/480 shows up, and we are
+      // incorrectly reading the calibration coefficients from the GINI file headers "Unidata cal block"
+      // (in the case of the original bug, we were decoding negative numbers as intended), the data values
+      // will be on the order of -3.9 x 10^5 for the minimum, and -2.1 x 10^5 for the maximum. Those
+      // values (radar reflectivity) should be -30 dBZ to 60 dBZ.
+      assertThat(minMax.min).isWithin(1e-6).of(-30);
+      assertThat(minMax.max).isWithin(1e-6).of(60);
+    }
+  }
+}


### PR DESCRIPTION
GINI calibration values can be negative (for the data value range), and GEMPAK uses the left most bit of the stored integer to designate the signedness. Fixes Unidata/netcdf-java#480

Minor addition - since the `long_name` attribute was there and so close, go ahead an add the `standard_name` attribute to the `x` and `y` coordinate variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/488)
<!-- Reviewable:end -->
