### PR TITLE
Improve region selection on AWS S3

### DIFF
--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
@@ -8,7 +8,7 @@ package ucar.unidata.io.s3;
 import static com.google.common.truth.Truth.assertThat;
 import java.io.IOException;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import software.amazon.awssdk.regions.Region;
@@ -50,6 +50,7 @@ public class TestS3ExternalCompressionRead {
   }
 
   @Test
+  @Ignore("Failing. Reason: This operation is not permitted on an archived blob. ?")
   public void testMicrosoftBlobS3() throws IOException {
     // https://nexradsa.blob.core.windows.net/nexrad-l2/1997/07/07/KHPX/KHPX19970707_000827.gz
     String host = "nexradsa.blob.core.windows.net";

--- a/docs/src/public/userguide/pages/netcdfJava/developer/DatasetUrls.md
+++ b/docs/src/public/userguide/pages/netcdfJava/developer/DatasetUrls.md
@@ -120,11 +120,11 @@ Example `cdms3` URIs (specific to AWS S3):
 * cdms3://profile_name@aws/bucket-name?super/long/key
 
 Note: In order to supply a profile name (one way to set the region and/or credentials) while maintaining conformance to the URI specification, you may use "aws" as the host.
-In addition to the Use of the credentials file for setting the region, as described above, the region may be set using the `aws.region` Java System Property, or the `AWS_REGION` environmental variable.
-Note that a region set in the credentials file takes precedence over all others.
-Possible values for region can be found in the [AWS Regional endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints){:target="_blank"} documentation.
+In addition to the use of the credentials file for setting the region, as described above, the region may be set using the `aws.region` Java System Property, or the `AWS_REGION` environment variable.
+Note that a region set within the credentials file for the `default` profile will take precedence over all others.
+Possible values for the region code can be found in the [AWS Regional endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints){:target="_blank"} documentation.
  
-The following examples show how one could access the same GOES 16 data file across a variety of Object Store technologies (special thanks to the [NOAA Big Data project's](https://www.noaa.gov/big-data-project){:target="_blank"})):
+The following examples show how one could access the same GOES 16 data file across a variety of Object Store technologies (special thanks to the [NOAA Big Data project's](https://www.noaa.gov/big-data-project){:target="_blank"}):
 
 [AWS S3 bucket](https://registry.opendata.aws/noaa-goes/){:target="_blank"} in the US East 1 region (open access):
 

--- a/docs/src/public/userguide/pages/netcdfJava/developer/DatasetUrls.md
+++ b/docs/src/public/userguide/pages/netcdfJava/developer/DatasetUrls.md
@@ -120,11 +120,11 @@ Example `cdms3` URIs (specific to AWS S3):
 * cdms3://profile_name@aws/bucket-name?super/long/key
 
 Note: In order to supply a profile name (one way to set the region and/or credentials) while maintaining conformance to the URI specification, you may use "aws" as the host.
-When the generic "aws" host is used, netCDF-Java will allow the AWS SDK to set the appropriate host based on region.
-There are multiple to set a region, and they are described in the [AWS Documentation](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-region-selection.html#default-region-provider-chain){:target="_blank"}.
-Use of the credentials file, as described above, takes precedence over all others.
+In addition to the Use of the credentials file for setting the region, as described above, the region may be set using the `aws.region` Java System Property, or the `AWS_REGION` environmental variable.
+Note that a region set in the credentials file takes precedence over all others.
+Possible values for region can be found in the [AWS Regional endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints){:target="_blank"} documentation.
  
-The following examples show how one could access the same GOES 16 data file across a variety of Object Store technologies (special thanks to the [NOAA Big Data project's](https://www.noaa.gov/big-data-project){:target="_blank"}):
+The following examples show how one could access the same GOES 16 data file across a variety of Object Store technologies (special thanks to the [NOAA Big Data project's](https://www.noaa.gov/big-data-project){:target="_blank"})):
 
 [AWS S3 bucket](https://registry.opendata.aws/noaa-goes/){:target="_blank"} in the US East 1 region (open access):
 


### PR DESCRIPTION
Uncovered some issues with region selection when using AWS IAM for managing credentials. Updated the docs with more information about how to set the region.

Also, the test against the Azure blob store for nexrad level 2 fails with the message "[t]his operation is not permitted on an archived blob.". Turning off for now, as the object cannot be accessed through the browser any longer, either. Might need to refactor these tests to use a more recent level 2 object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/492)
<!-- Reviewable:end -->
