### PR TITLE
Fix Vlens,  iterator returns Array<T>

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5eos.java
+++ b/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5eos.java
@@ -74,11 +74,11 @@ public class TestH5eos {
     try (NetcdfFile ncfile = TestH5.openH5("HIRDLS/HIRDLS1_v4.0.2a-aIrix-c2_2003d106.he5")) {
       Variable v = ncfile.findVariable("HDFEOS/SWATHS/HIRDLS_L1_Swath/Data_Fields/Elevation_Angle");
       assertThat(v).isNotNull();
-      assertThat(v.getRank()).isEqualTo(4);
-      assertThat(v.getDimension(0).getShortName()).isEqualTo("MaF");
-      assertThat(v.getDimension(1).getShortName()).isEqualTo("MiF");
-      assertThat(v.getDimension(2).getShortName()).isEqualTo("CR");
-      assertThat(v.getDimension(3).getShortName()).isEqualTo("CC");
+      assertThat( v.getRank()).isEqualTo(4);
+      assertThat( v.getDimension(0).getShortName()).isEqualTo("MaF");
+      assertThat( v.getDimension(1).getShortName()).isEqualTo("MiF");
+      assertThat( v.getDimension(2).getShortName()).isEqualTo("CR");
+      assertThat( v.getDimension(3).getShortName()).isEqualTo("CC");
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5eos.java
+++ b/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5eos.java
@@ -74,11 +74,11 @@ public class TestH5eos {
     try (NetcdfFile ncfile = TestH5.openH5("HIRDLS/HIRDLS1_v4.0.2a-aIrix-c2_2003d106.he5")) {
       Variable v = ncfile.findVariable("HDFEOS/SWATHS/HIRDLS_L1_Swath/Data_Fields/Elevation_Angle");
       assertThat(v).isNotNull();
-      assertThat( v.getRank()).isEqualTo(4);
-      assertThat( v.getDimension(0).getShortName()).isEqualTo("MaF");
-      assertThat( v.getDimension(1).getShortName()).isEqualTo("MiF");
-      assertThat( v.getDimension(2).getShortName()).isEqualTo("CR");
-      assertThat( v.getDimension(3).getShortName()).isEqualTo("CC");
+      assertThat(v.getRank()).isEqualTo(4);
+      assertThat(v.getDimension(0).getShortName()).isEqualTo("MaF");
+      assertThat(v.getDimension(1).getShortName()).isEqualTo("MiF");
+      assertThat(v.getDimension(2).getShortName()).isEqualTo("CR");
+      assertThat(v.getDimension(3).getShortName()).isEqualTo("CC");
     }
   }
 

--- a/cdm/core/src/main/java/ucar/array/Array.java
+++ b/cdm/core/src/main/java/ucar/array/Array.java
@@ -57,7 +57,7 @@ public abstract class Array<T> implements Iterable<T> {
     return indexFn.getSection();
   }
 
-  /** Get the total number of elements in the array. */
+  /** Get the total number of elements in the array. Excludes vlen dimensins. */
   public long length() {
     return indexFn.length();
   }

--- a/cdm/core/src/main/java/ucar/array/ArrayVlen.java
+++ b/cdm/core/src/main/java/ucar/array/ArrayVlen.java
@@ -11,8 +11,8 @@ import ucar.ma2.DataType;
 
 /**
  * Array of variable length primitive arrays of T, eg double[length][];
- * Cast resulting Object, eg to double[].
- * Find out type from getPrimitiveArrayType() (not getDataType, which is VLEN).
+ * Cast resulting Object, eg to Array<Double></Double>
+ * Find out type from getPrimitiveArrayType() (not getDataType(), which is VLEN).
  * This is mutable, to assist users in constructing. See set(index, value).
  */
 public class ArrayVlen<T> extends Array<Object> {
@@ -22,34 +22,15 @@ public class ArrayVlen<T> extends Array<Object> {
    * The shape of the resulting array has vlen dimension removed, if present.
    */
   public static <T> ArrayVlen<T> factory(DataType dataType, int[] shape) {
-    // find leftmost vlen, doesnt have to exist.
-    // TODO this implies that vlen doesnt have to be rightmost dimension. For now, we flatten into 1D.
-    int prefixrank = shape.length;
-    for (int i = 0; i < shape.length; i++) {
-      if (shape[i] < 0) {
-        prefixrank = i;
-        break;
-      }
-    }
-    int[] newshape = new int[prefixrank];
-    System.arraycopy(shape, 0, newshape, 0, prefixrank);
-
-    return new ArrayVlen<>(dataType, newshape);
+    return new ArrayVlen<>(dataType, Arrays.removeVlen(shape));
   }
 
-  /** Creates a Vlen of type dataType, and the appropriate primitive array. */
+  /**
+   * Creates a Vlen of type dataType, and the appropriate primitive array.
+   * The shape of the resulting array has vlen dimension removed, if present.
+   */
   public static <T> ArrayVlen<T> factory(DataType dataType, int[] shape, Object storage) {
-    int prefixrank = shape.length;
-    for (int i = 0; i < shape.length; i++) {
-      if (shape[i] < 0) {
-        prefixrank = i;
-        break;
-      }
-    }
-    int[] newshape = new int[prefixrank];
-    System.arraycopy(shape, 0, newshape, 0, prefixrank);
-
-    return new ArrayVlen<>(dataType, newshape, storage);
+    return new ArrayVlen<>(dataType, Arrays.removeVlen(shape), storage);
   }
 
   public static StorageMutable<Object> createStorage(DataType dataType, int length, Object dataArray) {
@@ -63,7 +44,7 @@ public class ArrayVlen<T> extends Array<Object> {
       case ENUM1:
       case OPAQUE:
       case UBYTE:
-        result = new StorageVByte((byte[][]) dataArray);
+        result = new StorageVByte(dataType, (byte[][]) dataArray);
         break;
       case CHAR:
         result = new StorageVChar((char[][]) dataArray);
@@ -77,16 +58,16 @@ public class ArrayVlen<T> extends Array<Object> {
       case INT:
       case ENUM4:
       case UINT:
-        result = new StorageVInt((int[][]) dataArray);
+        result = new StorageVInt(dataType, (int[][]) dataArray);
         break;
       case LONG:
       case ULONG:
-        result = new StorageVLong((long[][]) dataArray);
+        result = new StorageVLong(dataType, (long[][]) dataArray);
         break;
       case SHORT:
       case ENUM2:
       case USHORT:
-        result = new StorageVShort((short[][]) dataArray);
+        result = new StorageVShort(dataType, (short[][]) dataArray);
         break;
       case STRING:
         result = new StorageVString((String[][]) dataArray);
@@ -136,14 +117,14 @@ public class ArrayVlen<T> extends Array<Object> {
   /** Create an empty Vlen of type primitiveArrayType and the given shape. */
   private ArrayVlen(DataType primitiveArrayType, int[] shape) {
     super(DataType.VLEN, shape);
-    this.storage = createStorage(primitiveArrayType, (int) IndexFn.computeSize(shape), null);
+    this.storage = createStorage(primitiveArrayType, (int) Arrays.computeSize(shape), null);
     this.primitiveArrayType = primitiveArrayType;
   }
 
   /** Create an empty Vlen of type primitiveArrayType and data array T[][]. */
   private ArrayVlen(DataType primitiveArrayType, int[] shape, Object dataArray) {
     super(DataType.VLEN, shape);
-    this.storage = createStorage(primitiveArrayType, (int) IndexFn.computeSize(shape), dataArray);
+    this.storage = createStorage(primitiveArrayType, (int) Arrays.computeSize(shape), dataArray);
     this.primitiveArrayType = primitiveArrayType;
   }
 
@@ -232,10 +213,12 @@ public class ArrayVlen<T> extends Array<Object> {
 
   // standard storage using ragged array byte[fixed][]
   @Immutable
-  static class StorageVByte implements StorageMutable<byte[]> {
+  static class StorageVByte implements StorageMutable<Array<Byte>> {
+    private final DataType primitiveArrayType;
     private final byte[][] primitiveArray;
 
-    StorageVByte(byte[][] primitiveArray) {
+    StorageVByte(DataType primitiveArrayType, byte[][] primitiveArray) {
+      this.primitiveArrayType = primitiveArrayType;
       this.primitiveArray = primitiveArray;
     }
 
@@ -245,8 +228,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public byte[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<Byte> get(long elem) {
+      byte[] p = primitiveArray[(int) elem];
+      return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
     }
 
     @Override
@@ -255,16 +239,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<byte[]> iterator() {
+    public Iterator<Array<Byte>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, byte[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (byte[]) value;
     }
 
-    private final class StorageIter implements Iterator<byte[]> {
+    private final class StorageIter implements Iterator<Array<Byte>> {
       private int count = 0;
 
       @Override
@@ -273,15 +257,16 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final byte[] next() {
-        return primitiveArray[count++];
+      public final Array<Byte> next() {
+        byte[] p = primitiveArray[count++];
+        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
 
   // standard storage using ragged array char[fixed][]
   @Immutable
-  static class StorageVChar implements StorageMutable<char[]> {
+  static class StorageVChar implements StorageMutable<Array<Character>> {
     private final char[][] primitiveArray;
 
     StorageVChar(char[][] primitiveArray) {
@@ -294,8 +279,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public char[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<Character> get(long elem) {
+      char[] p = primitiveArray[(int) elem];
+      return Arrays.factory(DataType.CHAR, new int[] {p.length}, p);
     }
 
     @Override
@@ -304,16 +290,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<char[]> iterator() {
+    public Iterator<Array<Character>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, char[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (char[]) value;
     }
 
-    private final class StorageIter implements Iterator<char[]> {
+    private final class StorageIter implements Iterator<Array<Character>> {
       private int count = 0;
 
       @Override
@@ -322,15 +308,16 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final char[] next() {
-        return primitiveArray[count++];
+      public final Array<Character> next() {
+        char[] p = primitiveArray[count++];
+        return Arrays.factory(DataType.CHAR, new int[] {p.length}, p);
       }
     }
   }
 
   // standard storage using ragged array double[fixed][]
   @Immutable
-  static class StorageVDouble implements StorageMutable<double[]> {
+  static class StorageVDouble implements StorageMutable<Array<Double>> {
     private final double[][] primitiveArray;
 
     StorageVDouble(double[][] primitiveArray) {
@@ -343,8 +330,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public double[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<Double> get(long elem) {
+      double[] p = primitiveArray[(int) elem];
+      return Arrays.factory(DataType.DOUBLE, new int[] {p.length}, p);
     }
 
     @Override
@@ -353,16 +341,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<double[]> iterator() {
+    public Iterator<Array<Double>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, double[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (double[]) value;
     }
 
-    private final class StorageIter implements Iterator<double[]> {
+    private final class StorageIter implements Iterator<Array<Double>> {
       private int count = 0;
 
       @Override
@@ -371,15 +359,16 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final double[] next() {
-        return primitiveArray[count++];
+      public final Array<Double> next() {
+        double[] p = primitiveArray[count++];
+        return Arrays.factory(DataType.DOUBLE, new int[] {p.length}, p);
       }
     }
   }
 
   // standard storage using ragged array float[fixed][]
   @Immutable
-  static class StorageVFloat implements StorageMutable<float[]> {
+  static class StorageVFloat implements StorageMutable<Array<Float>> {
     private final float[][] primitiveArray;
 
     StorageVFloat(float[][] primitiveArray) {
@@ -392,8 +381,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public float[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<Float> get(long elem) {
+      float[] p = primitiveArray[(int) elem];
+      return Arrays.factory(DataType.FLOAT, new int[] {p.length}, p);
     }
 
     @Override
@@ -402,16 +392,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<float[]> iterator() {
+    public Iterator<Array<Float>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, float[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (float[]) value;
     }
 
-    private final class StorageIter implements Iterator<float[]> {
+    private final class StorageIter implements Iterator<Array<Float>> {
       private int count = 0;
 
       @Override
@@ -420,18 +410,21 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final float[] next() {
-        return primitiveArray[count++];
+      public final Array<Float> next() {
+        float[] p = primitiveArray[count++];
+        return Arrays.factory(DataType.FLOAT, new int[] {p.length}, p);
       }
     }
   }
 
   // standard storage using ragged array int[fixed][]
   @Immutable
-  static class StorageVInt implements StorageMutable<int[]> {
+  static class StorageVInt implements StorageMutable<Array<Integer>> {
+    private final DataType primitiveArrayType;
     private final int[][] primitiveArray;
 
-    StorageVInt(int[][] primitiveArray) {
+    StorageVInt(DataType primitiveArrayType, int[][] primitiveArray) {
+      this.primitiveArrayType = primitiveArrayType;
       this.primitiveArray = primitiveArray;
     }
 
@@ -441,8 +434,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public int[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<Integer> get(long elem) {
+      int[] p = primitiveArray[(int) elem];
+      return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
     }
 
     @Override
@@ -451,16 +445,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<int[]> iterator() {
+    public Iterator<Array<Integer>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, int[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (int[]) value;
     }
 
-    private final class StorageIter implements Iterator<int[]> {
+    private final class StorageIter implements Iterator<Array<Integer>> {
       private int count = 0;
 
       @Override
@@ -469,18 +463,21 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final int[] next() {
-        return primitiveArray[count++];
+      public final Array<Integer> next() {
+        int[] p = primitiveArray[count++];
+        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
 
   // standard storage using ragged array long[fixed][]
   @Immutable
-  static class StorageVLong implements StorageMutable<long[]> {
+  static class StorageVLong implements StorageMutable<Array<Long>> {
+    private final DataType primitiveArrayType;
     private final long[][] primitiveArray;
 
-    StorageVLong(long[][] primitiveArray) {
+    StorageVLong(DataType primitiveArrayType, long[][] primitiveArray) {
+      this.primitiveArrayType = primitiveArrayType;
       this.primitiveArray = primitiveArray;
     }
 
@@ -490,8 +487,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public long[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<Long> get(long elem) {
+      long[] p = primitiveArray[(int) elem];
+      return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
     }
 
     @Override
@@ -500,16 +498,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<long[]> iterator() {
+    public Iterator<Array<Long>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, long[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (long[]) value;
     }
 
-    private final class StorageIter implements Iterator<long[]> {
+    private final class StorageIter implements Iterator<Array<Long>> {
       private int count = 0;
 
       @Override
@@ -518,18 +516,21 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final long[] next() {
-        return primitiveArray[count++];
+      public final Array<Long> next() {
+        long[] p = primitiveArray[count++];
+        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
 
   // standard storage using ragged array short[fixed][]
   @Immutable
-  static class StorageVShort implements StorageMutable<short[]> {
+  static class StorageVShort implements StorageMutable<Array<Short>> {
+    private final DataType primitiveArrayType;
     private final short[][] primitiveArray;
 
-    StorageVShort(short[][] primitiveArray) {
+    StorageVShort(DataType primitiveArrayType, short[][] primitiveArray) {
+      this.primitiveArrayType = primitiveArrayType;
       this.primitiveArray = primitiveArray;
     }
 
@@ -539,8 +540,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public short[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<Short> get(long elem) {
+      short[] p = primitiveArray[(int) elem];
+      return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
     }
 
     @Override
@@ -549,16 +551,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<short[]> iterator() {
+    public Iterator<Array<Short>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, short[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (short[]) value;
     }
 
-    private final class StorageIter implements Iterator<short[]> {
+    private final class StorageIter implements Iterator<Array<Short>> {
       private int count = 0;
 
       @Override
@@ -567,15 +569,16 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final short[] next() {
-        return primitiveArray[count++];
+      public final Array<Short> next() {
+        short[] p = primitiveArray[count++];
+        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
 
   // standard storage using ragged array String[fixed][]
   @Immutable
-  static class StorageVString implements StorageMutable<String[]> {
+  static class StorageVString implements StorageMutable<Array<String>> {
     private final String[][] primitiveArray;
 
     StorageVString(String[][] primitiveArray) {
@@ -588,8 +591,9 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public String[] get(long elem) {
-      return primitiveArray[(int) elem];
+    public Array<String> get(long elem) {
+      String[] p = primitiveArray[(int) elem];
+      return Arrays.factory(DataType.STRING, new int[] {p.length}, p);
     }
 
     @Override
@@ -598,16 +602,16 @@ public class ArrayVlen<T> extends Array<Object> {
     }
 
     @Override
-    public Iterator<String[]> iterator() {
+    public Iterator<Array<String>> iterator() {
       return new StorageIter();
     }
 
     @Override
-    public void set(int index, String[] value) {
-      primitiveArray[index] = value;
+    public void set(int index, Object value) {
+      primitiveArray[index] = (String[]) value;
     }
 
-    private final class StorageIter implements Iterator<String[]> {
+    private final class StorageIter implements Iterator<Array<String>> {
       private int count = 0;
 
       @Override
@@ -616,8 +620,9 @@ public class ArrayVlen<T> extends Array<Object> {
       }
 
       @Override
-      public final String[] next() {
-        return primitiveArray[count++];
+      public final Array<String> next() {
+        String[] p = primitiveArray[count++];
+        return Arrays.factory(DataType.STRING, new int[] {p.length}, p);
       }
     }
   }

--- a/cdm/core/src/main/java/ucar/array/ArrayVlen.java
+++ b/cdm/core/src/main/java/ucar/array/ArrayVlen.java
@@ -259,7 +259,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<Byte> next() {
         byte[] p = primitiveArray[count++];
-        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
@@ -310,7 +310,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<Character> next() {
         char[] p = primitiveArray[count++];
-        return Arrays.factory(DataType.CHAR, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(DataType.CHAR, new int[] {p.length}, p);
       }
     }
   }
@@ -361,7 +361,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<Double> next() {
         double[] p = primitiveArray[count++];
-        return Arrays.factory(DataType.DOUBLE, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(DataType.DOUBLE, new int[] {p.length}, p);
       }
     }
   }
@@ -412,7 +412,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<Float> next() {
         float[] p = primitiveArray[count++];
-        return Arrays.factory(DataType.FLOAT, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(DataType.FLOAT, new int[] {p.length}, p);
       }
     }
   }
@@ -465,7 +465,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<Integer> next() {
         int[] p = primitiveArray[count++];
-        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
@@ -518,7 +518,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<Long> next() {
         long[] p = primitiveArray[count++];
-        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
@@ -571,7 +571,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<Short> next() {
         short[] p = primitiveArray[count++];
-        return Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(primitiveArrayType, new int[] {p.length}, p);
       }
     }
   }
@@ -622,7 +622,7 @@ public class ArrayVlen<T> extends Array<Object> {
       @Override
       public final Array<String> next() {
         String[] p = primitiveArray[count++];
-        return Arrays.factory(DataType.STRING, new int[] {p.length}, p);
+        return (p == null) ? null : Arrays.factory(DataType.STRING, new int[] {p.length}, p);
       }
     }
   }

--- a/cdm/core/src/main/java/ucar/array/Arrays.java
+++ b/cdm/core/src/main/java/ucar/array/Arrays.java
@@ -53,6 +53,7 @@ public class Arrays {
    */
   public static <T> Array<T> factory(DataType dataType, int[] shape, Object dataArray) {
     switch (dataType) {
+      case OPAQUE:
       case BOOLEAN:
       case BYTE:
       case ENUM1:
@@ -337,5 +338,47 @@ public class Arrays {
    */
   public static <T> Array<T> transpose(Array<T> org, int dim1, int dim2) {
     return org.createView(org.indexFn().transpose(dim1, dim2));
+  }
+
+  /**
+   * Compute total number of elements in the array. Stop at vlen.
+   *
+   * @param shape length of array in each dimension.
+   * @return total number of elements in the array.
+   */
+  public static long computeSize(int[] shape) {
+    long product = 1;
+    for (int aShape : shape) {
+      if (aShape < 0)
+        break; // stop at vlen
+      product *= aShape;
+    }
+    return product;
+  }
+
+  public static boolean isVariableLength(int[] shape) {
+    return shape.length > 0 && shape[shape.length - 1] < 0;
+  }
+
+  /**
+   * If there are any VLEN dimensions (length < 0), remove it and all dimensions to the right.
+   * 
+   * @param shape
+   * @return modified shape, if needed.
+   */
+  // TODO this implies that vlen doesnt have to be rightmost dimension. Is that true?
+  public static int[] removeVlen(int[] shape) {
+    int prefixrank;
+    for (prefixrank = 0; prefixrank < shape.length; prefixrank++) {
+      if (shape[prefixrank] < 0) {
+        break;
+      }
+    }
+    if (prefixrank == shape.length) {
+      return shape;
+    }
+    int[] newshape = new int[prefixrank];
+    System.arraycopy(shape, 0, newshape, 0, prefixrank);
+    return newshape;
   }
 }

--- a/cdm/core/src/main/java/ucar/array/IndexFn.java
+++ b/cdm/core/src/main/java/ucar/array/IndexFn.java
@@ -16,23 +16,7 @@ import ucar.ma2.Section;
 
 /** Translate between multidimensional index and 1-d arrays. */
 @Immutable
-public class IndexFn implements Iterable<Integer> {
-
-  /**
-   * Compute total number of elements in the array. Stop at vlen.
-   *
-   * @param shape length of array in each dimension.
-   * @return total number of elements in the array.
-   */
-  public static long computeSize(int[] shape) {
-    long product = 1;
-    for (int aShape : shape) {
-      if (aShape < 0)
-        break; // stop at vlen
-      product *= aShape;
-    }
-    return product;
-  }
+class IndexFn implements Iterable<Integer> {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -171,7 +155,7 @@ public class IndexFn implements Iterable<Integer> {
   }
 
   IndexFn reshape(int[] shape) {
-    Preconditions.checkArgument(computeSize(shape) == length());
+    Preconditions.checkArgument(Arrays.computeSize(shape) == length());
     return builder(shape).build();
   }
 
@@ -219,7 +203,7 @@ public class IndexFn implements Iterable<Integer> {
     newindex.setStride(newstride);
 
     // if equal, then its not a real subset, so can still use fastIterator
-    newindex.canonicalOrder = canonicalOrder && (computeSize(newindex.shape) == size);
+    newindex.canonicalOrder = canonicalOrder && (Arrays.computeSize(newindex.shape) == size);
     return newindex.build();
   }
 
@@ -331,7 +315,7 @@ public class IndexFn implements Iterable<Integer> {
       Preconditions.checkArgument(builder.stride.length == rank);
       this.stride = new int[rank];
       System.arraycopy(builder.stride, 0, this.stride, 0, rank);
-      this.size = computeSize(shape);
+      this.size = Arrays.computeSize(shape);
     }
     this.offset = builder.offset;
     this.canonicalOrder = builder.canonicalOrder;

--- a/cdm/core/src/main/java/ucar/array/StorageMutable.java
+++ b/cdm/core/src/main/java/ucar/array/StorageMutable.java
@@ -7,5 +7,5 @@ package ucar.array;
 
 /** Storage that can be changed. */
 public interface StorageMutable<T> extends Storage<T> {
-  void set(int index, T value);
+  void set(int index, Object value);
 }

--- a/cdm/core/src/main/java/ucar/array/StructureDataArray.java
+++ b/cdm/core/src/main/java/ucar/array/StructureDataArray.java
@@ -136,8 +136,8 @@ public class StructureDataArray extends Array<StructureData> {
     }
 
     @Override
-    public void set(int index, StructureData value) {
-      parray[index] = value;
+    public void set(int index, Object value) {
+      parray[index] = (StructureData) value;
     }
 
     @Override

--- a/cdm/core/src/main/java/ucar/array/StructureDataStorageBB.java
+++ b/cdm/core/src/main/java/ucar/array/StructureDataStorageBB.java
@@ -217,7 +217,7 @@ public class StructureDataStorageBB implements Storage<StructureData> {
       ArrayVlen<?> vlenArray = (ArrayVlen<?>) heap.get(heapIdx);
 
       if (vlenArray.length() == 1) {
-        Array<?> vlen = (Array<?>) vlenArray.get(vlenArray.getIndex());
+        Array<?> vlen = vlenArray.get(vlenArray.getIndex());
         return vlen;
       }
       return vlenArray;

--- a/cdm/core/src/main/java/ucar/array/StructureMembers.java
+++ b/cdm/core/src/main/java/ucar/array/StructureMembers.java
@@ -314,7 +314,7 @@ public final class StructureMembers implements Iterable<Member> {
 
     private int getStorageSizeBytes(boolean structuresOnHeap) {
       boolean isVariableLength = (shape != null && shape.length > 0 && shape[shape.length - 1] < 0);
-      int length = (shape == null) ? 1 : (int) IndexFn.computeSize(shape);
+      int length = (shape == null) ? 1 : (int) Arrays.computeSize(shape);
 
       if (isVariableLength) {
         return 4;

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5iospArrays.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5iospArrays.java
@@ -8,7 +8,6 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import ucar.array.Array;
 import ucar.array.ArrayVlen;
 import ucar.array.Arrays;
 import ucar.array.StructureDataArray;
@@ -171,7 +170,7 @@ public class H5iospArrays extends H5iosp {
    * @throws InvalidRangeException if invalid section
    */
   private Object readArrayOrPrimitive(H5header.Vinfo vinfo, Variable v, Layout layout, DataType dataType, int[] shape,
-      Object fillValue, int endian) throws IOException, InvalidRangeException {
+      Object fillValue, int endian) throws IOException {
 
     H5header.TypeInfo typeInfo = vinfo.typeInfo;
 
@@ -200,23 +199,6 @@ public class H5iospArrays extends H5iosp {
     if (dataType == DataType.STRUCTURE) { // LOOK what about subsetting ?
       return readStructureData((Structure) v, shape, layout);
     }
-
-    // normal case
-    return readDataArrayPrimitive(layout, dataType, shape, fillValue, endian, true);
-  }
-
-  /**
-   * Read data subset from file for a variable, create primitive array.
-   *
-   * @param layout handles skipping around in the file.
-   * @param dataType dataType of the variable
-   * @param shape the shape of the output
-   * @param fillValue fill value as a wrapped primitive
-   * @param endian byte order
-   * @return primitive array with data read in
-   */
-  private Object readDataArrayPrimitive(Layout layout, DataType dataType, int[] shape, Object fillValue, int endian,
-      boolean convertChar) throws IOException {
 
     if (dataType == DataType.STRING) {
       int size = (int) layout.getTotalNelems();
@@ -254,7 +236,7 @@ public class H5iospArrays extends H5iosp {
     }
 
     // normal case
-    return IospHelper.readDataFill(raf, layout, dataType, fillValue, endian, convertChar);
+    return IospHelper.readDataFill(raf, layout, dataType, fillValue, endian, true);
   }
 
   ///////////////////////////////////////////////
@@ -281,8 +263,7 @@ public class H5iospArrays extends H5iosp {
       }
     }
     if (vlenArray.length() == 1) {
-      Array<?> vlen = (Array<?>) vlenArray.get();
-      return vlen;
+      return vlenArray.get();
     }
     return vlenArray;
   }

--- a/cdm/core/src/test/java/ucar/array/TestArrayVlen.java
+++ b/cdm/core/src/test/java/ucar/array/TestArrayVlen.java
@@ -94,7 +94,7 @@ public class TestArrayVlen {
   @Test
   public void testTypes() {
     ArrayVlen<Short> array = ArrayVlen.factory(DataType.BYTE, new int[] {11});
-    Storage<Object> storage = array.storage();
+    Storage<Array<Short>> storage = array.storage();
     array.set(0, new byte[] {1});
     assertThat(storage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(storage.getLength()).isEqualTo(11);
@@ -102,7 +102,7 @@ public class TestArrayVlen {
     assertThat(array.get(array.getIndex())).isNotNull();
 
     ArrayVlen<Character> carray = ArrayVlen.factory(DataType.CHAR, new int[] {12});
-    Storage<Object> cstorage = carray.storage();
+    Storage<Array<Character>> cstorage = carray.storage();
     carray.set(0, new char[] {1});
     assertThat(cstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(cstorage.getLength()).isEqualTo(12);
@@ -110,7 +110,7 @@ public class TestArrayVlen {
     assertThat(carray.get(carray.getIndex())).isNotNull();
 
     ArrayVlen<Integer> iarray = ArrayVlen.factory(DataType.INT, new int[] {13});
-    Storage<Object> istorage = iarray.storage();
+    Storage<Array<Integer>> istorage = iarray.storage();
     iarray.set(0, new int[] {1});
     assertThat(istorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(istorage.getLength()).isEqualTo(13);
@@ -118,7 +118,7 @@ public class TestArrayVlen {
     assertThat(iarray.get(iarray.getIndex())).isNotNull();
 
     ArrayVlen<Integer> larray = ArrayVlen.factory(DataType.ULONG, new int[] {14});
-    Storage<Object> lstorage = larray.storage();
+    Storage<Array<Integer>> lstorage = larray.storage();
     larray.set(0, new long[] {1});
     assertThat(lstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(lstorage.getLength()).isEqualTo(14);
@@ -126,7 +126,7 @@ public class TestArrayVlen {
     assertThat(larray.get(larray.getIndex())).isNotNull();
 
     ArrayVlen<Double> darray = ArrayVlen.factory(DataType.DOUBLE, new int[] {15});
-    Storage<Object> dstorage = darray.storage();
+    Storage<Array<Double>> dstorage = darray.storage();
     darray.set(0, new double[] {1});
     assertThat(dstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(dstorage.getLength()).isEqualTo(15);
@@ -134,7 +134,7 @@ public class TestArrayVlen {
     assertThat(darray.get(darray.getIndex())).isNotNull();
 
     ArrayVlen<Float> farray = ArrayVlen.factory(DataType.FLOAT, new int[] {16});
-    Storage<Object> fstorage = farray.storage();
+    Storage<Array<Float>> fstorage = farray.storage();
     farray.set(0, new float[] {1});
     assertThat(fstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(fstorage.getLength()).isEqualTo(16);
@@ -142,7 +142,7 @@ public class TestArrayVlen {
     assertThat(farray.get(farray.getIndex())).isNotNull();
 
     ArrayVlen<String> sarray = ArrayVlen.factory(DataType.STRING, new int[] {17});
-    Storage<Object> sstorage = sarray.storage();
+    Storage<Array<String>> sstorage = sarray.storage();
     sarray.set(0, new String[] {"one"});
     assertThat(sstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(sstorage.getLength()).isEqualTo(17);

--- a/cdm/core/src/test/java/ucar/array/TestArrayVlen.java
+++ b/cdm/core/src/test/java/ucar/array/TestArrayVlen.java
@@ -7,7 +7,9 @@ package ucar.array;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import java.util.List;
 import org.junit.Test;
 import ucar.ma2.DataType;
 
@@ -22,12 +24,16 @@ public class TestArrayVlen {
     short[][] ragged = new short[][] {arr1, arr2};
     ArrayVlen<Short> array = ArrayVlen.factory(DataType.SHORT, shape, ragged);
 
-    assertThat(array.get(0, 0)).isEqualTo(arr1);
-    assertThat(array.get(0, 1)).isEqualTo(arr2);
+    Array<Short> elem1 = (Array<Short>) array.get(0, 0);
+    assertThat(Iterables.toString(elem1)).isEqualTo("[1, 2, 3, 4, 5]");
+    Array<Short> elem2 = (Array<Short>) array.get(0, 1);
+    assertThat(Iterables.toString(elem2)).isEqualTo("[6, 7]");
 
+    List<Integer> list = ImmutableList.of(5, 2);
     int count = 0;
     for (Object val : array) {
-      assertThat(val).isEqualTo(ragged[count]);
+      Array<Short> elem = (Array<Short>) val;
+      assertThat(elem.length()).isEqualTo(list.get(count));
       count++;
     }
 
@@ -56,24 +62,31 @@ public class TestArrayVlen {
     array.set(0, arr1);
     array.set(1, arr2);
 
-    assertThat(array.get(0, 0)).isEqualTo(arr1);
-    assertThat(array.get(0, 1)).isEqualTo(arr2);
+    Array<Short> elem1 = (Array<Short>) array.get(0, 0);
+    assertThat(Iterables.toString(elem1)).isEqualTo("[1, 2, 3, 4, 5]");
+    Array<Short> elem2 = (Array<Short>) array.get(0, 1);
+    assertThat(Iterables.toString(elem2)).isEqualTo("[6, 7]");
 
+    List<Integer> list = ImmutableList.of(5, 2);
     int count = 0;
     for (Object val : array) {
-      assertThat(val).isEqualTo(ragged[count]);
+      Array<Short> elem = (Array<Short>) val;
+      assertThat(elem.length()).isEqualTo(list.get(count));
       count++;
     }
 
     ArrayVlen<Short> flipped = (ArrayVlen<Short>) Arrays.flip(array, 1);
 
-    assertThat(flipped.get(0, 0)).isEqualTo(arr2);
-    assertThat(flipped.get(0, 1)).isEqualTo(arr1);
+    Array<Short> felem1 = (Array<Short>) flipped.get(0, 0);
+    assertThat(Iterables.toString(felem1)).isEqualTo("[6, 7]");
+    Array<Short> felem2 = (Array<Short>) flipped.get(0, 1);
+    assertThat(Iterables.toString(felem2)).isEqualTo("[1, 2, 3, 4, 5]");
 
-    short[][] fragged = new short[][] {arr2, arr1};
+    List<Integer> fragged = ImmutableList.of(2, 5);
     count = 0;
     for (Object val : flipped) {
-      assertThat(val).isEqualTo(fragged[count]);
+      Array<Short> elem = (Array<Short>) val;
+      assertThat(elem.length()).isEqualTo(fragged.get(count));
       count++;
     }
   }
@@ -86,6 +99,7 @@ public class TestArrayVlen {
     assertThat(storage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(storage.getLength()).isEqualTo(11);
     assertThat(Iterables.size(array)).isEqualTo(11);
+    assertThat(array.get(array.getIndex())).isNotNull();
 
     ArrayVlen<Character> carray = ArrayVlen.factory(DataType.CHAR, new int[] {12});
     Storage<Object> cstorage = carray.storage();
@@ -93,6 +107,7 @@ public class TestArrayVlen {
     assertThat(cstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(cstorage.getLength()).isEqualTo(12);
     assertThat(Iterables.size(carray)).isEqualTo(12);
+    assertThat(carray.get(carray.getIndex())).isNotNull();
 
     ArrayVlen<Integer> iarray = ArrayVlen.factory(DataType.INT, new int[] {13});
     Storage<Object> istorage = iarray.storage();
@@ -100,6 +115,7 @@ public class TestArrayVlen {
     assertThat(istorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(istorage.getLength()).isEqualTo(13);
     assertThat(Iterables.size(iarray)).isEqualTo(13);
+    assertThat(iarray.get(iarray.getIndex())).isNotNull();
 
     ArrayVlen<Integer> larray = ArrayVlen.factory(DataType.ULONG, new int[] {14});
     Storage<Object> lstorage = larray.storage();
@@ -107,6 +123,7 @@ public class TestArrayVlen {
     assertThat(lstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(lstorage.getLength()).isEqualTo(14);
     assertThat(Iterables.size(larray)).isEqualTo(14);
+    assertThat(larray.get(larray.getIndex())).isNotNull();
 
     ArrayVlen<Double> darray = ArrayVlen.factory(DataType.DOUBLE, new int[] {15});
     Storage<Object> dstorage = darray.storage();
@@ -114,6 +131,7 @@ public class TestArrayVlen {
     assertThat(dstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(dstorage.getLength()).isEqualTo(15);
     assertThat(Iterables.size(dstorage)).isEqualTo(15);
+    assertThat(darray.get(darray.getIndex())).isNotNull();
 
     ArrayVlen<Float> farray = ArrayVlen.factory(DataType.FLOAT, new int[] {16});
     Storage<Object> fstorage = farray.storage();
@@ -121,6 +139,7 @@ public class TestArrayVlen {
     assertThat(fstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(fstorage.getLength()).isEqualTo(16);
     assertThat(Iterables.size(fstorage)).isEqualTo(16);
+    assertThat(farray.get(farray.getIndex())).isNotNull();
 
     ArrayVlen<String> sarray = ArrayVlen.factory(DataType.STRING, new int[] {17});
     Storage<Object> sstorage = sarray.storage();
@@ -128,7 +147,7 @@ public class TestArrayVlen {
     assertThat(sstorage.getClass()).isAssignableTo(StorageMutable.class);
     assertThat(sstorage.getLength()).isEqualTo(17);
     assertThat(Iterables.size(sstorage)).isEqualTo(17);
-
+    assertThat(sarray.get(sarray.getIndex())).isNotNull();
   }
 
 

--- a/cdm/core/src/test/java/ucar/array/TestReadArrayCompare.java
+++ b/cdm/core/src/test/java/ucar/array/TestReadArrayCompare.java
@@ -9,7 +9,6 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Formatter;
 import java.util.Iterator;
 import java.util.List;
@@ -43,6 +42,8 @@ public class TestReadArrayCompare {
     List<Object[]> result = new ArrayList<>(500);
     try {
       TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/netcdf3/", ff, result);
+      TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/netcdf4/tst/", ff, result);
+      TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/netcdf4/vlen/", ff, result);
       TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/hdf5/samples/", ff, result);
       TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/hdf5/support/", ff, result);
       TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/hdf5/complex/", ff, result);
@@ -100,17 +101,27 @@ public class TestReadArrayCompare {
     }
 
     if (!Misc.compare(org.getShape(), array.getShape(), f)) {
-      f.format(" WARN shape %s: data shape %s !== %s%n", name, java.util.Arrays.toString(org.getShape()),
-          Arrays.toString(array.getShape()));
+      f.format(" WARN %s: data shape %s !== %s%n", name, java.util.Arrays.toString(org.getShape()),
+          java.util.Arrays.toString(array.getShape()));
       // ok = false;
     }
 
-    if (array.getDataType() == DataType.VLEN) {
-      testTypes = false;
+    if (org.isVlen() != (array.getDataType() == DataType.VLEN)) {
+      f.format(" WARN  %s: data vlen %s !== %s%n", name, org.isVlen(), (array.getDataType() == DataType.VLEN));
+      // ok = false;
     }
+
     if (testTypes && org.getDataType() != array.getDataType()) {
-      f.format(" WARN %s: data type %s !== %s%n", name, org.getDataType(), array.getDataType());
-      ok = false;
+      if (array instanceof ArrayVlen) {
+        ArrayVlen<?> arrv = (ArrayVlen<?>) array;
+        if (org.getDataType() != arrv.getPrimitiveArrayType()) {
+          f.format(" WARN %s: data type %s !== %s%n", name, org.getDataType(), arrv.getPrimitiveArrayType());
+          ok = false;
+        }
+      } else {
+        f.format(" WARN %s: data type %s !== %s%n", name, org.getDataType(), array.getDataType());
+        ok = false;
+      }
     }
 
     if (!ok) {
@@ -119,6 +130,26 @@ public class TestReadArrayCompare {
 
     DataType dt = org.getDataType();
     IndexIterator iter1 = org.getIndexIterator();
+
+    if (org.isVlen()) {
+      Iterator<Object> iter2 = (Iterator<Object>) array.iterator();
+      while (iter1.hasNext() && iter2.hasNext()) {
+        Object v1 = iter1.getObjectNext();
+        Object v2 = iter2.next();
+        if (v1 instanceof ucar.ma2.Array && v2 instanceof ucar.array.Array) {
+          ok &= compareData(f, name, (ucar.ma2.Array) v1, (ucar.array.Array) v2, justOne, testTypes);
+        } else if (v1 instanceof ucar.ma2.Array) {
+          // problem is we are unwrapping scalar Vlens, different from ma2
+          ok &= compareData(f, name, (ucar.ma2.Array) v1, array, justOne, testTypes);
+        } else {
+          f.format(" DIFF %s: Vlen class %s != %s %n", name, v1.getClass().getName(), v2.getClass().getName());
+          ok = false;
+          if (justOne)
+            break;
+        }
+      }
+      return ok;
+    }
 
     switch (dt) {
       case BYTE:
@@ -221,14 +252,14 @@ public class TestReadArrayCompare {
         while (iter1.hasNext() && iter2.hasNext()) {
           ByteBuffer v1 = (ByteBuffer) iter1.getObjectNext();
           v1.rewind();
-          byte[] v2 = (byte[]) iter2.next();
-          if (v1.remaining() != v2.length) {
-            f.format(" DIFF %s: opaque sizes differ %d != %d%n", name, v1.remaining(), v2.length);
+          Array<Byte> v2 = (Array<Byte>) iter2.next();
+          if (v1.remaining() != v2.length()) {
+            f.format(" DIFF %s: opaque sizes differ %d != %d%n", name, v1.remaining(), v2.length());
             ok = false;
           }
-          for (int idx = 0; idx < v1.remaining() && idx < v2.length; idx++) {
-            if (v1.get(idx) != v2[idx]) {
-              f.format(createNumericDataDiffMessage(dt, name, v1.get(idx), v2[idx], iter1));
+          for (int idx = 0; idx < v1.remaining() && idx < v2.length(); idx++) {
+            if (v1.get(idx) != v2.get(idx)) {
+              f.format(createNumericDataDiffMessage(dt, name, v1.get(idx), v2.get(idx), iter1));
               ok = false;
               if (justOne)
                 break;

--- a/cdm/core/src/test/java/ucar/array/TestReadArrayProblem.java
+++ b/cdm/core/src/test/java/ucar/array/TestReadArrayProblem.java
@@ -26,6 +26,14 @@ import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 @Category(NeedsCdmUnitTest.class)
 public class TestReadArrayProblem {
 
+
+  @Test
+  public void testStructureNestedSequence() throws IOException {
+    // problem is we are unwrapping scalar Vlens, different from ma2
+    String filename = TestDir.cdmUnitTestDir + "formats/netcdf4/vlen/IntTimSciSamp.nc";
+    compareArrays(filename);
+  }
+
   @Test
   public void testOpaque() throws IOException {
     String filename = TestDir.cdmLocalTestDataDir + "hdf5/test_atomic_types.nc"; // opaque
@@ -78,6 +86,12 @@ public class TestReadArrayProblem {
   public void testBufrCompressedNestedStructure() throws IOException {
     String filename = TestDir.cdmUnitTestDir + "formats/bufr/userExamples/TimeIncr0.bufr";
     compareSequence(filename);
+  }
+
+  @Test
+  public void testNc4Vlen() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "formats/netcdf4/vlen/cdm_sea_soundings.nc4";
+    compareArrays(filename);
   }
 
   private void compareSequence(String filename) throws IOException {


### PR DESCRIPTION
Fix Vlens. Currently only used by H5iosp. 
Change Vlen to use StorageMutable<Array<T>> not StorageMutable<T[]>, so the iterator returns Array<T>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/497)
<!-- Reviewable:end -->
