### PR TITLE
Add gradle dependency-check plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Thumbs.db
 # Coverity files 
 cov-int
 thredds.tgz
+
+# dependency check NVD files
+project-files/owasp-dependency-check/nvd

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
     classpath buildPlugins.gretty
     classpath buildPlugins.grgit
     classpath buildPlugins.protobuf
+    classpath buildPlugins.depcheck
   }
 }
 
@@ -106,6 +107,8 @@ apply from: "$rootDir/gradle/root/publishing.gradle"
 apply from: "$rootDir/gradle/root/sonarqube.gradle"
 // Adds the spotless tasks to the root project and add check for .gradle files
 apply from: "$rootDir/gradle/root/spotless.gradle"
+// Adds the owasp dependency-check tasks to the root project (dependencyCheckAggregate for project-wide check)
+apply from: "$rootDir/gradle/root/dependency-check.gradle"
 
 // Modifies Jar tasks created in fatJars.gradle
 apply from: "$rootDir/gradle/any/archiving.gradle"

--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -13,6 +13,7 @@ ext {
   buildPlugins.spotless = 'com.diffplug.spotless:spotless-plugin-gradle:4.5.1'
   buildPlugins.grgit = 'org.ajoberstar.grgit:grgit-core:4.0.2'
   buildPlugins.protobuf = 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
+  buildPlugins.depcheck = 'org.owasp:dependency-check-gradle:6.0.2'
 
   // slf4j version is declared in a place where we cannot use the tds-platform project to handle resolving versions
   // (e.g. gradle/any/dependencies.gradle, for transitive dependency replacement purposes)

--- a/gradle/root/dependency-check.gradle
+++ b/gradle/root/dependency-check.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'org.owasp.dependencycheck'
+
+dependencyCheck {
+  analyzers {
+    assemblyEnabled = false
+  }
+  data {
+    directory="$rootDir/project-files/owasp-dependency-check/nvd"
+  }
+  scanConfigurations = ['compileClasspath', 'runtimeClasspath']
+  suppressionFile = "$rootDir/project-files/owasp-dependency-check/dependency-check-suppression.xml"
+}

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -21,6 +21,12 @@ dependencies {
   compile 'org.slf4j:slf4j-api'
 
   compile 'com.amazonaws:aws-java-sdk-s3'  // For CrawlableDatasetAmazonS3.
+  constraints {
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.11.2') {
+      because 'Replacement v2.6.7.3, which is recomended by aws-java-sdk v1.x for those who do'
+      'not need java 6 compatibility - see https://github.com/aws/aws-sdk-java#cve-2017-15095--cve-2018-7489'
+    }
+  }
 
   testImplementation project(':cdm-test-utils')
   // These are all for Spock.

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -105,7 +105,7 @@ dependencies {
 
     // legacy gradle module
     // todo: remove with legacy in 6
-    api 'com.amazonaws:aws-java-sdk-s3:1.11.819'
+    api 'com.amazonaws:aws-java-sdk-s3:1.11.871'
 
     // In Spock, allows mocking of classes (in addition to interfaces).
     // todo: remove with legacy in 6

--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -1,89 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress>
-    <notes><![CDATA[
-    file name: tdmFat-5.0.0-SNAPSHOT.jar
-    file name: tdm-5.0.0-SNAPSHOT.jar
-    reason: not related to the THREDDS Data Manager (TDM), but a different tdm.
-    ]]></notes>
-    <filePath regex="true">.*\/tdm.*\.jar</filePath>
-    <cpe>cpe:/a:tdm_project:tdm</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: affinity-3.1.10.jar
-    reason: CVE in mintToken function of a smart contract implementation for Thread, an Ethereum token.
-            not related to the Java Thread Affinity library pulled in my chronicle-map.
-    ]]></notes>
-    <filePath regex="true">.*\/affinity.*\.jar</filePath>
-    <cve>CVE-2018-13752</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: affinity pom
-    reason: CVE in mintToken function of a smart contract implementation for Thread, an Ethereum token.
-            not related to the Java Thread Affinity library pulled in my chronicle-map.
-    ]]></notes>
-    <filePath regex="true">.*\/net.openhft\/affinity\/pom.xml</filePath>
-    <cve>CVE-2018-13752</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: org.slf4j:slf4j-api:1.8.0-beta2
-    reason: The CVE-80888 report says this is fixed in beta2, so false positive
-    ]]></notes>
-    <filePath regex="true">.*\/slf4j-api-1.8.0-beta2.jar</filePath>
-    <cve>CVE-2018-8088</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: org.slf4j:/jcl-over-slf4j:1.8.0-beta2
-    reason: The CVE-80888 report says this is fixed in beta2, so false positive
-    ]]></notes>
-    <filePath regex="true">.*\/jcl-over-slf4j-1.8.0-beta2.jar</filePath>
-    <cve>CVE-2018-8088</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-    file name: pax-url-aether jcl-over-slf4j pom
-    reason: we override the version of jcl-over-slf4j, so the one listed in this pom is not actually being used.
-    ]]></notes>
-    <filePath regex="true">.*pax-url-aether-2.4.5.jar\/META-INF\/maven\/org.slf4j\/jcl-over-slf4j\/pom.xml</filePath>
-    <cve>CVE-2018-8088</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      file name: toolsUI-*.jar
-      reason: toolsUI isn't data-tools -> https://github.com/clarkgrubb/data-tools/
-      ]]></notes>
-    <filePath regex="true">.*\/toolsUI.*\.jar</filePath>
-    <cve>CVE-2018-18749</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      file name: tds-*.war: ehcache-2.10.6.jar/rest-management-private-classpath/META-INF/maven/com.fasterxml.jackson.core/jackson-databind/pom.xml
-      reason: ehcache server not used, so safe to ignore (see https://groups.google.com/forum/#!category-topic/ehcache-users/pafTyMJIngI, https://github.com/jeremylong/DependencyCheck/issues/517)
-      ]]></notes>
-    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2.9.6.*$</gav>
-    <cve>CVE-2018-1000873</cve>
-    <cve>CVE-2018-14719</cve>
-    <cve>CVE-2018-14720</cve>
-    <cve>CVE-2018-14721</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      file name example: quartz-2.2.3.jar
-      reason: quartz is being misidentified as jenkins -> https://github.com/jeremylong/DependencyCheck/issues/1637#issuecomment-451115272
-      ]]></notes>
-    <gav regex="true">^org\.quartz-scheduler:quartz:.*$</gav>
-    <cpe>cpe:/a:jenkins:jenkins</cpe>
-  </suppress>
-  <suppress>
+  <!-- Example -->
+  <!--suppress>
     <notes><![CDATA[
       file name example: spring-security-core-4.2.7.RELEASE.jar, spring-security-cweb-4.2.7.RELEASE.jar
       reason: Only valid if specifically using in combination with Spring 5.0.5 RELEASE. https://pivotal.io/security/cve-2018-1258
       ]]></notes>
     <gav regex="true">^org\.springframework\.security:spring-security.*$</gav>
     <cve>CVE-2018-1258</cve>
-  </suppress>
+  </suppress-->
 </suppressions>


### PR DESCRIPTION
Similar to Unidata/tds#115.

The OWAPS dependency-check plugin for Jenkins is up for adoption, and
given that it has been failing to run for a week or so, does not seem to
be the way to go forward. This PR adds a gradle plugin as a replacement.
We will continue to use Jenkins to run the check on a regular schedule,
but now using the gradle machinery in place of the jenkins plugin.

To run the check locally, use:

./gradlew dependencyCheckAggregate

The plugin will generate an html report which can be found at

build/reports/dependency-check-report.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/500)
<!-- Reviewable:end -->
