### PR TITLE
Make sure projection setters also set base value

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/AlbersEqualArea.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/AlbersEqualArea.java
@@ -29,7 +29,7 @@ public class AlbersEqualArea extends ProjectionImpl {
 
   // values passed in through the constructor
   // need for constructCopy
-  private final double _lat0, _lon0;
+  private double _lat0, _lon0;
 
   /**
    * constants from Snyder's equations
@@ -278,6 +278,7 @@ public class AlbersEqualArea extends ProjectionImpl {
    *
    * @param par the second standard parallel
    */
+  @Deprecated
   public void setParallelTwo(double par) {
     par2 = par;
     precalculate();
@@ -288,6 +289,7 @@ public class AlbersEqualArea extends ProjectionImpl {
    *
    * @param par the first standard parallel
    */
+  @Deprecated
   public void setParallelOne(double par) {
     par1 = par;
     precalculate();
@@ -298,7 +300,9 @@ public class AlbersEqualArea extends ProjectionImpl {
    *
    * @param lon the origin longitude.
    */
+  @Deprecated
   public void setOriginLon(double lon) {
+    _lon0 = lon0;
     lon0 = Math.toRadians(lon);
     precalculate();
   }
@@ -308,7 +312,9 @@ public class AlbersEqualArea extends ProjectionImpl {
    *
    * @param lat the origin latitude.
    */
+  @Deprecated
   public void setOriginLat(double lat) {
+    _lat0 = lat0;
     lat0 = Math.toRadians(lat);
     precalculate();
   }
@@ -319,6 +325,7 @@ public class AlbersEqualArea extends ProjectionImpl {
    *
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -329,6 +336,7 @@ public class AlbersEqualArea extends ProjectionImpl {
    *
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertAzimuthalEqualArea.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertAzimuthalEqualArea.java
@@ -31,7 +31,7 @@ public class LambertAzimuthalEqualArea extends ProjectionImpl {
 
   // values passed in through the constructor
   // need for constructCopy
-  private final double _lat0;
+  private double _lat0;
 
   @Override
   public ProjectionImpl constructCopy() {
@@ -198,7 +198,9 @@ public class LambertAzimuthalEqualArea extends ProjectionImpl {
    *
    * @param lon the origin longitude.
    */
+  @Deprecated
   public void setOriginLon(double lon) {
+    lon0Degrees = lon0;
     lon0 = Math.toRadians(lon);
     precalculate();
   }
@@ -208,7 +210,9 @@ public class LambertAzimuthalEqualArea extends ProjectionImpl {
    *
    * @param lat the origin latitude.
    */
+  @Deprecated
   public void setOriginLat(double lat) {
+    _lat0 = lat0;
     lat0 = Math.toRadians(lat);
     precalculate();
   }
@@ -219,6 +223,7 @@ public class LambertAzimuthalEqualArea extends ProjectionImpl {
    *
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -229,6 +234,7 @@ public class LambertAzimuthalEqualArea extends ProjectionImpl {
    *
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
@@ -298,33 +298,41 @@ public class LambertConformal extends ProjectionImpl {
   //////////////////////////////////////////////
   // setters for IDV serialization - do not use except for object creating
 
+  @Deprecated
   public void setOriginLat(double lat0) {
+    _lat0 = lat0;
     this.lat0 = Math.toRadians(lat0);
     precalculate();
   }
 
+  @Deprecated
   public void setOriginLon(double lon0) {
+    _lon0 = lon0;
     this.lon0 = Math.toRadians(lon0);
     precalculate();
   }
 
   // sic
+  @Deprecated
   public void setParellelOne(double par1) {
     this.par1 = par1;
     precalculate();
   }
 
   // sic
+  @Deprecated
   public void setParellelTwo(double par2) {
     this.par2 = par2;
     precalculate();
   }
 
+  @Deprecated
   public void setParallelOne(double par1) {
     this.par1 = par1;
     precalculate();
   }
 
+  @Deprecated
   public void setParallelTwo(double par2) {
     this.par2 = par2;
     precalculate();
@@ -336,6 +344,7 @@ public class LambertConformal extends ProjectionImpl {
    *
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -346,6 +355,7 @@ public class LambertConformal extends ProjectionImpl {
    *
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Mercator.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Mercator.java
@@ -163,6 +163,7 @@ public class Mercator extends ProjectionImpl {
    *
    * @param par the first standard parallel
    */
+  @Deprecated
   public void setParallel(double par) {
     this.par = par;
     this.par_r = Math.toRadians(par);
@@ -174,6 +175,7 @@ public class Mercator extends ProjectionImpl {
    *
    * @param lon the origin longitude.
    */
+  @Deprecated
   public void setOriginLon(double lon) {
     lon0 = lon;
     precalculate();
@@ -185,6 +187,7 @@ public class Mercator extends ProjectionImpl {
    *
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -195,6 +198,7 @@ public class Mercator extends ProjectionImpl {
    *
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Orthographic.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Orthographic.java
@@ -155,7 +155,9 @@ public class Orthographic extends ProjectionImpl {
    *
    * @param lon the origin longitude.
    */
+  @Deprecated
   public void setOriginLon(double lon) {
+    lon0Degrees = lon0;
     lon0 = Math.toRadians(lon);
     precalculate();
   }
@@ -165,7 +167,9 @@ public class Orthographic extends ProjectionImpl {
    *
    * @param lat the origin latitude.
    */
+  @Deprecated
   public void setOriginLat(double lat) {
+    _lat0 = lat0;
     lat0 = Math.toRadians(lat);
     precalculate();
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Sinusoidal.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Sinusoidal.java
@@ -110,6 +110,7 @@ public class Sinusoidal extends ProjectionImpl {
    *
    * @param centMeridian central Meridian in degrees
    */
+  @Deprecated
   public void setCentMeridian(double centMeridian) {
     this.centMeridian = centMeridian;
   }
@@ -120,6 +121,7 @@ public class Sinusoidal extends ProjectionImpl {
    *
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -130,6 +132,7 @@ public class Sinusoidal extends ProjectionImpl {
    *
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Stereographic.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Stereographic.java
@@ -45,9 +45,10 @@ public class Stereographic extends ProjectionImpl {
 
   // values passed in through the constructor
   // need for constructCopy
-  private final double _latts;
-  private final double _latt;
-  private final double _lont;
+  private double _latts;
+  private double _latt;
+  private double _lont;
+  private double _scale;
 
   @Override
   public ProjectionImpl constructCopy() {
@@ -104,6 +105,7 @@ public class Stereographic extends ProjectionImpl {
     this._latts = 0.0;
     this._latt = latt;
     this._lont = lont;
+    this._scale = scale;
 
     this.latt = Math.toRadians(latt);
     this.lont = Math.toRadians(lont);
@@ -132,7 +134,7 @@ public class Stereographic extends ProjectionImpl {
    *
    * @param lat_ts_deg Latitude at natural origin (degrees_north)
    * @param latt_deg tangent point of projection (degrees_north)
-   * @param lont_deg tangent point of projection, also origin of projection coord system ((degrees_east)
+   * @param lont_deg tangent point of projection, also origin of projection coord system (degrees_east)
    * @param north true if north pole, false is south pole
    */
   public Stereographic(double lat_ts_deg, double latt_deg, double lont_deg, boolean north) {
@@ -206,7 +208,7 @@ public class Stereographic extends ProjectionImpl {
    * @return the scale
    */
   public double getScale() {
-    return scale / earthRadius;
+    return _scale;
   }
 
   /**
@@ -254,14 +256,18 @@ public class Stereographic extends ProjectionImpl {
   /**
    * @deprecated
    */
+  @Deprecated
   public void setScale(double scale) {
+    _scale = scale;
     this.scale = earthRadius * scale;
   }
 
   /**
    * @deprecated
    */
+  @Deprecated
   public void setTangentLat(double latt) {
+    _latt = latt;
     this.latt = Math.toRadians(latt);
     precalculate();
   }
@@ -269,7 +275,9 @@ public class Stereographic extends ProjectionImpl {
   /**
    * @deprecated
    */
+  @Deprecated
   public void setTangentLon(double lont) {
+    _lont = lont;
     this.lont = Math.toRadians(lont);
     precalculate();
   }
@@ -279,6 +287,7 @@ public class Stereographic extends ProjectionImpl {
   /**
    * @deprecated
    */
+  @Deprecated
   public void setCentralMeridian(double lont) {
     setTangentLon(lont);
   }
@@ -289,6 +298,7 @@ public class Stereographic extends ProjectionImpl {
    *
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -299,6 +309,7 @@ public class Stereographic extends ProjectionImpl {
    *
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/TransverseMercator.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/TransverseMercator.java
@@ -27,7 +27,7 @@ public class TransverseMercator extends ProjectionImpl {
 
   // values passed in through the constructor
   // need for constructCopy
-  private final double _lat0, _lon0, _scale;
+  private double _lat0, _lon0, _scale;
 
   @Override
   public ProjectionImpl constructCopy() {
@@ -166,7 +166,9 @@ public class TransverseMercator extends ProjectionImpl {
    *
    * @param scale the scale
    */
+  @Deprecated
   public void setScale(double scale) {
+    _scale = scale;
     this.scale = earthRadius * scale;
   }
 
@@ -175,7 +177,9 @@ public class TransverseMercator extends ProjectionImpl {
    *
    * @param lat the origin latitude
    */
+  @Deprecated
   public void setOriginLat(double lat) {
+    _lat0 = lat0;
     lat0 = Math.toRadians(lat);
   }
 
@@ -184,7 +188,9 @@ public class TransverseMercator extends ProjectionImpl {
    *
    * @param lon the tangent longitude
    */
+  @Deprecated
   public void setTangentLon(double lon) {
+    _lon0 = lon0;
     lon0 = Math.toRadians(lon);
   }
 
@@ -194,6 +200,7 @@ public class TransverseMercator extends ProjectionImpl {
    * 
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -204,6 +211,7 @@ public class TransverseMercator extends ProjectionImpl {
    * 
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/VerticalPerspectiveView.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/VerticalPerspectiveView.java
@@ -31,6 +31,10 @@ public class VerticalPerspectiveView extends ProjectionImpl {
   private double cosLat0, sinLat0;
   private double maxR; // "map limit" circle of this radius from the origin, p 173
 
+  // values passed in through the constructor
+  // need for constructCopy
+  private double _lat0, _lon0;
+
   @Override
   public ProjectionImpl constructCopy() {
     ProjectionImpl result =
@@ -171,7 +175,7 @@ public class VerticalPerspectiveView extends ProjectionImpl {
    * @return the origin longitude.
    */
   public double getOriginLon() {
-    return Math.toDegrees(lon0);
+    return _lon0;
   }
 
   /**
@@ -180,7 +184,7 @@ public class VerticalPerspectiveView extends ProjectionImpl {
    * @return the origin latitude.
    */
   public double getOriginLat() {
-    return Math.toDegrees(lat0);
+    return _lat0;
   }
 
   public double getP() {
@@ -196,7 +200,9 @@ public class VerticalPerspectiveView extends ProjectionImpl {
    * 
    * @param lon the origin longitude.
    */
+  @Deprecated
   public void setOriginLon(double lon) {
+    _lon0 = lon;
     lon0 = Math.toRadians(lon);
     precalculate();
   }
@@ -206,6 +212,7 @@ public class VerticalPerspectiveView extends ProjectionImpl {
    * 
    * @param height height above the earth
    */
+  @Deprecated
   public void setHeight(double height) {
     H = height;
     precalculate();
@@ -216,7 +223,9 @@ public class VerticalPerspectiveView extends ProjectionImpl {
    *
    * @param lat the origin latitude.
    */
+  @Deprecated
   public void setOriginLat(double lat) {
+    _lat0 = lat0;
     lat0 = Math.toRadians(lat);
     precalculate();
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/PolyconicProjection.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/proj4/PolyconicProjection.java
@@ -73,7 +73,7 @@ public class PolyconicProjection extends ProjectionImpl {
 
   // values passed in through the constructor
   // need for constructCopy
-  private final double _lat0, _lon0;
+  private double _lat0, _lon0;
 
   public PolyconicProjection() {
     this(23.56, 76.54);
@@ -313,7 +313,9 @@ public class PolyconicProjection extends ProjectionImpl {
    *
    * @param lat the origin latitude.
    */
+  @Deprecated
   public void setOriginLatitude(double lat) { // suppply in degrees
+    _lat0 = lat;
     projectionLatitude = Math.toRadians(lat);
   }
 
@@ -331,7 +333,9 @@ public class PolyconicProjection extends ProjectionImpl {
    *
    * @param lon the origin longitude.
    */
-  public void setOriginLongitude(double lon) {// suppply in degrees
+  @Deprecated
+  public void setOriginLongitude(double lon) {// supply in degrees
+    _lon0 = lon;
     projectionLongitude = Math.toRadians(lon);
   }
 
@@ -359,6 +363,7 @@ public class PolyconicProjection extends ProjectionImpl {
    *
    * @param falseEasting x offset
    */
+  @Deprecated
   public void setFalseEasting(double falseEasting) {
     this.falseEasting = falseEasting;
   }
@@ -378,6 +383,7 @@ public class PolyconicProjection extends ProjectionImpl {
    *
    * @param falseNorthing y offset
    */
+  @Deprecated
   public void setFalseNorthing(double falseNorthing) {
     this.falseNorthing = falseNorthing;
   }


### PR DESCRIPTION
When backporting Unidata/netcdf-java#367 in Unidata/netcdf-java#370, I
missed updating the setter methods (Projections are immutable in version
6). Also, found a case where we were still relying on a calculated value
for the scale parameter in the constructCopy of Sterographic, so fixed that
as well (will need to port that to the develop branch).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/502)
<!-- Reviewable:end -->
