### PR TITLE
Properly handle scale parameter in Stereographic projection

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Stereographic.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Stereographic.java
@@ -38,15 +38,13 @@ public class Stereographic extends AbstractProjection {
   private final double scale, earthRadius;
   private final double latt, lont;
   private final double sinlatt, coslatt;
-  private double latts;
-  private boolean isNorth;
-  private boolean isPolar;
+  private final double latts;
+  private final boolean isNorth;
+  private final boolean isPolar;
 
   // values passed in through the constructor
   // need for constructCopy
-  private final double _latts;
-  private final double _latt;
-  private final double _lont;
+  private final double _latts, _latt, _lont, _scale;
 
   @Override
   public Projection constructCopy() {
@@ -98,6 +96,7 @@ public class Stereographic extends AbstractProjection {
     this._latts = lat_ts_deg;
     this._latt = latt_deg;
     this._lont = lont_deg;
+    this._scale = 0;
 
     this.latts = Math.toRadians(lat_ts_deg);
     this.latt = Math.toRadians(latt_deg);
@@ -134,9 +133,15 @@ public class Stereographic extends AbstractProjection {
       double radius) {
     super("Stereographic", false);
 
-    this._latts = 0.0;
+    // defaults
+    this.latts = 0;
+    this.isNorth = false;
+    this.isPolar = false;
+
+    this._latts = 0;
     this._latt = latt;
     this._lont = lont;
+    this._scale = scale;
 
     this.latt = Math.toRadians(latt);
     this.lont = Math.toRadians(lont);
@@ -197,7 +202,7 @@ public class Stereographic extends AbstractProjection {
    * @return the scale
    */
   public double getScale() {
-    return scale / earthRadius;
+    return _scale;
   }
 
   /**


### PR DESCRIPTION
Make sure we keep track of the base scale value so that it can be used
by the constructCopy method. See comment on PR Unidata/netcdf-java#502

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/503)
<!-- Reviewable:end -->
