### PR TITLE
add new DataViewer service type

### DIFF
--- a/cdm/core/src/main/java/thredds/client/catalog/ServiceType.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/ServiceType.java
@@ -24,7 +24,7 @@ public enum ServiceType {
   GRIDFTP, //
   H5Service, //
   HTTPServer("HTTP file download.", AccessType.DataAccess, "httpserver"), //
-  JupyterNotebook("Generate a Jupyter Notebook that uses Siphon to access this dataset.", AccessType.DataAccess, null), //
+  JupyterNotebook("Generate a Jupyter Notebook that uses Siphon to access this dataset.", AccessType.DataViewer, null), //
   ISO("Provide ISO 19115 metdata representation of a dataset's structure and metadata.", AccessType.Metadata, null), //
   LAS, //
   NcJSON, //
@@ -88,7 +88,7 @@ public enum ServiceType {
   }
 
   public enum AccessType {
-    Catalog("Catalog"), Metadata("Metadata"), DataAccess("Data Access"), Unknown("Unknown");
+    Catalog("Catalog"), Metadata("Metadata"), DataAccess("Data Access"), DataViewer("Data Viewer"), Unknown("Unknown");
 
     protected final String name;
 


### PR DESCRIPTION
Add new service type for services with are data viewers (e.g. the Jupyter Notebook service)
[tds#116](https://github.com/Unidata/tds/pull/116) depends on this change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/507)
<!-- Reviewable:end -->
