### PR TITLE
Use the data_word_size from the level 2 message

### DIFF
--- a/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Level2Record.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Level2Record.java
@@ -6,6 +6,8 @@
 
 package ucar.nc2.iosp.nexrad2;
 
+import java.util.ArrayList;
+import java.util.List;
 import ucar.unidata.io.RandomAccessFile;
 import ucar.ma2.IndexIterator;
 import ucar.ma2.Range;
@@ -179,9 +181,9 @@ public class Level2Record {
     switch (datatype) {
       case REFLECTIVITY:
       case REFLECTIVITY_HIGH:
-      case DIFF_REFLECTIVITY_HIGH:
         return "dBz";
-
+      case DIFF_REFLECTIVITY_HIGH:
+        return "dB";
       case VELOCITY_HI:
       case VELOCITY_LOW:
       case SPECTRUM_WIDTH:
@@ -506,6 +508,10 @@ public class Level2Record {
   short phiHR_first_gate;
   short rhoHR_first_gate;
 
+  byte reflectHR_data_word_size, velocityHR_data_word_size, spectrumHR_data_word_size;
+  byte zdrHR_data_word_size, phiHR_data_word_size, rhoHR_data_word_size;
+
+  private List<String> missingProductWarned = new ArrayList<>();
 
   public static Level2Record factory(RandomAccessFile din, int record, long message_offset31) throws IOException {
     long offset = record * RADAR_DATA_SIZE + FILE_HEADER_SIZE + message_offset31;
@@ -625,7 +631,10 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp4;
         } else {
-          logger.warn("Missing radial product dbp4={} tname={}", dbp4, tname);
+          if (!missingProductWarned.contains(tname)) {
+            logger.warn("Missing radial product dbp4={} tname={}", dbp4, tname);
+            missingProductWarned.add(tname);
+          }
         }
 
       }
@@ -651,7 +660,10 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp5;
         } else {
-          logger.warn("Missing radial product dbp5={} tname={}", dbp5, tname);
+          if (!missingProductWarned.contains(tname)) {
+            logger.warn("Missing radial product dbp5={} tname={}", dbp5, tname);
+            missingProductWarned.add(tname);
+          }
         }
       }
       if (dbp6 > 0) {
@@ -676,7 +688,10 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp6;
         } else {
-          logger.warn("Missing radial product dbp6={} tname={}", dbp6, tname);
+          if (!missingProductWarned.contains(tname)) {
+            logger.warn("Missing radial product dbp6={} tname={}", dbp6, tname);
+            missingProductWarned.add(tname);
+          }
         }
       }
 
@@ -702,7 +717,10 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp7;
         } else {
-          logger.warn("Missing radial product dbp7={} tname={}", dbp7, tname);
+          if (!missingProductWarned.contains(tname)) {
+            logger.warn("Missing radial product dbp7={} tname={}", dbp7, tname);
+            missingProductWarned.add(tname);
+          }
         }
       }
 
@@ -728,7 +746,10 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp8;
         } else {
-          logger.warn("Missing radial product dbp8={} tname={}", dbp8, tname);
+          if (!missingProductWarned.contains(tname)) {
+            logger.warn("Missing radial product dbp8={} tname={}", dbp8, tname);
+            missingProductWarned.add(tname);
+          }
         }
       }
 
@@ -754,7 +775,10 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp9;
         } else {
-          logger.warn("Missing radial product dbp9={} tname={}", dbp9, tname);
+          if (!missingProductWarned.contains(tname)) {
+            logger.warn("Missing radial product dbp9={} tname={}", dbp9, tname);
+            missingProductWarned.add(tname);
+          }
         }
       }
       // hasHighResREFData = (dbp4 > 0);
@@ -765,6 +789,7 @@ public class Level2Record {
         reflectHR_gate_size = getDataBlockValue(din, (short) dbpp4, 12);
         ref_rf_threshold = getDataBlockValue(din, (short) dbpp4, 14);
         ref_snr_threshold = getDataBlockValue(din, (short) dbpp4, 16);
+        reflectHR_data_word_size = getDataBlockByte(din, (short) dbpp4, 19);
         reflectHR_scale = getDataBlockValue1(din, (short) dbpp4, 20);
         reflectHR_addoffset = getDataBlockValue1(din, (short) dbpp4, 24);
         reflectHR_offset = (short) (dbpp4 + 28);
@@ -777,6 +802,7 @@ public class Level2Record {
         velocityHR_gate_size = getDataBlockValue(din, (short) dbpp5, 12);
         vel_rf_threshold = getDataBlockValue(din, (short) dbpp5, 14);
         vel_snr_threshold = getDataBlockValue(din, (short) dbpp5, 16);
+        velocityHR_data_word_size = getDataBlockByte(din, (short) dbpp5, 19);
         velocityHR_scale = getDataBlockValue1(din, (short) dbpp5, 20);
         velocityHR_addoffset = getDataBlockValue1(din, (short) dbpp5, 24);
         velocityHR_offset = (short) (dbpp5 + 28);
@@ -789,6 +815,7 @@ public class Level2Record {
         spectrumHR_gate_size = getDataBlockValue(din, (short) dbpp6, 12);
         sw_rf_threshold = getDataBlockValue(din, (short) dbpp6, 14);
         sw_snr_threshold = getDataBlockValue(din, (short) dbpp6, 16);
+        spectrumHR_data_word_size = getDataBlockByte(din, (short) dbpp6, 19);
         spectrumHR_scale = getDataBlockValue1(din, (short) dbpp6, 20);
         spectrumHR_addoffset = getDataBlockValue1(din, (short) dbpp6, 24);
         spectrumHR_offset = (short) (dbpp6 + 28);
@@ -801,6 +828,7 @@ public class Level2Record {
         zdrHR_gate_size = getDataBlockValue(din, (short) dbpp7, 12);
         zdrHR_rf_threshold = getDataBlockValue(din, (short) dbpp7, 14);
         zdrHR_snr_threshold = getDataBlockValue(din, (short) dbpp7, 16);
+        zdrHR_data_word_size = getDataBlockByte(din, (short) dbpp7, 19);
         zdrHR_scale = getDataBlockValue1(din, (short) dbpp7, 20);
         zdrHR_addoffset = getDataBlockValue1(din, (short) dbpp7, 24);
         zdrHR_offset = (short) (dbpp7 + 28);
@@ -812,6 +840,7 @@ public class Level2Record {
         phiHR_gate_size = getDataBlockValue(din, (short) dbpp8, 12);
         phiHR_rf_threshold = getDataBlockValue(din, (short) dbpp8, 14);
         phiHR_snr_threshold = getDataBlockValue(din, (short) dbpp8, 16);
+        phiHR_data_word_size = getDataBlockByte(din, (short) dbpp8, 19);
         phiHR_scale = getDataBlockValue1(din, (short) dbpp8, 20);
         phiHR_addoffset = getDataBlockValue1(din, (short) dbpp8, 24);
         phiHR_offset = (short) (dbpp8 + 28);
@@ -823,6 +852,7 @@ public class Level2Record {
         rhoHR_gate_size = getDataBlockValue(din, (short) dbpp9, 12);
         rhoHR_rf_threshold = getDataBlockValue(din, (short) dbpp9, 14);
         rhoHR_snr_threshold = getDataBlockValue(din, (short) dbpp9, 16);
+        rhoHR_data_word_size = getDataBlockByte(din, (short) dbpp9, 19);
         rhoHR_scale = getDataBlockValue1(din, (short) dbpp9, 20);
         rhoHR_addoffset = getDataBlockValue1(din, (short) dbpp9, 24);
         rhoHR_offset = (short) (dbpp9 + 28);
@@ -1069,6 +1099,24 @@ public class Level2Record {
     return Short.MIN_VALUE;
   }
 
+  byte getDataWordSize(int datatype) {
+    switch (datatype) {
+      case REFLECTIVITY_HIGH:
+        return reflectHR_data_word_size;
+      case VELOCITY_HIGH:
+        return velocityHR_data_word_size;
+      case SPECTRUM_WIDTH_HIGH:
+        return spectrumHR_data_word_size;
+      case DIFF_REFLECTIVITY_HIGH:
+        return zdrHR_data_word_size;
+      case DIFF_PHASE:
+        return phiHR_data_word_size;
+      case CORRELATION_COEFFICIENT:
+        return rhoHR_data_word_size;
+    }
+    return 8;
+  }
+
   private short getDataBlockValue(RandomAccessFile raf, short offset, int skip) throws IOException {
     long off = offset + message_offset + MESSAGE_HEADER_SIZE;
     raf.seek(off);
@@ -1088,6 +1136,13 @@ public class Level2Record {
     raf.seek(off);
     raf.skipBytes(skip);
     return raf.readFloat();
+  }
+
+  private byte getDataBlockByte(RandomAccessFile raf, short offset, int skip) throws IOException {
+    long off = offset + message_offset + MESSAGE_HEADER_SIZE;
+    raf.seek(off);
+    raf.skipBytes(skip);
+    return raf.readByte();
   }
 
   public java.util.Date getDate() {
@@ -1115,7 +1170,9 @@ public class Level2Record {
     }
 
     int dataCount = getGateCount(datatype);
-    if (datatype == DIFF_PHASE) {
+    byte wordSize = getDataWordSize(datatype);
+
+    if (wordSize == 16) {
       short[] data = new short[dataCount];
       raf.readShort(data, 0, dataCount);
 
@@ -1125,8 +1182,7 @@ public class Level2Record {
         else
           ii.setShortNext(data[gateIdx]);
       }
-    } else {
-
+    } else if (wordSize == 8) {
       byte[] data = new byte[dataCount];
       raf.readFully(data);
       // short [] ds = convertunsignedByte2Short(data);
@@ -1136,7 +1192,10 @@ public class Level2Record {
         else
           ii.setByteNext(data[gateIdx]);
       }
-
+    } else {
+      String message = String.format("Data word size of %i bits not understood for data type %i (%s).", wordSize,
+          datatype, getDatatypeName(datatype));
+      throw new IOException(message);
     }
   }
 

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Level2Record.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Level2Record.java
@@ -511,7 +511,7 @@ public class Level2Record {
   byte reflectHR_data_word_size, velocityHR_data_word_size, spectrumHR_data_word_size;
   byte zdrHR_data_word_size, phiHR_data_word_size, rhoHR_data_word_size;
 
-  private List<String> missingProductWarned = new ArrayList<>();
+  private static List<String> missingProductWarned = new ArrayList<>();
 
   public static Level2Record factory(RandomAccessFile din, int record, long message_offset31) throws IOException {
     long offset = record * RADAR_DATA_SIZE + FILE_HEADER_SIZE + message_offset31;
@@ -610,6 +610,10 @@ public class Level2Record {
       int dbpp8 = 0;
       int dbpp9 = 0;
 
+      int missingPointerNumber = -999;
+      int missingPointerValue = -999;
+      String missingName = "";
+
       if (dbp4 > 0) {
         String tname = getDataBlockStringValue(din, (short) dbp4, 1, 3);
         if (tname.startsWith("REF")) {
@@ -631,10 +635,9 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp4;
         } else {
-          if (!missingProductWarned.contains(tname)) {
-            logger.warn("Missing radial product dbp4={} tname={}", dbp4, tname);
-            missingProductWarned.add(tname);
-          }
+          missingName = tname;
+          missingPointerNumber = 4;
+          missingPointerValue = dbp4;
         }
 
       }
@@ -660,10 +663,9 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp5;
         } else {
-          if (!missingProductWarned.contains(tname)) {
-            logger.warn("Missing radial product dbp5={} tname={}", dbp5, tname);
-            missingProductWarned.add(tname);
-          }
+          missingName = tname;
+          missingPointerNumber = 5;
+          missingPointerValue = dbp5;
         }
       }
       if (dbp6 > 0) {
@@ -688,10 +690,9 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp6;
         } else {
-          if (!missingProductWarned.contains(tname)) {
-            logger.warn("Missing radial product dbp6={} tname={}", dbp6, tname);
-            missingProductWarned.add(tname);
-          }
+          missingName = tname;
+          missingPointerNumber = 6;
+          missingPointerValue = dbp6;
         }
       }
 
@@ -717,10 +718,9 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp7;
         } else {
-          if (!missingProductWarned.contains(tname)) {
-            logger.warn("Missing radial product dbp7={} tname={}", dbp7, tname);
-            missingProductWarned.add(tname);
-          }
+          missingName = tname;
+          missingPointerNumber = 7;
+          missingPointerValue = dbp7;
         }
       }
 
@@ -746,10 +746,9 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp8;
         } else {
-          if (!missingProductWarned.contains(tname)) {
-            logger.warn("Missing radial product dbp8={} tname={}", dbp8, tname);
-            missingProductWarned.add(tname);
-          }
+          missingName = tname;
+          missingPointerNumber = 8;
+          missingPointerValue = dbp8;
         }
       }
 
@@ -775,13 +774,23 @@ public class Level2Record {
           hasHighResRHOData = true;
           dbpp9 = dbp9;
         } else {
-          if (!missingProductWarned.contains(tname)) {
-            logger.warn("Missing radial product dbp9={} tname={}", dbp9, tname);
-            missingProductWarned.add(tname);
-          }
+          missingName = tname;
+          missingPointerNumber = 9;
+          missingPointerValue = dbp9;
         }
       }
-      // hasHighResREFData = (dbp4 > 0);
+
+      if (missingPointerNumber != -999) {
+        // warn once per type per pointer location
+        String missingKey = String.format("%s%d", missingName, missingPointerNumber);
+        if (!missingProductWarned.contains(missingKey)) {
+          String msg = String.format(
+              "Unknown radial product dbp%d=%d tname=%s " + "(this is the only message you will see about this.)",
+              missingPointerNumber, missingPointerValue, missingName);
+          logger.warn(msg);
+          missingProductWarned.add(missingKey);
+        }
+      }
 
       if (hasHighResREFData) {
         reflectHR_gate_count = getDataBlockValue(din, (short) dbpp4, 8);

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Nexrad2IOServiceProvider.java
@@ -283,7 +283,7 @@ public class Nexrad2IOServiceProvider extends AbstractIOServiceProvider {
     dims.add(gateDim);
 
     Variable v = new Variable(ncfile, null, null, shortName);
-    if (datatype == DIFF_PHASE) {
+    if (firstRecord.getDataWordSize(datatype) == 16) {
       v.setDataType(DataType.USHORT);
     } else {
       v.setDataType(DataType.UBYTE);

--- a/cdm/radial/src/test/java/ucar/nc2/iosp/nexrad2/Test16BitDataWidth.java
+++ b/cdm/radial/src/test/java/ucar/nc2/iosp/nexrad2/Test16BitDataWidth.java
@@ -1,0 +1,54 @@
+package ucar.nc2.iosp.nexrad2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import ucar.ma2.Array;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.MAMath;
+import ucar.ma2.MAMath.MinMax;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+@Category(NeedsCdmUnitTest.class)
+public class Test16BitDataWidth {
+
+  private static final String filename =
+      TestDir.cdmUnitTestDir + "formats/nexrad/newLevel2/testfiles/Level2_KDDC_20201007_1914.ar2v";
+
+  @Test
+  public void testNonPhiVar() throws IOException, InvalidRangeException {
+    try (NetcdfFile ncf = NetcdfFiles.open(filename)) {
+      // verified against metpy
+      int expectedMin = 0;
+      int expectedMax = 1058;
+      Variable var = ncf.findVariable("DifferentialReflectivity_HI");
+      Array data = var.read("0,:,:");
+      MinMax minMax = MAMath.getMinMax(data);
+      assertThat(minMax.min).isWithin(1e-6).of(expectedMin);
+      assertThat(minMax.max).isWithin(1e-6).of(expectedMax);
+    }
+  }
+
+  @Test
+  public void testNonPhiVarEnhanced() throws IOException, InvalidRangeException {
+    try (NetcdfDataset ncf = NetcdfDatasets.openDataset(filename)) {
+      // verified against metpy
+      int expectedMin = -13;
+      int expectedMax = 20;
+      Variable var = ncf.findVariable("DifferentialReflectivity_HI");
+      Array data = var.read("0,:,:");
+      MinMax minMax = MAMath.getMinMax(data);
+      assertThat(minMax.min).isWithin(1e-6).of(expectedMin);
+      assertThat(minMax.max).isWithin(1e-6).of(expectedMax);
+    }
+  }
+
+}


### PR DESCRIPTION
Previously, the level 2 code used a fixed word size of 8 bits for the
data blocks, with a special exception for the differential phase
product, which was hardcoded to use 16 bits. This PR enables the IOSP
and Level2 Record parser to use the actual word size as encoded in the
message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/514)
<!-- Reviewable:end -->
