### PR TITLE
Ignore doc deprecation check on the develop branch

### DIFF
--- a/.github/workflows/docs-tutorials.yml
+++ b/.github/workflows/docs-tutorials.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
-
+    branches-ignore:
+      # ignore this workflow while the develop branch is under heavy construction
+      - '**'
 jobs:
   check-doc-build:
     name: netCDF-Java Documentation Code Deprecation Check


### PR DESCRIPTION
Temporarily ignore the deprecation warning check for the documentation
while the develop branch is under heavy construction. This only applies
to PRs against the develop branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/516)
<!-- Reviewable:end -->
