### PR TITLE
ncss documentation --> tds docs

### DIFF
--- a/docs/src/public/userguide/_config.yml
+++ b/docs/src/public/userguide/_config.yml
@@ -5,6 +5,9 @@ output: web
 docset_version: 5.4
 # this will appear in an HTML meta tag, sidebar, and perhaps elsewhere
 
+tds_docset_version: 5.0
+# this will appear in the sidebar and doc pages
+
 topnav_title: netCDF-Java
 # this appears on the top navigation bar next to the home button
 

--- a/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
+++ b/docs/src/public/userguide/_data/sidebars/netcdfJavaTutorial_sidebar.yml
@@ -252,7 +252,7 @@ entries:
       output: web, pdf
 
     - title: NetCDF Subset Service
-      url: subset_service.html
+      external_url: https://docs.unidata.ucar.edu/tds/current/userguide/netcdf_subset_service_ref.html
       output: web, pdf
 
     - title: netCDF C Library

--- a/docs/src/public/userguide/_includes/sidebar.html
+++ b/docs/src/public/userguide/_includes/sidebar.html
@@ -1,4 +1,6 @@
 {% include custom/sidebarconfigs.html %}
+{% capture tds_doc_version %}{{ "/tds/" | append: site.tds_docset_version }}{% endcapture %}
+{% capture tds_doc_replace %}{{ tds_doc_version | append: "/"}}{% endcapture %}
 
 <ul id="mysidebar" class="nav">
     <li class="sidebarTitle">{{sidebar[0].product}}</li>
@@ -11,7 +13,7 @@
             {% for folderitem in folder.folderitems %}
             {% if folderitem.output contains "web" %}
             {% if folderitem.external_url %}
-            <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+            <li><a href="{{folderitem.external_url | replace: "/tds/current/", tds_doc_replace  }}" target="_blank">{{folderitem.title}}</a></li>
             {% elsif page.url == folderitem.url %}
             <li class="active"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
             {% else %}
@@ -25,7 +27,7 @@
                     {% for subfolderitem in subfolders.subfolderitems %}
                     {% if subfolderitem.output contains "web" %}
                     {% if subfolderitem.external_url %}
-                    <li><a href="{{subfolderitem.external_url}}" target="_blank">{{subfolderitem.title}}</a></li>
+                    <li><a href="{{subfolderitem.external_url | replace: "/tds/current/", tds_doc_replace  }}" target="_blank">{{subfolderitem.title}}</a></li>
                     {% elsif page.url == subfolderitem.url %}
                     <li class="active"><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
                     {% else %}


### PR DESCRIPTION
- added liquid substitution for links to tds docs
- changed sidebar ncss link to reference ncss stuff in TDS docs.
- did NOT remove the userguide/subset_service.html page (keeping this around until the docs revamp).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/537)
<!-- Reviewable:end -->
