### PR TITLE
Enable the creation of DtCoverageDatasets using NcML JoinNew Aggregations

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1D.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1D.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.dataset;
 
-import ucar.ma2.*;
+import ucar.ma2.Array;
+import ucar.ma2.ArrayChar;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.MAMath;
+import ucar.ma2.Range;
+import ucar.ma2.Section;
 import ucar.nc2.Group;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.constants.CF;
@@ -844,7 +853,7 @@ public class CoordinateAxis1D extends CoordinateAxis {
       names[count++] = iter.next();
   }
 
-  private void readValues() {
+  protected void readValues() {
     Array data;
     try {
       // setUseNaNs(false); // missing values not allowed LOOK not true for point data !!
@@ -994,13 +1003,13 @@ public class CoordinateAxis1D extends CoordinateAxis {
 
   ////////////////////////////////////////////////////////////////////////////////////////////
   // These are all calculated, I think?
-  private boolean wasRead; // have the data values been read
+  protected boolean wasRead; // have the data values been read
   private boolean wasBoundsDone; // have we created the bounds arrays if exists ?
   private boolean isInterval; // is this an interval coordinates - then should use bounds
   private boolean isAscending;
 
   // read in on doRead()
-  private double[] coords; // coordinate values, must be between edges
+  protected double[] coords; // coordinate values, must be between edges
   private String[] names; // only set if String or char values
 
   // defer making until asked, use makeBounds()

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1DTime.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1DTime.java
@@ -1,21 +1,36 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
 package ucar.nc2.dataset;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Formatter;
+import java.util.List;
+import java.util.StringTokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ucar.ma2.Array;
+import ucar.ma2.ArrayChar;
+import ucar.ma2.ArrayObject;
+import ucar.ma2.DataType;
+import ucar.ma2.Index;
+import ucar.ma2.IndexIterator;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Range;
 import ucar.nc2.Group;
-import ucar.nc2.time.*;
+import ucar.nc2.constants.AxisType;
+import ucar.nc2.constants._Coordinate;
+import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.CalendarDateFormatter;
+import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.units.TimeUnit;
 import ucar.nc2.Dimension;
 import ucar.nc2.Attribute;
 import ucar.nc2.util.NamedAnything;
 import ucar.nc2.util.NamedObject;
-import ucar.ma2.*;
-import java.util.*;
 import java.io.IOException;
 import ucar.nc2.units.DateRange;
 
@@ -79,7 +94,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Get the the ith CalendarDate.
-   * 
+   *
    * @param idx index
    * @return the ith CalendarDate
    */
@@ -90,7 +105,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Get calendar date range
-   * 
+   *
    * @return calendar date range
    */
   public CalendarDateRange getCalendarDateRange() {
@@ -163,7 +178,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Get the list of datetimes in this coordinate as CalendarDate objects.
-   * 
+   *
    * @return list of CalendarDates.
    */
   public List<CalendarDate> getCalendarDates() {
@@ -182,6 +197,26 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
     double[] intv = getCoordBounds(i);
     double midpoint = (intv[0] + intv[1]) / 2;
     return helper.makeCalendarDateFromOffset(midpoint);
+  }
+
+  @Override
+  protected void readValues() {
+    // if DataType is not numeric, handle special
+    if (!this.dataType.isNumeric()) {
+      this.coords = cdates.stream().mapToDouble(cdate -> (double) cdate.getDifferenceInMsecs(cdates.get(0))).toArray();
+      // make sure we don't try to read from the orgVar again
+      this.wasRead = true;
+    } else {
+      super.readValues();
+    }
+  }
+
+  @Override
+  public boolean isNumeric() {
+    // we're going to always handle the 1D time coordinate axis case as if it were numeric
+    // because if it is a String or Char, we'll try to convert the values into a
+    // UDUNITS compatible value in the readValues() method.
+    return true;
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -218,6 +253,20 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
     for (Attribute att : org.attributes()) {
       addAttribute(att);
     }
+
+    // look for _CoordinateAxisType attribute and use it if it is time or runtime
+    Attribute coordAxisTypeAttr = org.attributes().findAttributeIgnoreCase(_Coordinate.AxisType);
+    String attributeTypeName = coordAxisTypeAttr != null ? coordAxisTypeAttr.getStringValue() : null;
+    if (attributeTypeName != null) {
+      if (attributeTypeName.equalsIgnoreCase(AxisType.Time.name())
+          || attributeTypeName.equalsIgnoreCase(AxisType.RunTime.name())) {
+        this.axisType = AxisType.getType(attributeTypeName);
+      } else {
+        logger.info("Attribute {} on variable {} is not a recognized time axis type.", _Coordinate.AxisType,
+            org.getFullName());
+      }
+    }
+    this.setUnitsString("milliseconds since " + cdates.get(0).toString());
   }
 
   private List<CalendarDate> makeTimesFromChar(VariableDS org, Formatter errMessages) throws IOException {
@@ -273,7 +322,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Constructor for numeric values - must have units
-   * 
+   *
    * @param ncd the containing dataset
    * @param org the underlying Variable
    * @throws IOException on read error
@@ -330,7 +379,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Does not handle non-standard Calendars
-   * 
+   *
    * @deprecated use getCalendarDates() to correctly interpret calendars
    */
   public java.util.Date[] getTimeDates() {
@@ -344,7 +393,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Does not handle non-standard Calendars
-   * 
+   *
    * @deprecated use getCalendarDate()
    */
   public java.util.Date getTimeDate(int idx) {
@@ -353,7 +402,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Does not handle non-standard Calendars
-   * 
+   *
    * @deprecated use getCalendarDateRange()
    */
   public DateRange getDateRange() {
@@ -363,7 +412,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Does not handle non-standard Calendars
-   * 
+   *
    * @deprecated use findTimeIndexFromCalendarDate
    */
   public int findTimeIndexFromDate(java.util.Date d) {
@@ -372,7 +421,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Does not handle non-standard Calendars
-   * 
+   *
    * @deprecated use hasCalendarDate
    */
   public boolean hasTime(Date date) {
@@ -403,7 +452,7 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
 
   /**
    * Get Builder for this class that allows subclassing.
-   * 
+   *
    * @see "https://community.oracle.com/blogs/emcmanus/2010/10/24/using-builder-pattern-subclasses"
    */
   public static Builder<?> builder() {

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageDataset.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.ft2.coverage.adapter;
 
 import java.io.Closeable;
@@ -12,10 +13,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import ucar.nc2.*;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.FeatureType;
-import ucar.nc2.dataset.*;
+import ucar.nc2.dataset.CoordinateAxis;
+import ucar.nc2.dataset.CoordinateSystem;
+import ucar.nc2.dataset.DatasetUrl;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasetInfo;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.dataset.VariableDS;
+import ucar.nc2.dataset.VariableEnhanced;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.unidata.geoloc.LatLonRect;
@@ -269,11 +281,18 @@ public class DtCoverageDataset implements Closeable {
    * @return the name of the dataset
    */
   public String getName() {
-    String loc = ncd.getLocation();
-    int pos = loc.lastIndexOf('/');
-    if (pos < 0)
-      pos = loc.lastIndexOf('\\');
-    return (pos < 0) ? loc : loc.substring(pos + 1);
+    String name = ncd.getLocation();
+    if (name != null) {
+      int pos = name.lastIndexOf('/');
+      if (pos < 0)
+        pos = name.lastIndexOf('\\');
+      name = (pos < 0) ? name : name.substring(pos + 1);
+    } else {
+      // A dataset defined using NcML inside of a TDS configuration catalog will not have a location.
+      // While location cannot be set for these virtual datasets, the id value can, so let's look for it.
+      name = ncd.getId();
+    }
+    return name;
   }
 
   /**

--- a/cdm/s3/src/test/data/ncml/joinNewScan/suffix/S3DelimEnhanced.ncml
+++ b/cdm/s3/src/test/data/ncml/joinNewScan/suffix/S3DelimEnhanced.ncml
@@ -1,4 +1,6 @@
-<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" enhance="all">
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+  id="GOES16 Aggregation for tests"
+  enhance="all">
   <!-- should find and aggregate 12 objects because we are only looking at OR_ABI-L1b-RadC-M3C01_G16_s* -->
   <!-- see https://noaa-goes16.s3.amazonaws.com/index.html#ABI-L1b-RadC/2017/090/00/ -->
   <remove name="t" type="variable" />

--- a/cdm/s3/src/test/java/ucar/nc2/internal/ncml/s3/S3AggScan.java
+++ b/cdm/s3/src/test/java/ucar/nc2/internal/ncml/s3/S3AggScan.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.AfterClass;
@@ -27,13 +26,8 @@ import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.constants.CF;
-import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
-import ucar.nc2.ft2.coverage.adapter.DtCoverage;
-import ucar.nc2.ft2.coverage.adapter.DtCoverageCS;
-import ucar.nc2.ft2.coverage.adapter.DtCoverageDataset;
-import ucar.nc2.ft2.coverage.adapter.DtCoverageDataset.Gridset;
 import ucar.unidata.io.s3.S3TestsCommon;
 
 public class S3AggScan {
@@ -102,32 +96,6 @@ public class S3AggScan {
   public void testAggJoinNewRegExpOpenNcml() throws IOException, InvalidRangeException {
     for (String ncmlFile : scanWithRegExp) {
       checkOpenNcmlFromString(ncmlFile, NcmlTestsCommon.expectedNumberOfTimesInAggRegExp);
-    }
-  }
-
-  @Test
-  public void testAggNewOpenAsDtCoverage() throws IOException {
-    String ncmlFile = NcmlTestsCommon.joinNewNcmlScanEnhanced;
-    logger.info("Opening {}", ncmlFile);
-    DtCoverageDataset cds = DtCoverageDataset.open(ncmlFile);
-    checkDtCoverage(cds);
-  }
-
-  @Test
-  public void testAggNewOpenNcmlAsDtCoverage() throws IOException {
-    String ncml;
-    String ncmlFile = NcmlTestsCommon.joinNewNcmlScanEnhanced;
-    logger.info("Reading {}", ncmlFile);
-    try (Stream<String> ncmlStream = Files.lines(Paths.get(ncmlFile))) {
-      ncml = ncmlStream.collect(Collectors.joining());
-    }
-    assertThat(ncml).isNotNull();
-
-    logger.debug("...opening contents of {} as string", ncmlFile);
-    try (NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), ncmlFile, null)) {
-      logger.debug("...opening NetcdfDataset as DtCoverageDataset");
-      DtCoverageDataset cds = new DtCoverageDataset(ncd);
-      checkDtCoverage(cds);
     }
   }
 
@@ -205,19 +173,6 @@ public class S3AggScan {
     try (NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), ncmlFile, null)) {
       expectedTimeCheck(ncd, expectedNumberOfTimes, timeVarName);
     }
-  }
-
-  private void checkDtCoverage(DtCoverageDataset cds) {
-    assertThat(cds).isNotNull();
-    List<DtCoverage> grids = cds.getGrids();
-    // two agg variables
-    assertThat(grids.size()).isEqualTo(2);
-    List<Gridset> gridSets = cds.getGridsets();
-    // one coordinate system
-    assertThat(gridSets.size()).isEqualTo(1);
-    DtCoverageCS coordSys = gridSets.get(0).getGeoCoordSystem();
-    CoordinateAxis timeAxis = coordSys.getTimeAxis();
-    assertThat(timeAxis.getSize()).isEqualTo(NcmlTestsCommon.expectedNumberOfTimesInAgg);
   }
 
   @AfterClass

--- a/cdm/s3/src/test/java/ucar/nc2/internal/ncml/s3/S3AggScanFeatureType.java
+++ b/cdm/s3/src/test/java/ucar/nc2/internal/ncml/s3/S3AggScanFeatureType.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.internal.ncml.s3;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.ma2.Array;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.dataset.CoordinateAxis;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.ft2.coverage.Coverage;
+import ucar.nc2.ft2.coverage.CoverageCollection;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis1D;
+import ucar.nc2.ft2.coverage.CoverageCoordSys;
+import ucar.nc2.ft2.coverage.CoverageDatasetFactory;
+import ucar.nc2.ft2.coverage.FeatureDatasetCoverage;
+import ucar.nc2.ft2.coverage.GeoReferencedArray;
+import ucar.nc2.ft2.coverage.HorizCoordSys;
+import ucar.nc2.ft2.coverage.SubsetParams;
+import ucar.nc2.ft2.coverage.adapter.DtCoverage;
+import ucar.nc2.ft2.coverage.adapter.DtCoverageCS;
+import ucar.nc2.ft2.coverage.adapter.DtCoverageDataset;
+import ucar.nc2.ft2.coverage.adapter.DtCoverageDataset.Gridset;
+import ucar.nc2.time.Calendar;
+import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.CalendarDateRange;
+import ucar.nc2.time.CalendarPeriod.Field;
+import ucar.nc2.util.Optional;
+import ucar.unidata.io.s3.S3TestsCommon;
+
+public class S3AggScanFeatureType {
+
+  private static final Logger logger = LoggerFactory.getLogger(S3AggScanFeatureType.class);
+  private static final double diffTolerance = 1e-6;
+
+  @BeforeClass
+  public static void setAwsRegion() {
+    System.setProperty(S3TestsCommon.AWS_REGION_PROP_NAME, S3TestsCommon.AWS_G16_REGION);
+  }
+
+  @Test
+  public void testAggNewOpenAsDtCoverage() throws IOException {
+    String ncmlFile = NcmlTestsCommon.joinNewNcmlScanEnhanced;
+    logger.info("Opening {}", ncmlFile);
+    DtCoverageDataset cds = DtCoverageDataset.open(ncmlFile);
+    checkDtCoverages(cds);
+  }
+
+  @Test
+  public void testAggNewOpenNcmlAsDtCoverage() throws IOException {
+    String ncml;
+    String ncmlFile = NcmlTestsCommon.joinNewNcmlScanEnhanced;
+    logger.info("Reading {}", ncmlFile);
+    try (Stream<String> ncmlStream = Files.lines(Paths.get(ncmlFile))) {
+      ncml = ncmlStream.collect(Collectors.joining());
+    }
+    assertThat(ncml).isNotNull();
+
+    logger.debug("...opening contents of {} as string", ncmlFile);
+    List<String> names = Arrays.asList(ncmlFile, null);
+    for (String name : names) {
+      try (NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), name, null)) {
+        logger.info("...opening NetcdfDataset as DtCoverageDataset using name {}", name);
+        DtCoverageDataset cds = new DtCoverageDataset(ncd);
+        checkDtCoverages(cds);
+      }
+    }
+  }
+
+  @Test
+  public void testAggNewOpenAsCoverage() throws IOException, InvalidRangeException {
+    String ncml;
+    String ncmlFile = NcmlTestsCommon.joinNewNcmlScanEnhanced;
+    logger.info("Reading {}", ncmlFile);
+    try (Stream<String> ncmlStream = Files.lines(Paths.get(ncmlFile))) {
+      ncml = ncmlStream.collect(Collectors.joining());
+    }
+    assertThat(ncml).isNotNull();
+    Optional<FeatureDatasetCoverage> fdc = CoverageDatasetFactory.openNcmlString(ncml);
+    assertThat(fdc.isPresent()).isTrue();
+    List<CoverageCollection> cc = fdc.get().getCoverageCollections();
+    checkCoverages(cc);
+  }
+
+
+  private void checkDtCoverages(DtCoverageDataset cds) {
+    assertThat(cds).isNotNull();
+    List<DtCoverage> grids = cds.getGrids();
+    // two agg variables
+    assertThat(grids).hasSize(2);
+    List<Gridset> gridSets = cds.getGridsets();
+    // one coordinate system
+    assertThat(gridSets).hasSize(1);
+    DtCoverageCS coordSys = gridSets.get(0).getGeoCoordSystem();
+    CoordinateAxis timeAxis = coordSys.getTimeAxis();
+    assertThat(timeAxis.getSize()).isEqualTo(NcmlTestsCommon.expectedNumberOfTimesInAgg);
+  }
+
+  private void checkCoverages(List<CoverageCollection> coverageCollections) throws IOException, InvalidRangeException {
+    assertThat(coverageCollections).hasSize(1);
+    CoverageCollection cc = coverageCollections.get(0);
+    // check that ID was picked up from NcML and used for the name
+    String name = cc.getName();
+    String coverageName = "GOES16 Aggregation for tests";
+    assertThat(name).isEqualTo(coverageName);
+    Iterable<Coverage> coverages1 = cc.getCoverages();
+    List<Coverage> coverages = ImmutableList.copyOf(coverages1);
+    // two aggregated variables
+    assertThat(coverages).hasSize(2);
+    // one coordinate system in the collection
+    List<CoverageCoordSys> coordinateSystems = cc.getCoordSys();
+    assertThat(coordinateSystems).hasSize(1);
+    CoverageCoordSys cs = coordinateSystems.get(0);
+    // check that time axis has all times
+    CoverageCoordAxis timeAxis = cs.getTimeAxis();
+    assertThat(timeAxis.getNcoords()).isEqualTo(NcmlTestsCommon.expectedNumberOfTimesInAgg);
+    // get horizontal coordinate system
+    HorizCoordSys coverageHcs = cs.getHorizCoordSys();
+    CoverageCoordAxis1D xAxis = coverageHcs.getXAxis();
+    CoverageCoordAxis1D yAxis = coverageHcs.getYAxis();
+    // test subsetting
+    SubsetParams subsetParams = new SubsetParams();
+    // five minute data, should get three times in subset
+    CalendarDate start = CalendarDate.parseISOformat(Calendar.getDefault().name(), "2017-08-30T00:07:16Z");
+    CalendarDate end = CalendarDate.parseISOformat(Calendar.getDefault().name(), "2017-08-30T00:17:16Z");
+    // Anticipate: 2017-08-30T00:07:16Z, 2017-08-30T00:12:16Z, 2017-08-30T00:17:16Z
+    long expectedTimesInSubset = end.getDifference(start, Field.Minute) / 5 + 1;
+    CalendarDateRange requestDateRange = CalendarDateRange.of(start, end);
+    subsetParams.setTimeRange(requestDateRange);
+    // if we don't do a horizontal stride, we will run out of heap
+    int horizontalStride = 10;
+    subsetParams.setHorizStride(horizontalStride);
+    // read subset from single coverage
+    Coverage singleCoverage = coverages.get(0);
+    GeoReferencedArray subset = singleCoverage.readData(subsetParams);
+    // check that time axis was subset
+    CoverageCoordSys subsetCoordSys = subset.getCoordSysForData();
+    CoverageCoordAxis subsetTimeAxis = subsetCoordSys.getTimeAxis();
+    // have to compare the string value of a date range for now
+    assertThat(subsetTimeAxis.getDateRange().equals(requestDateRange)).isTrue();
+    assertThat(subsetTimeAxis.getNcoords()).isEqualTo(expectedTimesInSubset);
+    // check horizontal coordinate system
+    HorizCoordSys subsetHcs = subsetCoordSys.getHorizCoordSys();
+    CoverageCoordAxis1D subsetXAxis = subsetHcs.getXAxis();
+    CoverageCoordAxis1D subsetYAxis = subsetHcs.getYAxis();
+    assertThat(subsetXAxis.getNcoords()).isEqualTo(xAxis.getNcoords() / horizontalStride);
+    assertThat(subsetYAxis.getNcoords()).isEqualTo(yAxis.getNcoords() / horizontalStride);
+    checkAxesFirstLastCoordValues(subsetXAxis, xAxis, horizontalStride);
+    checkAxesFirstLastCoordValues(subsetYAxis, yAxis, horizontalStride);
+  }
+
+  private void checkAxesFirstLastCoordValues(CoverageCoordAxis1D axSub, CoverageCoordAxis axFull, int stride) {
+    // check that subset axis has expected number of points
+    int expectedNumberOfPoints = axFull.getNcoords() / stride;
+    assertThat(axSub.getNcoords()).isEqualTo(expectedNumberOfPoints);
+    // check first and last coordinate values of the axis
+    Array fullValues = axFull.getCoordsAsArray();
+    Array subsetValues = axSub.getCoordsAsArray();
+    // check first coordinate value of subset axis
+    assertThat(subsetValues.getDouble(0)).isWithin(diffTolerance).of(fullValues.getDouble(0));
+    int lastIndexSub = Ints.checkedCast(subsetValues.getSize() - 1);
+    int lastIndexFull = Ints.checkedCast(lastIndexSub * stride);
+    // check last coordinate value of subset axis
+    assertThat(subsetValues.getDouble(lastIndexSub)).isWithin(diffTolerance).of(fullValues.getDouble(lastIndexFull));
+  }
+
+  @AfterClass
+  public static void clearAwsRegion() {
+    System.clearProperty(S3TestsCommon.AWS_REGION_PROP_NAME);
+  }
+}


### PR DESCRIPTION
JoinNew aggregations produce time coordinates that have `String` values. This PR enables the use of sting values for 1D time axis objects by transforming the `String` values into UDUINTS compliant numerical values on read (assuming we can parse the date/time strings). This also fixes the case for reading in NcML aggregations from a `String` (as opposed to a file) when creating a `DtCoverageDataset` by allowing a the name of the dataset to use the `id` attribute defined in the NcML, as a `NetcdfDataset` created using NcML from a `String` does not have a `location` (this scenairo shows up when using NcML in a TDS configuration catalog directly). One thing these changes will enable downstream is the ability to do NCSS requests against S3 aggregations (defined in TDS configuration catalogs using NcML), in the TDS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/548)
<!-- Reviewable:end -->
