### PR TITLE
Improve S3 access and NcML Aggregation support by Coverage API

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
@@ -3,6 +3,7 @@ package ucar.nc2.grib;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -350,6 +351,8 @@ public class TestGribIndexCreation {
 
   @Test
   @Category(NeedsCdmUnitTest.class)
+  @Ignore("There appears to be an issue with the encoding of these messages, so they have been moved to "
+      + "cdmUnitTest/gribCollections/ecmwf/exclude/bcs/ until we can figure out what ECMWF has done to make these.")
   public void createECMWFbcs() throws IOException { // SRC
     FeatureCollectionConfig config =
         new FeatureCollectionConfig("ECMWFbcs", "test/ECMWFbcs", FeatureCollectionType.GRIB1,

--- a/cdm/core/src/main/java/ucar/unidata/io/RemoteRandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/RemoteRandomAccessFile.java
@@ -118,7 +118,8 @@ public abstract class RemoteRandomAccessFile extends ucar.unidata.io.RandomAcces
     int currentOffsetIntoBuffer = offset;
 
     // Read cacheBlock containing pos, and fill the buffer from the effective location of pos in the cache block
-    // to end of the cache block
+    // up to the smaller of these three lengths: 1. bytes remaining in the cache block, 2. bytes remaining in the file,
+    // or 3. bytes remaining in the destination array.
     totalBytesRead += readCacheBlockPartial(pos, buff, currentOffsetIntoBuffer, true);
     currentOffsetIntoBuffer += totalBytesRead;
     // If we have read everything we have been asked to read, skip the rest of the read logic.
@@ -137,9 +138,8 @@ public abstract class RemoteRandomAccessFile extends ucar.unidata.io.RandomAcces
       }
       logger.debug("Number of full cache block reads: {}", currentCacheBlockNumber - firstCacheBlockNumber - 1);
 
-      // Read last cacheBlock containing current pos, and fill the buffer from the start of the cache block to the
-      // effective location of the current pos in the cache block. Can be skipped if totalBytesRead is less than the
-      // length of the requested read size.
+      // If there are still bytes to read, read last cacheBlock from the start of the cache block to the
+      // smaller of these two lengths: 1. bytes remaining in the file, or 2. bytes remaining in the destination array.
       if (totalBytesRead < len) {
         totalBytesRead += readCacheBlockPartial(pos + totalBytesRead, buff, currentOffsetIntoBuffer, false);
       }

--- a/cdm/core/src/main/java/ucar/unidata/io/RemoteRandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/RemoteRandomAccessFile.java
@@ -43,14 +43,17 @@ public abstract class RemoteRandomAccessFile extends ucar.unidata.io.RandomAcces
     file = null;
     location = url;
 
-    // Only enable cache if given size is at least twice the buffer size
-    if (maxRemoteCacheSize >= 2 * bufferSize) {
-      this.readCacheBlockSize = 2 * bufferSize;
+    // Only enable cache if its maximum size is at least 2x the buffer size, both of which are configurable
+    // at runtime
+    int minimumCacheActivationSize = 2 * bufferSize;
+    if (maxRemoteCacheSize >= minimumCacheActivationSize) {
+      // have each cache block hold a 1 buffer sized chunk
+      this.readCacheBlockSize = bufferSize;
       // user set max cache size in bytes
       // guava cache set as number of objects
       // The question here is, how many readCacheBlockSize objects would there be in maxRemoteCacheSize bytes?
       // total max cache size in bytes / size of one cache block, rounded up.
-      long numberOfCacheBlocks = (long) Math.ceil(maxRemoteCacheSize / readCacheBlockSize);
+      long numberOfCacheBlocks = (maxRemoteCacheSize / readCacheBlockSize) + 1;
       this.readCache = initCache(numberOfCacheBlocks, Duration.ofMillis(defaultReadCacheTimeToLive));
       readCacheEnabled = true;
     } else {
@@ -93,43 +96,134 @@ public abstract class RemoteRandomAccessFile extends ucar.unidata.io.RandomAcces
     return readCacheEnabled ? readFromCache(pos, buff, offset, len) : readRemote(pos, buff, offset, len);
   }
 
+  /**
+   * Fill byte array with remote data.
+   *
+   * @param pos position of remote file or object to start reading
+   * @param buff put data into this buffer
+   * @param offset buffer offset
+   * @param len number of bytes to read
+   * @return actual number of bytes read
+   * @throws IOException error reading remote data
+   */
   private int readFromCache(long pos, byte[] buff, int offset, int len) throws IOException {
-    long startCacheBlock = pos / readCacheBlockSize;
-    long endCacheBlock = (pos + len - 1) / readCacheBlockSize;
+    // We basically treat the entire remote file or object as a series of non-overlapping blocks of size
+    // readCacheBlockSize. Each of these blocks are assigned a number (0 - N) starting from position 0 in the
+    // remote file or object, and that number is used as the key of the cache.
+    // Here, we compute the first and last cache block that we need to read from based on the desired position in the
+    // file and the length of read.
+    long firstCacheBlockNumber = pos / readCacheBlockSize;
+    long lastCacheBlockNumber = (pos + len) / readCacheBlockSize;
+    int totalBytesRead = 0;
+    int currentOffsetIntoBuffer = offset;
 
-    if (pos >= length()) {
-      // Do not read past end of the file
-      return 0;
-    } else if (endCacheBlock - startCacheBlock > 1) {
-      // If the request touches more than two cache blocks, punt
-      // This should never happen because cache block size is
-      // twice the buffer size
-      return readFromCache(pos, buff, offset, len);
-    } else if (endCacheBlock - startCacheBlock == 1) {
-      // If the request touches two cache blocks, split it
-      int length1 = (int) ((endCacheBlock * readCacheBlockSize) - pos);
-      int length2 = (int) ((pos + len) - (endCacheBlock * readCacheBlockSize));
-      return readFromCache(pos, buff, offset, length1) + readFromCache(pos + length1, buff, offset + length1, length2);
+    // Read cacheBlock containing pos, and fill the buffer from the effective location of pos in the cache block
+    // to end of the cache block
+    totalBytesRead += readCacheBlockPartial(pos, buff, currentOffsetIntoBuffer, true);
+    currentOffsetIntoBuffer += totalBytesRead;
+    // If we have read everything we have been asked to read, skip the rest of the read logic.
+    // Otherwise, keep going.
+    if ((totalBytesRead < len) && (firstCacheBlockNumber != lastCacheBlockNumber)) {
+      // Now fill the buffer using whole cache blocks, up until the last cache block (as reading from the last cache
+      // block might be a partial read).
+      // LOOK: might benefit from concurrency? Need to see how often we end up inside this while statement.
+      // Initial testing shows this only happens for small readCacheBlockSize (which is equal to the read buffer size)
+      // when reading netCDF-4 files, but I think might depend on the specific IOSP in use.
+      long currentCacheBlockNumber = firstCacheBlockNumber + 1;
+      while (currentCacheBlockNumber < lastCacheBlockNumber) {
+        totalBytesRead += readCacheBlockFull(currentCacheBlockNumber, currentOffsetIntoBuffer, buff);
+        currentOffsetIntoBuffer += readCacheBlockSize;
+        currentCacheBlockNumber += 1;
+      }
+      logger.debug("Number of full cache block reads: {}", currentCacheBlockNumber - firstCacheBlockNumber - 1);
+
+      // Read last cacheBlock containing current pos, and fill the buffer from the start of the cache block to the
+      // effective location of the current pos in the cache block. Can be skipped if totalBytesRead is less than the
+      // length of the requested read size.
+      if (totalBytesRead < len) {
+        totalBytesRead += readCacheBlockPartial(pos + totalBytesRead, buff, currentOffsetIntoBuffer, false);
+      }
     }
 
-    // If we make it here, we are servicing a request that touches
-    // only one cache block.
+    return totalBytesRead;
+  }
+
+  private int readCacheBlockPartial(long pos, byte[] buff, int positionInBuffer, boolean fillForward)
+      throws IOException {
+
+    long cacheBlockNumber = pos / readCacheBlockSize;
+
+    // read in the cache block
     byte[] src;
-    Long key = startCacheBlock;
     try {
-      src = readCache.get(key);
+      src = readCache.get(cacheBlockNumber);
     } catch (ExecutionException ee) {
-      throw new IOException(ee.getCause());
+      throw new IOException("Error obtaining data from the remote data read cache.", ee);
     }
 
-    int srcPos = (int) (pos - (key * readCacheBlockSize));
-    int toEOB = src.length - srcPos;
-    int length = Math.min(toEOB, len);
-    // copy byte array fulfilling the request as obtained from the cache or a fresh read
-    // of the remote data into the destination buffer
-    System.arraycopy(src, srcPos, buff, offset, length);
+    // Careful - we are doing a partial read from the cache block. The pos in the file is some offset into the cache
+    // block, so let's start by calculating the pos of the first block
+    long posCacheBlockStart = cacheBlockNumber * readCacheBlockSize;
 
-    return len;
+    // Now, there are two possible cases. We either need to read from this position in the cache block to the end of
+    // the cache block (i.e. "fill buffer forward from the offset into the cache block"), or read from the beginning
+    // of the cache block up to the offset in the cache block (useful if reading last cache block in a series of cache
+    // blocks). Basically,the question is where do we start reading in the cache block, and what size read do we use?
+    int offsetIntoCacheBlock;
+    int sizeToCopy;
+    if (fillForward) {
+      // size to copy (assuming we will be hitting multiple blocks with the total read length)
+      // __________
+      // | |
+      // V V
+      // X ---|------- X
+      // ^____^
+      // |
+      // Offset Into Cache Block
+      offsetIntoCacheBlock = Math.toIntExact(pos - posCacheBlockStart);
+      sizeToCopy = readCacheBlockSize - offsetIntoCacheBlock;
+    } else {
+      // size to copy
+      // ______
+      // | |
+      // V V
+      // X ---|------- X
+      // ^
+      // Offset Into Cache Block
+      offsetIntoCacheBlock = 0;
+      sizeToCopy = Math.toIntExact(pos - posCacheBlockStart);
+    }
+
+    // We don't want to read past the end of the file, so let's check sizeToCopy against how much of the file
+    // is left to read
+    long toEof = length() - pos;
+    sizeToCopy = Math.toIntExact(Math.min(sizeToCopy, toEof));
+
+    // Finally, check to make sure we are not reading more than buff will hold
+    sizeToCopy = Math.toIntExact(Math.min(sizeToCopy, buff.length - positionInBuffer));
+
+    // Copy byte array fulfilling the request as obtained from the cache into the destination buffer
+    logger.debug("Requested {} bytes from the cache block (cache block size upper limit: {} bytes.)", sizeToCopy,
+        readCacheBlockSize);
+    logger.debug("Actual size of the cache block: {} bytes.", src.length);
+    logger.debug("Offset into cache block to begin copy: {} bytes.", offsetIntoCacheBlock);
+    logger.debug("Total size of the destination buffer: {} bytes.", buff.length);
+    logger.debug("Position in buffer to place the copy from the cache: {} bytes.", positionInBuffer);
+    logger.debug("Trying to fit {} bytes from the cache into {} bytes of the destination.",
+        src.length - offsetIntoCacheBlock, buff.length - positionInBuffer);
+    System.arraycopy(src, offsetIntoCacheBlock, buff, positionInBuffer, sizeToCopy);
+    return sizeToCopy;
+  }
+
+  private int readCacheBlockFull(long cacheBlockNumber, int positionInBuffer, byte[] buff) throws IOException {
+    byte[] src;
+    try {
+      src = readCache.get(cacheBlockNumber);
+    } catch (ExecutionException ee) {
+      throw new IOException("Error obtaining data from the remote data read cache.", ee);
+    }
+    System.arraycopy(src, 0, buff, positionInBuffer, readCacheBlockSize);
+    return readCacheBlockSize;
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/unidata/io/RemoteRandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/RemoteRandomAccessFile.java
@@ -172,21 +172,17 @@ public abstract class RemoteRandomAccessFile extends ucar.unidata.io.RandomAcces
     int offsetIntoCacheBlock;
     int sizeToCopy;
     if (fillForward) {
-      // size to copy (assuming we will be hitting multiple blocks with the total read length)
-      // __________
-      // | |
-      // V V
+      // .....size to copy (assuming we will want to read until the end of the cache block)
+      // .....<-------->
       // X ---|------- X
       // ^____^
-      // |
+      // ..|
       // Offset Into Cache Block
       offsetIntoCacheBlock = Math.toIntExact(pos - posCacheBlockStart);
       sizeToCopy = readCacheBlockSize - offsetIntoCacheBlock;
     } else {
       // size to copy
-      // ______
-      // | |
-      // V V
+      // <---->
       // X ---|------- X
       // ^
       // Offset Into Cache Block

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggSynGrid.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggSynGrid.java
@@ -54,7 +54,7 @@ public class TestAggSynGrid {
     assert gcsys.getTimeAxis() != null;
 
     CoordinateAxis1DTime taxis = gcsys.getTimeAxis1D();
-    assert taxis.getDataType() == DataType.STRING : taxis.getDataType();
+    assert taxis.getDataType() == DataType.DOUBLE : taxis.getDataType();
 
     List names = taxis.getNames();
     java.util.Date[] dates = taxis.getTimeDates();

--- a/cdm/radial/src/test/java/ucar/nc2/iosp/nexrad2/TestNexrad2HiResolution.java
+++ b/cdm/radial/src/test/java/ucar/nc2/iosp/nexrad2/TestNexrad2HiResolution.java
@@ -45,7 +45,7 @@ public class TestNexrad2HiResolution {
 
     @Override
     public int doAct(String filename) throws IOException {
-      if (deleteUncompress && !filename.endsWith(".bz2")) {
+      if (deleteUncompress && !filename.endsWith(".bz2") && !filename.endsWith(".ar2v")) {
         File uf = new File(filename);
         if (!uf.delete())
           System.out.printf("Failed to delete %s%n", filename);

--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3Read.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3Read.java
@@ -6,6 +6,8 @@
 package ucar.unidata.io.s3;
 
 import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -33,6 +35,7 @@ import ucar.nc2.dataset.DatasetUrl;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.util.CompareNetcdf2;
+import ucar.nc2.util.IO;
 import ucar.unidata.util.test.category.NeedsExternalResource;
 import ucar.unidata.util.test.category.NeedsUcarNetwork;
 
@@ -68,6 +71,8 @@ public class TestS3Read {
   private static final String NCAR_G16_S3_URI = "cdms3://" + NCAR_PROFILE_NAME
       + "@stratus.ucar.edu/unidata-netcdf-zarr-testing?netcdf-java/test/" + COMMON_G16_KEY;
 
+  // Location to save local copy of file for comparison
+  private static File LOCAL_G16_FILE;
 
   private static String credentialsFileGoodDefault = null;
   private static String credentialsFileBadDefault = null;
@@ -95,6 +100,14 @@ public class TestS3Read {
     // Disable CdmS3Uri cache, otherwise credentials, regions, etc. will be ignored.
     // For example, awsProfileSharedCredsBadDefault will not pass.
     CdmS3Client.enableCache(false);
+    String buffSize = System.getProperty("ucar.unidata.io.s3.bufferSize");
+    logger.info("S3 Read Buffer Size: {} bytes", buffSize);
+
+    // fetch local copy of the file we are testing against from AWS S3
+    String directDownloadUrl = "https://noaa-goes16.s3.amazonaws.com/" + COMMON_G16_KEY;
+    LOCAL_G16_FILE = File.createTempFile("ncj-", "TestS3Read.nc");
+    LOCAL_G16_FILE.deleteOnExit();
+    IO.readURLtoFile(directDownloadUrl, LOCAL_G16_FILE);
   }
 
   /**
@@ -364,9 +377,27 @@ public class TestS3Read {
         NetcdfFile aws = NetcdfFiles.open(AWS_G16_S3_URI_FULL)) {
       Formatter f = new Formatter();
       CompareNetcdf2 comparer = new CompareNetcdf2(f, false, false, true);
-      Assert.assertTrue(comparer.compare(aws, gcs));
-      Assert.assertTrue(comparer.compare(aws, osdc));
-      Assert.assertTrue(comparer.compare(osdc, gcs));
+      Assert.assertTrue("Compare AWS S3 Object to GCS Object.", comparer.compare(aws, gcs));
+      Assert.assertTrue("Compare AWS S3 Object to OSDC Object.", comparer.compare(aws, osdc));
+      Assert.assertTrue("Compare OSDC Object to GCS Object.", comparer.compare(osdc, gcs));
+    } finally {
+      System.clearProperty(S3TestsCommon.AWS_REGION_PROP_NAME);
+    }
+  }
+
+  @Test
+  public void compareAgainstLocal() throws IOException {
+    System.setProperty(S3TestsCommon.AWS_REGION_PROP_NAME, S3TestsCommon.AWS_G16_REGION);
+    try (NetcdfFile osdc = NetcdfFiles.open(OSDC_G16_S3_URI);
+        NetcdfFile gcs = NetcdfFiles.open(GCS_G16_S3_URI);
+        NetcdfFile aws = NetcdfFiles.open(AWS_G16_S3_URI_FULL);
+        NetcdfFile local = NetcdfFiles.open(LOCAL_G16_FILE.getPath())) {
+      Formatter f = new Formatter();
+      CompareNetcdf2 comparer = new CompareNetcdf2(f, false, false, true);
+      // Indirectly verify some of the S3RandomAccessFile reading logic
+      Assert.assertTrue("Compare local file read to AWS S3 Object store read.", comparer.compare(local, aws));
+      Assert.assertTrue("Compare local file read to GCS Object store read.", comparer.compare(local, gcs));
+      Assert.assertTrue("Compare local file read to OSDC Object store read.", comparer.compare(local, osdc));
     } finally {
       System.clearProperty(S3TestsCommon.AWS_REGION_PROP_NAME);
     }


### PR DESCRIPTION
This PR does a few things:
 * Improve Coverage support for NcML aggregations (which produce Time coordinate variables of type String)
 * Remove regression from S3 read logic (fixes Unidata/netcdf-java#433)
 * Improve S3 read testing

In addition, this PR also knocks out a few test errors encountered on Jenkins. These errors are not code related (post-test file cleanup too broad, files in test datasets moved).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/568)
<!-- Reviewable:end -->
