### PR TITLE
Backports from develop

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/Construct2.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/Construct2.java
@@ -298,7 +298,7 @@ class Construct2 {
 
       Group g = struct.getParentGroupOrRoot();
       if (g == null)
-        System.out.printf("HEY%n");
+        log.warn("Struct parent group is null.");
       EnumTypedef enumTypedef = g.findEnumeration(ct.getName());
       if (enumTypedef == null) {
         enumTypedef = new EnumTypedef(ct.getName(), ct.getMap());

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/GribCoverageValidator.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/GribCoverageValidator.java
@@ -50,7 +50,7 @@ public class GribCoverageValidator implements GribDataValidator {
     Double timeOffset = coords.getTimeOffset();
     double[] timeOffsetIntv = coords.getTimeOffsetIntv(); // LOOK ??
     if (timeOffset == null) {
-      logger.debug("HEY no timeOffsetCoord ");
+      logger.debug("no timeOffsetCoord ");
       return;
     }
 
@@ -117,7 +117,7 @@ public class GribCoverageValidator implements GribDataValidator {
     } else {
       CalendarDate fdate = cust.getForecastDate(gr);
       if (!fdate.equals(wantTimeOffset))
-        logger.debug("HEY forecast date");
+        logger.debug("forecast date");
       Assert.assertEquals("time coord", wantTimeOffset, fdate);
     }
 

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestDtWithCoverageBuilding.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestDtWithCoverageBuilding.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2015-2018 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
 package ucar.nc2.ft.coverage;
 
 import java.io.IOException;

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbxP.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbxP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2016-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.grib;
@@ -10,12 +10,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.nc2.NetcdfFile;
-import ucar.nc2.dt.GridDatatype;
-import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.grib.collection.Grib;
-import ucar.nc2.grib.collection.GribIosp;
-import ucar.nc2.iosp.IOServiceProvider;
 import ucar.nc2.util.DebugFlagsImpl;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
@@ -1,4 +1,11 @@
+/*
+ * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
 package ucar.nc2.grib;
+
+import static thredds.inventory.CollectionUpdateType.always;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -13,6 +20,7 @@ import thredds.featurecollection.FeatureCollectionType;
 import thredds.inventory.CollectionUpdateType;
 import ucar.nc2.Group;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.grib.collection.*;
 import ucar.nc2.util.DebugFlagsImpl;
 import ucar.nc2.util.DiskCache2;
@@ -26,10 +34,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.Formatter;
 
 /**
- * Test that the CDM Index Creation works
- *
- * @author caron
- * @since 11/14/2014
+ * Test that the CDM Index Creation works.
+ * Jenkins recreates indices, and so needs this to run.
  */
 public class TestGribIndexCreation {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -97,14 +103,14 @@ public class TestGribIndexCreation {
 
     boolean changed = GribCdmIndex.updateGribCollection(config, updateMode, logger);
     System.out.printf("changed = %s%n", changed);
+    String location = TestDir.cdmUnitTestDir + "gribCollections/gdsHashChange/noaaport/NDFD-CONUS_noaaport.ncx4";
     // LOOK add check that records were combined
-    try (NetcdfFile ncfile = NetcdfFile
-        .open(TestDir.cdmUnitTestDir + "gribCollections/gdsHashChange/noaaport/NDFD-CONUS_noaaport.ncx4", null)) {
+    try (NetcdfFile ncfile = NetcdfFiles.open(location, null)) {
       Group root = ncfile.getRootGroup();
       Assert.assertEquals(2, root.getGroups().size());
     }
 
-    Grib.setDebugFlags(new DebugFlagsImpl(""));
+    Grib.setDebugFlags(new DebugFlagsImpl());
   }
 
   /*
@@ -324,19 +330,6 @@ public class TestGribIndexCreation {
 
   @Test
   @Category(NeedsCdmUnitTest.class)
-  public void testWW3() throws IOException {
-    // String name, String path, FeatureCollectionType fcType,
-    // String spec, String collectionName,
-    // String dateFormatMark, String olderThan, String timePartition, Element innerNcml)
-    FeatureCollectionConfig config = new FeatureCollectionConfig("ds093.1", "test/ds093.1", FeatureCollectionType.GRIB2,
-        TestDir.cdmUnitTestDir + "tds/ncep/WW3_Coastal_Alaska_20140804_0000.grib2", null, null, null, "file", null);
-
-    boolean changed = GribCdmIndex.updateGribCollection(config, updateMode, logger);
-    System.out.printf("changed = %s%n", changed);
-  }
-
-  @Test
-  @Category(NeedsCdmUnitTest.class)
   public void testMRUTP() throws IOException { // should be a TP (multiple runtime, single offset
     // String name, String path, FeatureCollectionType fcType,
     // String spec, String collectionName,
@@ -415,6 +408,32 @@ public class TestGribIndexCreation {
 
     boolean changed = GribCdmIndex.updateGribCollection(config, updateMode, logger);
     System.out.printf("changed = %s%n", changed);
+  }
+
+  @Ignore("files not available")
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void createNBMOcean() throws IOException { // TWOD
+    Grib.setDebugFlags(new DebugFlagsImpl("Grib/debugGbxIndexOnly"));
+    FeatureCollectionConfig config = new FeatureCollectionConfig("NCEP_OCEAN_MODEL_FIXED", "test/NCEP_OCEAN_MODEL",
+        FeatureCollectionType.GRIB2, "/media/twobee/tds/NCEP/NBM/Ocean/.*gbx9", null, null, null, "file", null);
+
+    boolean changed = GribCdmIndex.updateGribCollection(config, always, logger);
+    System.out.printf("changed = %s%n", changed);
+    Grib.setDebugFlags(new DebugFlagsImpl());
+  }
+
+  @Ignore("files not available")
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void createNndfCpc() throws IOException { // TWOD
+    Grib.setDebugFlags(new DebugFlagsImpl("Grib/debugGbxIndexOnly"));
+    FeatureCollectionConfig config = new FeatureCollectionConfig("NCEP_NDFD_CPC_Experimental", "test/NCEP_NDFD_CPC",
+        FeatureCollectionType.GRIB2, "/media/twobee/tds/NCEP/NDFD/CPC/.*gbx9", null, null, null, "file", null);
+
+    boolean changed = GribCdmIndex.updateGribCollection(config, always, logger);
+    System.out.printf("changed = %s%n", changed);
+    Grib.setDebugFlags(new DebugFlagsImpl());
   }
 
   @Test

--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFile.java
@@ -2253,21 +2253,13 @@ public class NetcdfFile implements FileCacheable, Closeable {
     return (iosp == null) ? "" : iosp.toStringDebug(o);
   }
 
-  /**
-   * Access to iosp debugging info.
-   *
-   * @return debug / underlying implementation details
-   * @deprecated do not use
-   */
-  @Deprecated
+  /** Show debug / underlying implementation details */
   public String getDetailInfo() {
     Formatter f = new Formatter();
     getDetailInfo(f);
     return f.toString();
   }
 
-  /** @deprecated do not use */
-  @Deprecated
   public void getDetailInfo(Formatter f) {
     f.format("NetcdfFile location= %s%n", getLocation());
     f.format("  title= %s%n", getTitle());

--- a/cdm/core/src/main/java/ucar/nc2/constants/AxisType.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/AxisType.java
@@ -6,12 +6,10 @@
 package ucar.nc2.constants;
 
 /**
- * Type-safe enumeration of netCDF Coordinate Axis types. These are used for tagging georeferencing axes.
+ * Enumeration of Coordinate Axis types. These are used for tagging georeferencing axes.
  * Do not change the ordering of these enums, as they are used in protobuf messages, only add new ones onto the end.
- *
- * @author john caron
+ * TODO: remove dependency on ordering.
  */
-
 public enum AxisType {
   RunTime(0, "R"), // runtime / reference time
   Ensemble(2, "E"), Time(1, "T"), GeoX(5, "X"), GeoY(4, "Y"), GeoZ(3, "Z"), // typically "dimensionless" vertical
@@ -19,16 +17,17 @@ public enum AxisType {
   Lat(4, "Y"), Lon(5, "X"), Height(3, "Z"), // vertical height coordinate
   Pressure(3, "Z"), // vertical pressure coordinate
   RadialAzimuth(7), RadialDistance(8), RadialElevation(6), Spectral(1), TimeOffset(1, "TO"), // time offset from runtime
-                                                                                             // / reference time
+                                                                                             // reference time
   Dimension(99, "Dim"), // used for dimension axis (experimental);
   SimpleGeometryX(100, "SgX"), // Simple Geometry X
   SimpleGeometryY(101, "SgY"), // Simple Geometry Y
   SimpleGeometryZ(102, "SgZ"), // Simple Geometry Z
   SimpleGeometryID(103, "SgID"); // Simple Geometry ID Axis, used for indexing simple geometry variables
 
-  private final int order; // canonical ordering runTime - ensemble - time - z - y - x or elev - azimuth - distance
-  private final String cfAxisName; // X, Y, Z, T from
-                                   // http://cf-pcmdi.llnl.gov/documents/cf-conventions/1.6/cf-conventions.html#coordinate-types
+  // canonical ordering runTime - ensemble - time - z - y - x or elev - azimuth - distance
+  private final int order;
+  // X, Y, Z, T from http://cf-pcmdi.llnl.gov/documents/cf-conventions/1.6/cf-conventions.html#coordinate-types
+  private final String cfAxisName;
 
   AxisType(int order) {
     this.order = order;

--- a/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
@@ -52,6 +52,8 @@ public class CDM {
   public static final String LON_UNITS = "degrees_east";
   public static final String RLATLON_UNITS = "degrees";
   public static final String TIME_OFFSET = "time offset from runtime";
+  public static final String TIME_OFFSET_HOUR = "hoursFrom0z";
+  public static final String RUNTIME_COORDINATE = "runtimeCoordinate";
 
   // Special Attribute Names used in jni.Nc4Iosp
   public static final String NCPROPERTIES = "_NCProperties";

--- a/cdm/core/src/main/java/ucar/nc2/constants/CF.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/CF.java
@@ -2,8 +2,10 @@
  * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.constants;
 
+import javax.annotation.Nullable;
 import ucar.nc2.NetcdfFile;
 
 /**
@@ -192,12 +194,11 @@ public class CF {
   public static final String featureTypeAtt3 = "CF:feature_type"; // GRIB was using this form (!)
   ///////////////////////////////////////////////////////////////////////
 
-  /**
-   * Map from CF feature type names to our FeatureType enums.
-   */
+  /** Map from CF feature type names to our FeatureType enums. */
   public enum FeatureType {
     point, timeSeries, profile, trajectory, timeSeriesProfile, trajectoryProfile, line, polygon,;
 
+    @Nullable
     public static FeatureType convert(ucar.nc2.constants.FeatureType ft) {
       switch (ft) {
         case POINT:
@@ -216,6 +217,7 @@ public class CF {
       return null;
     }
 
+    @Nullable
     public static ucar.nc2.constants.FeatureType convert(FeatureType cff) {
       switch (cff) {
         case point:
@@ -234,6 +236,7 @@ public class CF {
       return null;
     }
 
+    @Nullable
     public static FeatureType getFeatureType(String s) {
       if (s.equalsIgnoreCase("point"))
         return FeatureType.point;
@@ -257,9 +260,14 @@ public class CF {
         return FeatureType.trajectoryProfile;
       if (s.equalsIgnoreCase("section"))
         return FeatureType.trajectoryProfile;
+      if (s.equalsIgnoreCase("line"))
+        return FeatureType.line;
+      if (s.equalsIgnoreCase("polygon"))
+        return FeatureType.polygon;
       return null;
     }
 
+    @Nullable
     public static FeatureType getFeatureTypeFromGlobalAttribute(NetcdfFile ds) {
       String ftypeS = ds.getRootGroup().findAttributeString(CF.FEATURE_TYPE, null);
       if (ftypeS == null)

--- a/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
@@ -407,6 +407,8 @@ public class VariableDS extends Variable implements VariableEnhanced, EnhanceSca
     return null;
   }
 
+  /** @deprecated Removed in v6 */
+  @Deprecated
   public boolean hasCachedDataRecurse() {
     return super.hasCachedData() || ((orgVar != null) && orgVar.hasCachedData());
   }

--- a/cdm/core/src/main/java/ucar/nc2/dataset/VerticalCT.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/VerticalCT.java
@@ -80,7 +80,9 @@ public class VerticalCT extends CoordinateTransform {
    * @param authority naming authority.
    * @param type type of vertical transform
    * @param builder creates the VerticalTransform
+   * @deprecated use builder
    */
+  @Deprecated
   public VerticalCT(String name, String authority, VerticalCT.Type type, VertTransformBuilderIF builder) {
     super(name, authority, TransformType.Vertical);
     this.type = type;

--- a/cdm/core/src/main/java/ucar/nc2/ft/fmrc/FmrcInv.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/fmrc/FmrcInv.java
@@ -258,7 +258,7 @@ public class FmrcInv {
     double result = diff / 1000.0 / 60.0 / 60.0; // LOOK why convert to double? precision may be lost ??
     long testRoundoff = (long) (result * 1000.0 * 60.0 * 60.0);
     if (diff != testRoundoff)
-      log.debug("HEY getOffsetInHours");
+      log.debug("getOffsetInHours");
     return result;
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.ft2.coverage;
 
 import com.google.common.collect.ImmutableList;
@@ -87,7 +88,7 @@ public class HorizCoordSys {
     }
 
     if (!isProjection && isLatLon2D && !(this instanceof HorizCoordSys2D))
-      logger.warn("HEY Should be HorizCoordSys2D");
+      logger.warn("Should be HorizCoordSys2D");
 
     if (isLatLon1D) {
       this.latAxis = (CoverageCoordAxis1D) latAxis;

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/FmrcCS.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/FmrcCS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2012-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -20,12 +20,14 @@ public class FmrcCS extends DtCoverageCS {
     super(builder);
   }
 
-  @Override
-  public CoordinateAxis getTimeAxis() {
-    if (builder.timeOffsetAxis != null)
-      return builder.timeOffsetAxis;
-    return builder.timeAxis;
-  }
+  // 2D time coordinate system rework made this override unnecessary. Even though this class is now pointless, we'll
+  // keep it so that FMRC continue to have coordinate systems of type FmrcCS.
+  // @Override
+  // public CoordinateAxis getTimeAxis() {
+  // if (builder.timeOffsetAxis != null)
+  // return builder.timeOffsetAxis;
+  // return builder.timeAxis;
+  // }
 
   /*
    * public CoordinateAxis1DTime getTimeAxisForRun(CalendarDate runTime) {

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordSystemBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordSystemBuilder.java
@@ -135,6 +135,13 @@ public class CoordSystemBuilder {
 
     for (int i = 0; i < checkDims; i++) {
       Dimension axisDim = axisDims.get(i);
+      // added in 6, but causes the following tests to fail:
+      // ucar.nc2.dataset.TestCoordSysCompareMore.compareCoordSysBuilders:
+      // --> cdmUnitTest/formats/hdf4/ssec/CAL_LID_L1-Launch-V1-06.2006-07-07T21-20-40ZD.hdf
+      // --> cdmUnitTest/formats/hdf5/SMAP_L4_SM_aup_20140115T030000_V05007_001.h5
+      // if (!axisDim.isShared()) { // anon dimensions dont count. TODO does this work?
+      // continue;
+      // }
       if (!varDims.contains(axisDim)) {
         return false;
       }

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationExisting.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationExisting.java
@@ -72,7 +72,7 @@ class AggregationExisting extends AggregationOuter {
             .setParentGroupBuilder(rootGroup).setDimensionsByName(dimName);
         fake.setAutoGen(0, 1);
         rootGroup.addVariable(fake);
-        System.out.printf("HEY adding a fake coord var for %s%n", dimName);
+        logger.warn("Adding a fake coord var for {}", dimName);
       }
 
     } else {

--- a/cdm/core/src/main/java/ucar/nc2/stream/NcStream.java
+++ b/cdm/core/src/main/java/ucar/nc2/stream/NcStream.java
@@ -474,8 +474,6 @@ public class NcStream {
 
     if (dtUse == DataType.STRING) {
       int lenp = attp.getSdataCount();
-      if (lenp != len)
-        System.out.println("HEY lenp != len");
       if (lenp == 1)
         return new Attribute(attp.getName(), attp.getSdata(0));
       else {

--- a/cdm/core/src/test/java/ucar/ma2/TestString.java
+++ b/cdm/core/src/test/java/ucar/ma2/TestString.java
@@ -67,7 +67,7 @@ public class TestString extends TestCase {
 
     // write
     ima.set0(0);
-    A.setString(ima, "hey");
+    A.setString(ima, "hiy");
     ima.set0(1);
     A.setString(ima, "there");
     ima.set0(2);
@@ -77,7 +77,7 @@ public class TestString extends TestCase {
 
     // read
     ima.set0(0);
-    assert (A.getString(ima).equals("hey"));
+    assert (A.getString(ima).equals("hiy"));
     ima.set0(1);
     assert (A.getString(ima).equals("the"));
     ima.set0(2);

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Iosp.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Iosp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2011-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -11,7 +11,6 @@ import ucar.nc2.grib.*;
 import ucar.nc2.grib.grib2.table.Grib2Tables;
 import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.io.http.HTTPRandomAccessFile;
-import ucar.unidata.util.StringUtil2;
 import java.io.IOException;
 import java.util.Formatter;
 
@@ -43,7 +42,7 @@ public class Grib2Iosp extends GribIosp {
 
       } else if (useGenType && vindex.getGenProcessType() >= 0) {
         String genType = cust.getGeneratingProcessTypeName(vindex.getGenProcessType());
-        String s = StringUtil2.substitute(genType, " ", "_");
+        String s = genType.replace(" ", "_");
         f.format("_%s", s);
       }
 
@@ -76,10 +75,14 @@ public class Grib2Iosp extends GribIosp {
       if (vindex.getEnsDerivedType() >= 0) {
         f.format("_%s", cust.getProbabilityNameShort(vindex.getEnsDerivedType()));
       } else if (vindex.getProbabilityName() != null && !vindex.getProbabilityName().isEmpty()) {
-        String s = StringUtil2.substitute(vindex.getProbabilityName(), ".", "p");
+        String s = vindex.getProbabilityName().replace(".", "p");
         f.format("_probability_%s", s);
       } else if (vindex.isEnsemble()) {
         f.format("_ens");
+      }
+
+      if (vindex.getPercentileValue() >= 0) {
+        f.format("_Percentile%2d", vindex.getPercentileValue());
       }
       return f.toString();
     }
@@ -135,6 +138,10 @@ public class Grib2Iosp extends GribIosp {
 
       } else if (useGenType && vindex.getGenProcessType() >= 0) {
         f.format(" %s", cust.getGeneratingProcessTypeName(vindex.getGenProcessType()));
+      }
+
+      if (vindex.getPercentileValue() >= 0) {
+        f.format(" %d Percentile", vindex.getPercentileValue());
       }
 
       if (vindex.getLevelType() != GribNumbers.UNDEFINED) { // satellite data doesnt have a level

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCdmIndex.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCdmIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2013-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -40,23 +40,20 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Utilities for creating GRIB CDM index (ncx) files, both collections and partitions
- *
- * @author John
- * @since 12/5/13
+ * Utilities for creating GRIB CDM index (ncx) files, both collections and partitions.
+ * Can be used as a standalone program.
+ * TODO review - is this working?
  */
 public class GribCdmIndex implements IndexReader {
   public enum GribCollectionType {
     GRIB1, GRIB2, Partition1, Partition2, none
   }
 
-  public static final String NCX_SUFFIX = ".ncx4"; // LOOK this will have to be generalized, so different collections
-                                                   // (GRIB, BUFR, FMRC can use different suffix)
+  // LOOK this will have to be generalized, so different collections (GRIB, BUFR, FMRC can use different suffix)
+  public static final String NCX_SUFFIX = ".ncx4";
 
   private static final Logger classLogger = LoggerFactory.getLogger(GribCdmIndex.class);
 
-
-  /////////////////////////////////////////////////////////////////////////////
 
   // object cache for ncx files - these are opened only as GribCollection
   public static FileCacheIF gribCollectionCache;
@@ -287,7 +284,7 @@ public class GribCdmIndex implements IndexReader {
 
     boolean changed = updatePartition(isGrib1, dcm, updateType, logger, errlog);
     if (errlog != null)
-      errlog.format("PartitionCollection {} was recreated{}", dcm.getCollectionName(), changed);
+      errlog.format("PartitionCollection %s was recreated %s%n", dcm.getCollectionName(), changed);
     return changed;
   }
 
@@ -818,10 +815,8 @@ public class GribCdmIndex implements IndexReader {
     MCollection dcm = new CollectionSingleFile(mfile, logger);
     dcm.putAuxInfo(FeatureCollectionConfig.AUX_CONFIG, config);
     if (isGrib1) {
-      Grib1CollectionBuilder builder = new Grib1CollectionBuilder(dcm.getCollectionName(), dcm, logger); // LOOK
-                                                                                                         // ignoring
-                                                                                                         // partition
-                                                                                                         // type
+      // LOOK ignoring partition type
+      Grib1CollectionBuilder builder = new Grib1CollectionBuilder(dcm.getCollectionName(), dcm, logger);
       boolean changed =
           (builder.updateNeeded(updateType) && builder.createIndex(FeatureCollectionConfig.PartitionType.file, errlog));
     } else {
@@ -974,57 +969,6 @@ public class GribCdmIndex implements IndexReader {
       logger.error("Error reading index " + indexRaf.getLocation(), t);
       return false;
     }
-  }
-
-
-  public static void main2(String[] args) throws IOException {
-    org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger("test");
-    PartitionManager partition = new PartitionManagerFromIndexDirectory("NCDC-gfs4_all", new FeatureCollectionConfig(),
-        new File("B:/ncdc/gfs4_all/"), NCX_SUFFIX, logger);
-    Grib1PartitionBuilder builder =
-        new Grib1PartitionBuilder("NCDC-gfs4_all", new File(partition.getRoot()), partition, logger);
-    builder.createPartitionedIndex(CollectionUpdateType.nocheck, new Formatter());
-  }
-
-  public static void main3(String[] args) throws IOException {
-    org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger("test");
-
-    /*
-     * <featureCollection name="DGEX-CONUS_12km" featureType="GRIB" harvest="true" path="grib/NCEP/DGEX/CONUS_12km">
-     * <collection spec="F:/data/grib/idd/dgex/  /.*grib2$"
-     * dateFormatMark="#DGEX_CONUS_12km_#yyyyMMdd_HHmm"
-     * timePartition="directory"
-     * olderThan="5 min"/>
-     */
-
-    // String name, String path, FeatureCollectionType fcType, String spec, String dateFormatMark, String olderThan,
-    // String timePartition, String useIndexOnlyS, Element innerNcml
-    // FeatureCollectionConfig config = new FeatureCollectionConfig("DGEX-test", "grib/NCEP/DGEX/CONUS_12km",
-    // FeatureCollectionType.GRIB2,
-    // "Q:/cdmUnitTest/gribCollections/dgex/**/.*grib2$", "#DGEX_CONUS_12km_#yyyyMMdd_HHmm", null, "directory", null,
-    // null);
-
-    // FeatureCollectionConfig config = new FeatureCollectionConfig("GFS_CONUS_80km", "grib/NCEP/GFS/CONUS_80km",
-    // FeatureCollectionType.GRIB1,
-    // "Q:/cdmUnitTest/ncss/GFS/CONUS_80km/GFS_CONUS_80km_#yyyyMMdd_HHmm#.grib1", null, null, "file", null, null);
-
-    // FeatureCollectionConfig config = new FeatureCollectionConfig("ds083.2_Aggregation", "ds083.2/Aggregation",
-    // FeatureCollectionType.GRIB1,
-    // "Q:/cdmUnitTest/gribCollections/rdavm/ds083.2/grib1/**/.*grib1", "#fnl_#yyyyMMdd_HH_mm", null, "directory", null,
-    // null);
-    /*
-     * <pdsHash>
-     * <useTableVersion>false</useTableVersion>
-     * </pdsHash>
-     */
-
-    FeatureCollectionConfig config = new FeatureCollectionConfig("RFC", "grib/NPVU/RFC", FeatureCollectionType.GRIB1,
-        "B:/motherlode/rfc/**/.*grib1$", null, "yyyyMMdd#.grib1#", null, "directory", null);
-
-    // config.gribConfig.pdsHash.put("useTableVersion", false);
-
-    // boolean isGrib1, MCollection dcm, CollectionUpdateType updateType, Formatter errlog, org.slf4j.Logger logger
-    boolean changed = GribCdmIndex.updateGribCollection(config, CollectionUpdateType.test, logger);
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionImmutable.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionImmutable.java
@@ -653,7 +653,7 @@ public abstract class GribCollectionImmutable implements Closeable, FileCacheabl
       return sa;
     }
 
-    public int getNRecords() {
+    public int countNRecords() {
       return sa == null ? -1 : sa.countNotMissing();
     }
 
@@ -691,6 +691,10 @@ public abstract class GribCollectionImmutable implements Closeable, FileCacheabl
 
     public int getProbType() {
       return info.probType;
+    }
+
+    public int getPercentileValue() {
+      return info.percentile;
     }
 
     public String getIntvName() {
@@ -738,7 +742,6 @@ public abstract class GribCollectionImmutable implements Closeable, FileCacheabl
       }
       return size;
     }
-
 
     @Override
     public String toString() {
@@ -817,7 +820,7 @@ public abstract class GribCollectionImmutable implements Closeable, FileCacheabl
       final int discipline; // grib2 only
 
       // derived from pds
-      final int category, parameter, levelType, intvType, ensDerivedType, probType;
+      final int category, parameter, levelType, intvType, ensDerivedType, probType, percentile;
       @Nullable
       final String intvName; // eg "mixed intervals, 3 Hour, etc"
       final String probabilityName;
@@ -840,6 +843,7 @@ public abstract class GribCollectionImmutable implements Closeable, FileCacheabl
         this.isEnsemble = gcVar.isEnsemble;
         this.genProcessType = gcVar.genProcessType;
         this.spatialStatType = gcVar.spatialStatType;
+        this.percentile = gcVar.percentile;
       }
 
       @Override

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionMutable.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionMutable.java
@@ -426,7 +426,7 @@ public class GribCollectionMutable implements Closeable {
     List<Integer> coordIndex; // indexes into group.coords
 
     // derived from pds
-    public final int category, parameter, levelType, intvType, ensDerivedType, probType;
+    public final int category, parameter, levelType, intvType, ensDerivedType, probType, percentile;
     private String intvName; // eg "mixed intervals, 3 Hour, etc"
     public final String probabilityName;
     public final boolean isLayer, isEnsemble;
@@ -470,6 +470,7 @@ public class GribCollectionMutable implements Closeable {
         this.ensDerivedType = -1;
         this.probType = -1;
         this.probabilityName = null;
+        this.percentile = -1;
 
         this.genProcessType = pds.getGenProcess(); // LOOK process vs process type ??
         this.isEnsemble = pds.isEnsemble();
@@ -508,6 +509,13 @@ public class GribCollectionMutable implements Closeable {
         } else {
           this.probType = -1;
           this.probabilityName = null;
+        }
+
+        if (pds.isPercentile()) {
+          Grib2Pds.PdsPercentile pdsPctl = (Grib2Pds.PdsPercentile) pds;
+          this.percentile = pdsPctl.getPercentileValue();
+        } else {
+          this.percentile = -1;
         }
 
         this.genProcessType = pds.getGenProcessType();
@@ -549,6 +557,7 @@ public class GribCollectionMutable implements Closeable {
       this.genProcessType = other.genProcessType;
       this.spatialStatType = other.spatialStatType;
       this.isEnsemble = other.isEnsemble;
+      this.percentile = other.percentile;
     }
 
     public List<Coordinate> getCoordinates() {

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionMutable.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionMutable.java
@@ -105,9 +105,9 @@ public class GribCollectionMutable implements Closeable {
     this.config = config;
     this.isGrib1 = isGrib1;
     if (config == null)
-      logger.error("HEY GribCollection {} has empty config%n", name);
+      logger.error("GribCollection {} has empty config%n", name);
     if (name == null)
-      logger.error("HEY GribCollection has null name dir={}%n", directory);
+      logger.error("GribCollection has null name dir={}%n", directory);
   }
 
   // for making partition collection

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2.grib.collection;
 
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import ucar.ma2.*;
 import ucar.nc2.*;
@@ -12,6 +13,7 @@ import ucar.nc2.constants.AxisType;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
 import ucar.nc2.constants._Coordinate;
+import ucar.nc2.dataset.VariableDS;
 import ucar.nc2.grib.*;
 import ucar.nc2.grib.collection.GribIosp.Time2Dinfo;
 import ucar.nc2.grib.collection.GribIosp.Time2DinfoType;
@@ -84,22 +86,23 @@ class GribIospBuilder {
     boolean isLatLon = isGrib1 ? hcs.isLatLon() : Grib2Utils.isLatLon(hcs.template, gribCollection.getCenter());
 
     if (isRotatedLatLon) {
-      Variable.Builder hcsV = Variable.builder().setName(grid_mapping).setDataType(DataType.INT);
+      Variable.Builder<?> hcsV = Variable.builder().setName(grid_mapping).setDataType(DataType.INT);
       g.addVariable(hcsV);
       hcsV.setCachedData(Array.factory(DataType.INT, new int[0], new int[] {0}), false);
       for (Parameter p : hcs.proj.getProjectionParameters()) {
         hcsV.addAttribute(new Attribute(p));
       }
+
       horizDims = "rlat rlon";
       g.addDimension(new Dimension("rlat", hcs.ny));
       g.addDimension(new Dimension("rlon", hcs.nx));
-      Variable.Builder rlat = Variable.builder().setName("rlat").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
+      Variable.Builder<?> rlat = Variable.builder().setName("rlat").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
           .setDimensionsByName("rlat");
       g.addVariable(rlat);
       rlat.addAttribute(new Attribute(CF.STANDARD_NAME, CF.GRID_LATITUDE));
       rlat.addAttribute(new Attribute(CDM.UNITS, CDM.RLATLON_UNITS));
       rlat.setCachedData(Array.makeArray(DataType.FLOAT, hcs.ny, hcs.starty, hcs.dy), false);
-      Variable.Builder rlon = Variable.builder().setName("rlon").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
+      Variable.Builder<?> rlon = Variable.builder().setName("rlon").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
           .setDimensionsByName("rlon");
       g.addVariable(rlon);
       rlon.addAttribute(new Attribute(CF.STANDARD_NAME, CF.GRID_LONGITUDE));
@@ -114,7 +117,7 @@ class GribIospBuilder {
 
     } else if (isLatLon) {
       // make horiz coordsys coordinate variable
-      Variable.Builder hcsV = Variable.builder().setName(grid_mapping).setDataType(DataType.INT);
+      Variable.Builder<?> hcsV = Variable.builder().setName(grid_mapping).setDataType(DataType.INT);
       g.addVariable(hcsV);
       hcsV.setCachedData(Array.factory(DataType.INT, new int[0], new int[] {0}), false);
       for (Parameter p : hcs.proj.getProjectionParameters()) {
@@ -125,7 +128,7 @@ class GribIospBuilder {
       g.addDimension(new Dimension("lon", hcs.nx));
       g.addDimension(new Dimension("lat", hcs.ny));
 
-      Variable.Builder lat = Variable.builder().setName("lat").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
+      Variable.Builder<?> lat = Variable.builder().setName("lat").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
           .setDimensionsByName("lat");
       g.addVariable(lat);
       lat.addAttribute(new Attribute(CDM.UNITS, CDM.LAT_UNITS));
@@ -136,7 +139,7 @@ class GribIospBuilder {
         lat.setCachedData(Array.makeArray(DataType.FLOAT, hcs.ny, hcs.starty, hcs.dy), false);
       }
 
-      Variable.Builder lon = Variable.builder().setName("lon").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
+      Variable.Builder<?> lon = Variable.builder().setName("lon").setDataType(DataType.FLOAT).setParentGroupBuilder(g)
           .setDimensionsByName("lon");
       g.addVariable(lon);
       lon.addAttribute(new Attribute(CDM.UNITS, CDM.LON_UNITS));
@@ -144,7 +147,7 @@ class GribIospBuilder {
 
     } else {
       // make horiz coordsys coordinate variable
-      Variable.Builder hcsV = Variable.builder().setName(grid_mapping).setDataType(DataType.INT);
+      Variable.Builder<?> hcsV = Variable.builder().setName(grid_mapping).setDataType(DataType.INT);
       g.addVariable(hcsV);
       hcsV.setCachedData(Array.factory(DataType.INT, new int[0], new int[] {0}), false);
       for (Parameter p : hcs.proj.getProjectionParameters()) {
@@ -155,22 +158,20 @@ class GribIospBuilder {
       g.addDimension(new Dimension("x", hcs.nx));
       g.addDimension(new Dimension("y", hcs.ny));
 
-      Variable.Builder xcv =
+      Variable.Builder<?> xcv =
           Variable.builder().setName("x").setDataType(DataType.FLOAT).setParentGroupBuilder(g).setDimensionsByName("x");
       g.addVariable(xcv);
       xcv.addAttribute(new Attribute(CF.STANDARD_NAME, CF.PROJECTION_X_COORDINATE));
       xcv.addAttribute(new Attribute(CDM.UNITS, "km"));
       xcv.setCachedData(Array.makeArray(DataType.FLOAT, hcs.nx, hcs.startx, hcs.dx), false);
 
-      Variable.Builder ycv =
+      Variable.Builder<?> ycv =
           Variable.builder().setName("y").setDataType(DataType.FLOAT).setParentGroupBuilder(g).setDimensionsByName("y");
       g.addVariable(ycv);
       ycv.addAttribute(new Attribute(CF.STANDARD_NAME, CF.PROJECTION_Y_COORDINATE));
       ycv.addAttribute(new Attribute(CDM.UNITS, "km"));
       ycv.setCachedData(Array.makeArray(DataType.FLOAT, hcs.ny, hcs.starty, hcs.dy), false);
     }
-
-    boolean singleRuntimeWasMade = false;
 
     for (Coordinate coord : group.coords) {
       Coordinate.Type ctype = coord.getType();
@@ -196,7 +197,16 @@ class GribIospBuilder {
           if (gctype.isUniqueTime()) {
             makeUniqueTimeCoordinate2D(g, (CoordinateTime2D) coord);
           } else {
-            makeTimeCoordinate2D(g, (CoordinateTime2D) coord, gctype);
+            CoordinateTime2D time2D = (CoordinateTime2D) coord;
+            if (time2D.isOrthogonal()) {
+              String timeDimName = makeTimeOffsetOrthogonal(g, time2D);
+              makeTimeCoordinate2D(g, time2D, timeDimName);
+            } else if (time2D.isRegular()) {
+              String timeDimName = makeTimeOffsetRegular(g, time2D);
+              makeTimeCoordinate2D(g, time2D, timeDimName);
+            } else {
+              makeTimeCoordinate2D(g, time2D, make2dValidTimeDimensionName(time2D.getName()));
+            }
           }
           break;
       }
@@ -212,11 +222,18 @@ class GribIospBuilder {
           throw new IllegalStateException("No time coordinate = " + vindex);
         }
 
-        String timeDimName =
-            time instanceof CoordinateTime2D ? make2dValidTimeDimensionName(time.getName()) : time.getName();
+        String timeDimName = time.getName();
+        String timeCoordName = time.getName();
 
-        String timeCoordName =
-            time instanceof CoordinateTime2D ? make2dValidTimeCoordName(time.getName()) : time.getName();
+        if (time instanceof CoordinateTime2D) {
+          CoordinateTime2D time2D = (CoordinateTime2D) time;
+          if (!gctype.isUniqueTime() && (time2D.isOrthogonal() || time2D.isRegular())) {
+            timeDimName = makeTimeOffsetName(time.getName());
+          } else {
+            timeDimName = make2dValidTimeDimensionName(time.getName());
+            timeCoordName = make2dValidTimeCoordName(timeDimName); // TODO backport this to version 5
+          }
+        }
 
         boolean isRunScaler = (run != null) && run.getSize() == 1;
 
@@ -245,6 +262,9 @@ class GribIospBuilder {
               dimNames.format("%s %s ", run.getName(), timeDimName);
             }
             coordinateAtt.format("%s %s ", run.getName(), timeCoordName);
+            if (timeDimName != timeCoordName) {
+              coordinateAtt.format("%s ", timeDimName);
+            }
             break;
 
           case Best: // PC: Best time partition [ntimes] (time) reftime is generated in makeTimeAuxReference()
@@ -271,7 +291,7 @@ class GribIospBuilder {
         coordinateAtt.format("%s ", horizDims);
 
         String vname = iosp.makeVariableName(vindex);
-        Variable.Builder v = Variable.builder().setName(vname).setDataType(DataType.FLOAT).setParentGroupBuilder(g)
+        Variable.Builder<?> v = Variable.builder().setName(vname).setDataType(DataType.FLOAT).setParentGroupBuilder(g)
             .setDimensionsByName(dimNames.toString());
         g.addVariable(v);
 
@@ -338,11 +358,10 @@ class GribIospBuilder {
     boolean isScalar = (n == 1); // this is the case of runtime[1]
     String tcName = rtc.getName();
     String dims = isScalar ? null : rtc.getName(); // null means scalar
-    if (!isScalar) {
-      g.addDimension(new Dimension(tcName, n));
-    }
+    g.addDimension(new Dimension(tcName, n));
 
-    Variable.Builder v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
+
+    Variable.Builder<?> v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
         .setDimensionsByName(dims);
     g.addVariable(v);
     v.addAttribute(new Attribute(CDM.UNITS, rtc.getUnit()));
@@ -369,7 +388,7 @@ class GribIospBuilder {
     String timeDimName = make2dValidTimeDimensionName(tcName);
 
     g.addDimension(new Dimension(timeDimName, ntimes));
-    Variable.Builder v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
+    Variable.Builder<?> v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
         .setDimensionsByName(timeDimName);
     g.addVariable(v);
     String units = runtime.getUnit(); // + " since " + runtime.getFirstDate();
@@ -385,7 +404,7 @@ class GribIospBuilder {
       v.setSPobject(new Time2Dinfo(Time2DinfoType.intvU, time2D, null));
       // bounds for intervals
       String bounds_name = timeDimName + "_bounds";
-      Variable.Builder bounds = Variable.builder().setName(bounds_name).setDataType(DataType.DOUBLE)
+      Variable.Builder<?> bounds = Variable.builder().setName(bounds_name).setDataType(DataType.DOUBLE)
           .setParentGroupBuilder(g).setDimensionsByName(timeDimName + " 2");
       g.addVariable(bounds);
       v.addAttribute(new Attribute(CF.BOUNDS, bounds_name));
@@ -398,7 +417,7 @@ class GribIospBuilder {
       // for this case we have to generate a separate reftime, because have to use the same dimension
       String refName = "ref" + tcName;
       if (!g.findVariableLocal(refName).isPresent()) {
-        Variable.Builder vref = Variable.builder().setName(refName).setDataType(DataType.DOUBLE)
+        Variable.Builder<?> vref = Variable.builder().setName(refName).setDataType(DataType.DOUBLE)
             .setParentGroupBuilder(g).setDimensionsByName(timeDimName);
         g.addVariable(vref);
         vref.addAttribute(new Attribute(CF.STANDARD_NAME, CF.TIME_REFERENCE));
@@ -423,24 +442,27 @@ class GribIospBuilder {
   }
 
   private String make2dValidTimeCoordName(String dimName) {
-    return dimName.startsWith("valid") ? dimName : "valid" + dimName;
+    return "valid" + dimName;
+  }
+
+  private String makeTimeOffsetName(String timeName) {
+    return timeName.toLowerCase() + "Offset";
   }
 
   /*
    * non unique time case
    * 3) time(nruns, ntimes) with reftime(nruns)
    */
-  private void makeTimeCoordinate2D(Group.Builder g, CoordinateTime2D time2D, GribCollectionImmutable.Type gctype) {
+  private void makeTimeCoordinate2D(Group.Builder g, CoordinateTime2D time2D, String timeDimName) {
     CoordinateRuntime runtime = time2D.getRuntimeCoordinate();
 
     int ntimes = time2D.getNtimes();
     String tcName = time2D.getName();
-    String timeDimName = make2dValidTimeDimensionName(tcName);
     String dims = runtime.getName() + " " + timeDimName;
     int dimLength = ntimes;
 
-    g.addDimension(new Dimension(timeDimName, dimLength));
-    Variable.Builder v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
+    g.addDimensionIfNotExists(new Dimension(timeDimName, dimLength));
+    Variable.Builder<?> v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
         .setDimensionsByName(dims);
     g.addVariable(v);
     String units = runtime.getUnit(); // + " since " + runtime.getFirstDate();
@@ -459,8 +481,8 @@ class GribIospBuilder {
     } else {
       v.setSPobject(new Time2Dinfo(Time2DinfoType.intv, time2D, null));
       // bounds for intervals
-      String bounds_name = timeDimName + "_bounds";
-      Variable.Builder bounds = Variable.builder().setName(bounds_name).setDataType(DataType.DOUBLE)
+      String bounds_name = tcName + "_bounds";
+      Variable.Builder<?> bounds = Variable.builder().setName(bounds_name).setDataType(DataType.DOUBLE)
           .setParentGroupBuilder(g).setDimensionsByName(dims + " 2");
       g.addVariable(bounds);
       v.addAttribute(new Attribute(CF.BOUNDS, bounds_name));
@@ -637,7 +659,7 @@ class GribIospBuilder {
     String tcName = coordTime.getName();
     String dims = coordTime.getName();
     g.addDimension(new Dimension(tcName, ntimes));
-    Variable.Builder v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
+    Variable.Builder<?> v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
         .setDimensionsByName(dims);
     g.addVariable(v);
     String units = coordTime.getTimeUdUnit();
@@ -663,7 +685,7 @@ class GribIospBuilder {
       return;
     }
     String tcName = "ref" + timeName;
-    Variable.Builder v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
+    Variable.Builder<?> v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
         .setDimensionsByName(timeName);
     g.addVariable(v);
     v.addAttribute(new Attribute(CF.STANDARD_NAME, CF.TIME_REFERENCE));
@@ -681,7 +703,7 @@ class GribIospBuilder {
     String tcName = coordTime.getName();
     String dims = coordTime.getName();
     g.addDimension(new Dimension(tcName, ntimes));
-    Variable.Builder v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
+    Variable.Builder<?> v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
         .setDimensionsByName(dims);
     g.addVariable(v);
     String units = coordTime.getTimeUdUnit();
@@ -701,7 +723,7 @@ class GribIospBuilder {
 
     // bounds
     String bounds_name = tcName + "_bounds";
-    Variable.Builder bounds = Variable.builder().setName(bounds_name).setDataType(DataType.DOUBLE)
+    Variable.Builder<?> bounds = Variable.builder().setName(bounds_name).setDataType(DataType.DOUBLE)
         .setParentGroupBuilder(g).setDimensionsByName(dims + " 2");
     g.addVariable(bounds);
     v.addAttribute(new Attribute(CF.BOUNDS, bounds_name));
@@ -724,7 +746,7 @@ class GribIospBuilder {
     String vcName = vc.getName().toLowerCase();
 
     g.addDimension(new Dimension(vcName, n));
-    Variable.Builder v = Variable.builder().setName(vcName).setDataType(DataType.FLOAT).setParentGroupBuilder(g)
+    Variable.Builder<?> v = Variable.builder().setName(vcName).setDataType(DataType.FLOAT).setParentGroupBuilder(g)
         .setDimensionsByName(vcName);
     g.addVariable(v);
     if (vc.getUnit() != null) {
@@ -752,7 +774,7 @@ class GribIospBuilder {
       }
       v.setCachedData(Array.factory(DataType.FLOAT, new int[] {n}, data), false);
 
-      Variable.Builder bounds = Variable.builder().setName(vcName + "_bounds").setDataType(DataType.FLOAT)
+      Variable.Builder<?> bounds = Variable.builder().setName(vcName + "_bounds").setDataType(DataType.FLOAT)
           .setParentGroupBuilder(g).setDimensionsByName(vcName + " 2");
       g.addVariable(bounds);
       v.addAttribute(new Attribute(CF.BOUNDS, vcName + "_bounds"));
@@ -785,7 +807,7 @@ class GribIospBuilder {
     String ecName = ec.getName().toLowerCase();
     g.addDimension(new Dimension(ecName, n));
 
-    Variable.Builder v = Variable.builder().setName(ecName).setDataType(DataType.INT).setParentGroupBuilder(g)
+    Variable.Builder<?> v = Variable.builder().setName(ecName).setDataType(DataType.INT).setParentGroupBuilder(g)
         .setDimensionsByName(ecName);
     g.addVariable(v);
     v.addAttribute(new Attribute(_Coordinate.AxisType, AxisType.Ensemble.toString()));
@@ -796,5 +818,123 @@ class GribIospBuilder {
       data[count++] = ecc.getEnsMember();
     }
     v.setCachedData(Array.factory(DataType.INT, new int[] {n}, data), false);
+  }
+
+  // orthogonal runtime, offset; both independent
+  private String makeTimeOffsetOrthogonal(Group.Builder g, CoordinateTime2D time2D) {
+    List<?> offsets = time2D.getOffsetsSorted();
+    int n = offsets.size();
+    String toName = makeTimeOffsetName(time2D.getName());
+    g.addDimension(new Dimension(toName, n));
+
+    Variable.Builder<?> v = Variable.builder().setName(toName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
+        .setDimensionsByName(toName);
+    g.addVariable(v);
+    v.addAttribute(new Attribute(_Coordinate.AxisType, AxisType.TimeOffset.toString()));
+    v.addAttribute(new Attribute(CDM.UNITS, time2D.getUnit()));
+    v.addAttribute(new Attribute(CF.STANDARD_NAME, CF.TIME_OFFSET));
+    v.addAttribute(new Attribute(CDM.LONG_NAME, CDM.TIME_OFFSET));
+    v.addAttribute(new Attribute(CDM.UDUNITS, time2D.getTimeUdUnit()));
+    v.addAttribute(new Attribute(_Coordinate.AxisType, AxisType.TimeOffset.toString()));
+
+    double[] midpoints = new double[n];
+    double[] bounds = null;
+    if (time2D.isTimeInterval()) {
+      bounds = new double[2 * n];
+      int count = 0;
+      int countb = 0;
+      for (Object offset : offsets) {
+        TimeCoordIntvValue tinv = (TimeCoordIntvValue) offset;
+        midpoints[count++] = (tinv.getBounds1() + tinv.getBounds2()) / 2.0;
+        bounds[countb++] = tinv.getBounds1();
+        bounds[countb++] = tinv.getBounds2();
+      }
+    } else {
+      int count = 0;
+      for (Object val : offsets) {
+        Integer off = (Integer) val;
+        midpoints[count++] = off; // int ??
+      }
+    }
+    v.setCachedData(Array.factory(DataType.DOUBLE, new int[] {n}, midpoints), false);
+
+    if (time2D.isTimeInterval()) {
+      String boundsName = toName + "_bounds";
+      Variable.Builder<?> coordVarBounds = VariableDS.builder().setName(boundsName).setDataType(DataType.DOUBLE)
+          .setDesc("TimeOffset coord bounds").setParentGroupBuilder(g).setDimensionsByName(toName + " 2")
+          .setCachedData(Array.factory(DataType.DOUBLE, new int[] {n, 2}, bounds), false);
+
+      g.addVariable(coordVarBounds);
+
+      v.addAttribute(new Attribute(CF.BOUNDS, boundsName));
+    }
+
+    return toName;
+  }
+
+  // regular runtime, offset; offset depends on runtime hour from 0z
+  private String makeTimeOffsetRegular(Group.Builder gb, CoordinateTime2D time2D) {
+    List<Object> hourFrom0z = ImmutableList.copyOf(time2D.getRegularHourOffsets());
+    int nhours = hourFrom0z.size();
+    int noffsets = time2D.getNtimes();
+    String toName = makeTimeOffsetName(time2D.getName());
+    gb.addDimension(new Dimension(toName, noffsets));
+    String dimNames = nhours + " " + toName;
+
+    Variable.Builder<?> v = Variable.builder().setName(toName).setDataType(DataType.DOUBLE).setParentGroupBuilder(gb)
+        .setDimensionsByName(dimNames);
+    gb.addVariable(v);
+    v.addAttribute(new Attribute(_Coordinate.AxisType, AxisType.TimeOffset.toString()));
+    v.addAttribute(new Attribute(CDM.UNITS, time2D.getUnit()));
+    v.addAttribute(new Attribute(CF.STANDARD_NAME, CF.TIME_OFFSET));
+    v.addAttribute(new Attribute(CDM.LONG_NAME, CDM.TIME_OFFSET));
+    v.addAttribute(new Attribute(CDM.UDUNITS, time2D.getTimeUdUnit()));
+    v.addAttribute(new Attribute(_Coordinate.AxisType, AxisType.TimeOffset.toString()));
+
+    // Special Coordinates. TODO is there a CF equivalent?
+    v.addAttribute(new Attribute(CDM.RUNTIME_COORDINATE, gb.makeFullName() + time2D.getRuntimeCoordinate().getName()));
+    Attribute.Builder attb =
+        Attribute.builder(CDM.TIME_OFFSET_HOUR).setDataType(DataType.INT).setValues(hourFrom0z, false);
+    v.addAttribute(attb.build());
+
+    // We use a rectangular array; uneven arrays will have NaNs.
+    double[] midpoints = new double[nhours * noffsets];
+    java.util.Arrays.fill(midpoints, Double.NaN);
+    double[] bounds = null;
+    if (time2D.isTimeInterval()) {
+      bounds = new double[2 * nhours * noffsets];
+      java.util.Arrays.fill(bounds, Double.NaN);
+      for (int runidx = 0; runidx < nhours; runidx++) {
+        CoordinateTimeIntv timeCoord = (CoordinateTimeIntv) time2D.getTimeCoordinate(runidx);
+        // uneven number of values for each hour
+        int count = runidx * noffsets;
+        int countb = 2 * runidx * noffsets;
+        for (TimeCoordIntvValue tinv : timeCoord.getTimeIntervals()) {
+          midpoints[count++] = (tinv.getBounds1() + tinv.getBounds2()) / 2.0;
+          bounds[countb++] = tinv.getBounds1();
+          bounds[countb++] = tinv.getBounds2();
+        }
+      }
+    } else {
+      for (int runidx = 0; runidx < nhours; runidx++) {
+        int count = runidx * noffsets;
+        CoordinateTime timeCoord = (CoordinateTime) time2D.getTimeCoordinate(runidx);
+        for (Integer offset : timeCoord.getOffsetSorted()) {
+          midpoints[count++] = offset;
+        }
+      }
+    }
+    v.setCachedData(Array.factory(DataType.DOUBLE, new int[] {nhours, noffsets}, midpoints), false);
+
+    if (time2D.isTimeInterval()) {
+      String boundsName = toName + "_bounds";
+      Variable.Builder<?> coordVarBounds = VariableDS.builder().setName(boundsName).setDataType(DataType.DOUBLE)
+          .setDesc("time offset coord bounds").setParentGroupBuilder(gb).setDimensionsByName(dimNames + " 2");
+      gb.addVariable(coordVarBounds);
+      coordVarBounds.setCachedData(Array.factory(DataType.DOUBLE, new int[] {nhours, noffsets, 2}, bounds), false);
+
+      v.addAttribute(new Attribute(CF.BOUNDS, boundsName));
+    }
+    return toName;
   }
 }

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribPartitionBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribPartitionBuilder.java
@@ -384,7 +384,7 @@ abstract class GribPartitionBuilder {
         CoordinateRuntime runtime2D = t2d.getRuntimeCoordinate();
         CoordinateRuntime runtime = runtimes.get(runtime2D);
         if (runtime == null)
-          logger.warn("HEY assignRuntimeNames failed on {} group {}", t2d.getName(), resultGroup.getId());
+          logger.warn("assignRuntimeNames failed on {} group {}", t2d.getName(), resultGroup.getId());
       } // end debug
 
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribPartitionBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribPartitionBuilder.java
@@ -234,9 +234,10 @@ abstract class GribPartitionBuilder {
         GribCollectionMutable.Dataset ds2dp = gc.getDatasetCanonical(); // the twoD or GC dataset
 
         // date ranges must not overlap in order to use MRUTP
-        if (dateRangeAll == null)
+        if (dateRangeAll == null) {
+          // System.out.printf(" %s = %s%n", gc.name, gc.dateRange);
           dateRangeAll = gc.dateRange;
-        else if (!rangeOverlaps) {
+        } else if (!rangeOverlaps) {
           rangeOverlaps = dateRangeAll.intersects(gc.dateRange);
           dateRangeAll = dateRangeAll.extend(gc.dateRange);
         }

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinatePartitionUnionizer.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinatePartitionUnionizer.java
@@ -89,7 +89,7 @@ public class CoordinatePartitionUnionizer {
           // debug
           CoordinateRuntime runtimeFrom2D = time2D.getRuntimeCoordinate();
           if (!runtimeFrom2D.equals(runtime))
-            logger.warn("HEY CoordinateUnionizer runtimes not equal");
+            logger.warn("CoordinateUnionizer runtimes not equal");
           break;
 
         case ens:
@@ -138,7 +138,7 @@ public class CoordinatePartitionUnionizer {
     if (runtimeBuilder != null)
       unionCoords.add(runtimeBuilder.finish());
     else
-      logger.warn("HEY CoordinateUnionizer missing runtime");
+      logger.warn("CoordinateUnionizer missing runtime");
 
     if (timeBuilder != null)
       unionCoords.add(timeBuilder.finish());
@@ -147,7 +147,7 @@ public class CoordinatePartitionUnionizer {
     else if (time2DBuilder != null)
       unionCoords.add(time2DBuilder.finish());
     else
-      logger.warn("HEY CoordinateUnionizer missing time");
+      logger.warn("CoordinateUnionizer missing time");
 
     if (ensBuilder != null) // ens must come before vert to preserve order
       unionCoords.add(ensBuilder.finish());

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateRuntime.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateRuntime.java
@@ -210,6 +210,11 @@ public class CoordinateRuntime implements Coordinate {
     return result;
   }
 
+  @Override
+  public String toString() {
+    return name;
+  }
+
   ///////////////////////////////////////////////////////
 
   public static class Builder2 extends CoordinateBuilderImpl<Grib2Record> {

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime2D.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime2D.java
@@ -43,9 +43,8 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
   private final int[] offset; // list all offsets from the base/first runtime, length nruns (LOOK can we use
                               // SmartArrayInt ?)
 
-  private final boolean isRegular; // all offsets are the same for each "runtime hour of day"
-  private final boolean isOrthogonal; // all offsets are the same for all runtimes, so 2d time array is (runtime X
-                                      // otime)
+  private final boolean isRegular; // offsets are the same for each "runtime hour of day"
+  private final boolean isOrthogonal; // offsets same for all runtimes, so 2d time array is (runtime X otime)
   private final boolean isTimeInterval;
   private final int nruns;
   private final int ntimes;
@@ -222,6 +221,13 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
   public int getOffset(int runIndex) {
     return offset[runIndex];
+  }
+
+  public Iterable<Integer> getRegularHourOffsets() {
+    if (!isRegular) {
+      return null;
+    }
+    return regTimes.keySet();
   }
 
   @Override
@@ -438,8 +444,8 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
   public CoordinateTimeAbstract getTimeCoordinate(int runIdx) {
     if (isOrthogonal)
-      return factory(otime, getRefDate(runIdx)); // LOOK problem is cant use time.getRefDate(), must use
-                                                 // time2D.getRefDate(runIdx) !!
+      // LOOK problem is cant use time.getRefDate(), must use time2D.getRefDate(runIdx) !!
+      return factory(otime, getRefDate(runIdx));
 
     if (isRegular) {
       CalendarDate ref = getRefDate(runIdx);

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTimeAbstract.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTimeAbstract.java
@@ -96,6 +96,12 @@ public abstract class CoordinateTimeAbstract implements Coordinate {
   public double getOffsetInTimeUnits(CalendarDate start) {
     return timeUnit.getOffset(start, getRefDate());
   }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
   ////////////////////////////////////////
 
   /**

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2DataReader.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2DataReader.java
@@ -790,7 +790,7 @@ public class Grib2DataReader {
       for (int i = 0, j = 0; i < totalNPoints; i++) {
         if (GribNumbers.testBitIsSet(bitmap[i / 8], i % 8)) {
           if (j >= idata.length) {
-            logger.warn("HEY jj2000 data count {} < bitmask count {}, i={}, totalNPoints={}", idata.length, j, i,
+            logger.warn("jj2000 data count {} < bitmask count {}, i={}, totalNPoints={}", idata.length, j, i,
                 totalNPoints);
             break;
           }
@@ -849,7 +849,7 @@ public class Grib2DataReader {
       for (int i = 0, j = 0; i < totalNPoints; i++) {
         if (GribNumbers.testBitIsSet(bitmap[i / 8], i % 8)) {
           if (j >= idata.length) {
-            logger.warn("HEY jj2000 data count {} < bitmask count {}, i={}, totalNPoints={}", idata.length, j, i,
+            logger.warn("jj2000 data count {} < bitmask count {}, i={}, totalNPoints={}", idata.length, j, i,
                 totalNPoints);
             break;
           }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Pds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Pds.java
@@ -240,6 +240,10 @@ public abstract class Grib2Pds {
     return (template >= 30 && template <= 32);
   }
 
+  public boolean isPercentile() {
+    return false;
+  }
+
   /*
    * public int getPerturbationNumber() {
    * return GribNumbers.UNDEFINED;
@@ -269,14 +273,6 @@ public abstract class Grib2Pds {
    *
    * public int getProbabilityType() {
    * return GribNumbers.UNDEFINED;
-   * }
-   *
-   * public boolean isPercentile() {
-   * return false;
-   * }
-   *
-   * public int getPercentileValue() {
-   * return -1;
    * }
    */
 
@@ -1253,11 +1249,7 @@ public abstract class Grib2Pds {
       return true;
     }
 
-    /**
-     * Percentile - from 100 to 0
-     *
-     * @return Percentile
-     */
+    /** Percentile - from 0 to 100 */
     public int getPercentileValue() {
       return getOctet(35);
     }
@@ -1266,9 +1258,7 @@ public abstract class Grib2Pds {
     public int templateLength() {
       return 36;
     }
-
   }
-
 
   /**
    * Product definition template 4.10 -

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2SectionBitMap.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2SectionBitMap.java
@@ -87,7 +87,7 @@ public class Grib2SectionBitMap {
 
     // LOOK: bitMapIndicator=254 == previously defined bitmap
     if (bitMapIndicator == 254)
-      logger.debug("HEY bitMapIndicator=254 previously defined bitmap");
+      logger.debug("bitMapIndicator=254 previously defined bitmap");
 
     if (bitMapIndicator != 0) {
       throw new UnsupportedOperationException(

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Variable.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Variable.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.grib.grib2;
 
 import ucar.nc2.grib.grib2.table.Grib2Tables;
@@ -144,6 +145,15 @@ public class Grib2Variable {
       probType = pdsProb.getProbabilityType();
     }
 
+    if (pds.isPercentile() != pds2.isPercentile())
+      return false;
+    if (pds.isPercentile()) {
+      Grib2Pds.PdsPercentile pdsPctl = (Grib2Pds.PdsPercentile) pds;
+      Grib2Pds.PdsPercentile pdsPctl2 = (Grib2Pds.PdsPercentile) pds2;
+      if (pdsPctl.getPercentileValue() != pdsPctl2.getPercentileValue())
+        return false;
+    }
+
     // if this uses any local tables, then we have to add the center id, and subcenter if present
     if ((pds2.getParameterCategory() > 191) || (pds2.getParameterNumber() > 191) || (pds2.getLevelType1() > 191)
         || (pds2.isTimeInterval() && pds2.getStatisticalProcessType() > 191) || (ensDerivedType > 191)
@@ -163,7 +173,6 @@ public class Grib2Variable {
     if (error != error2)
       return false;
     return !useGenType || (genType == genType2);
-
   }
 
 
@@ -213,6 +222,11 @@ public class Grib2Variable {
       Grib2Pds.PdsProbability pdsProb = (Grib2Pds.PdsProbability) pds;
       probType = pdsProb.getProbabilityType();
       result += result * 31 + pdsProb.getProbabilityHashcode();
+    }
+
+    if (pds.isPercentile()) {
+      Grib2Pds.PdsPercentile pdsPerc = (Grib2Pds.PdsPercentile) pds;
+      result += result * 31 + pdsPerc.getPercentileValue();
     }
 
     // if this uses any local tables, then we have to add the center id, and subcenter if present

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -348,6 +348,9 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
       case 109:
         return new VertCoordType(code, "K m2 kg-1 s-1", null, true); // positive?
 
+      case 111:
+        return new VertCoordType(code, "eta", null, false); // positive?
+
       case 114:
         return new VertCoordType(code, "numeric", null, false);// ??
 

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -40,7 +40,7 @@ import java.util.*;
 @Immutable
 public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Grib2Tables.class);
-  private static Map<Grib2TablesId, Grib2Tables> tables = new HashMap<>();
+  private static final Map<Grib2TablesId, Grib2Tables> tables = new HashMap<>();
   private static Grib2Tables wmoStandardTable;
 
   public static Grib2Tables factory(Grib2Record gr) {
@@ -349,7 +349,7 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
         return new VertCoordType(code, "K m2 kg-1 s-1", null, true); // positive?
 
       case 111:
-        return new VertCoordType(code, "eta", null, false); // positive?
+        return new VertCoordType(code, "eta", null, false);
 
       case 114:
         return new VertCoordType(code, "numeric", null, false);// ??

--- a/opendap/src/main/java/opendap/dap/DConnect2.java
+++ b/opendap/src/main/java/opendap/dap/DConnect2.java
@@ -346,10 +346,12 @@ public class DConnect2 implements Closeable {
   }
 
   public static String captureStream(InputStream is) throws IOException {
+    BufferedInputStream s = new BufferedInputStream(is);
+    byte[] bytes = new byte[4096];
     ByteArrayOutputStream text = new ByteArrayOutputStream();
     int b;
-    while ((b = is.read()) >= 0) {
-      text.write(b);
+    while ((b = s.read(bytes)) >= 0) {
+      text.write(bytes, 0, b);
     }
     return new String(text.toByteArray(), StandardCharsets.UTF_8);
   }

--- a/uibase/src/test/java/ucar/util/memory/memory/MemoryCounterAgent.java
+++ b/uibase/src/test/java/ucar/util/memory/memory/MemoryCounterAgent.java
@@ -221,8 +221,6 @@ public class MemoryCounterAgent {
   }
 
   private static long deepSizeOf3(String name, Object obj, Map visited, Class skipClass, boolean show, int indent) {
-    // if (name.endsWith("firstRecord-this$0-index-elementData"))
-    // System.out.println("HEY");
     long result = internalSizeOf3(name, obj, visited, skipClass, show, indent);
     if (show) {
       for (int i = 0; i < indent; i++)

--- a/uicdm/src/main/java/thredds/ui/monitor/ServletLogTable.java
+++ b/uicdm/src/main/java/thredds/ui/monitor/ServletLogTable.java
@@ -458,7 +458,7 @@ public class ServletLogTable extends JPanel {
       if (log instanceof ServletLogParser.ServletLog) {
         logs.add((ServletLogParser.ServletLog) log);
       } else {
-        System.out.printf("HEY NULL LOG%n");
+        System.out.printf("NULL LOG%n");
       }
     }
   }

--- a/uicdm/src/main/java/ucar/nc2/ui/ReportPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/ReportPanel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2013-2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
 package ucar.nc2.ui;
 
 import thredds.inventory.*;
@@ -8,12 +13,7 @@ import java.awt.*;
 import java.io.*;
 import java.util.*;
 
-/**
- * Superclass for report panels
- *
- * @author caron
- * @since 8/22/13
- */
+/** Superclass for report panels */
 public abstract class ReportPanel extends JPanel {
 
   protected PreferencesExt prefs;
@@ -102,8 +102,8 @@ public abstract class ReportPanel extends JPanel {
       CollectionFiltered filteredCollection = new CollectionFiltered("GribReportPanel", org, new MFileFilter() {
         public boolean accept(MFile mfile) {
           String suffix = mfile.getName();
-          if (suffix.contains(".ncx"))
-            return false;
+          // if (suffix.contains(".ncx")) TODO how to control this??
+          // return false;
           return !suffix.contains(".gbx");
         }
       });

--- a/uicdm/src/main/java/ucar/nc2/ui/ToolsUI.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/ToolsUI.java
@@ -20,6 +20,7 @@ import ucar.nc2.ft.point.PointDatasetImpl;
 import ucar.nc2.ft2.coverage.*;
 import ucar.nc2.grib.GribIndexCache;
 import ucar.nc2.grib.collection.GribCdmIndex;
+import ucar.nc2.internal.ncml.NcmlReader;
 import ucar.nc2.iosp.hdf5.H5iosp;
 import ucar.nc2.jni.netcdf.Nc4Iosp;
 import ucar.nc2.ncml.Aggregation;
@@ -54,11 +55,7 @@ import java.lang.reflect.Proxy;
 import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
 
-/**
- * Netcdf Tools user interface.
- *
- * @author caron
- */
+/** Netcdf Tools user interface. */
 public class ToolsUI extends JPanel {
   private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -71,7 +68,7 @@ public class ToolsUI extends JPanel {
   public static final String GRIDVIEW_FRAME_SIZE = "GridUIWindowSize";
   public static final String GRIDIMAGE_FRAME_SIZE = "GridImageWindowSize";
 
-  private static boolean debugListen;
+  private static boolean debugListen = false;
 
   private static ToolsUI ui;
   private static JFrame frame;
@@ -84,6 +81,7 @@ public class ToolsUI extends JPanel {
   private final JFrame parentFrame; // redundant? will equal static "frame" defined just above
 
   private final FileManager fileChooser;
+  private final FileManager dirChooser;
   private FileManager bufrFileChooser;
 
   private final JTabbedPane tabbedPane;
@@ -110,6 +108,7 @@ public class ToolsUI extends JPanel {
   private BufrCodePanel bufrCodePanel;
   private CdmrFeatureOpPanel cdmremotePanel;
   private CdmIndexOpPanel cdmIndexPanel;
+  private CdmIndexScanOp cdmIndexScanOp;
   private ReportOpPanel cdmIndexReportPanel;
   private CollectionSpecPanel fcPanel;
   private CoordSysPanel coordSysPanel;
@@ -120,7 +119,7 @@ public class ToolsUI extends JPanel {
   private DirectoryPartitionPanel dirPartPanel;
   private FeatureScanOpPanel ftPanel;
   private FmrcPanel fmrcPanel;
-  private GeoGridPanel gridPanel;
+  private GeoGridPanel geoGridPanel;
   private GeotiffPanel geotiffPanel;
   private GribCodePanel gribCodePanel;
   private GribFilesOpPanel gribFilesPanel;
@@ -166,9 +165,10 @@ public class ToolsUI extends JPanel {
     this.mainPrefs = prefs;
     this.parentFrame = parentFrame;
 
-    // FileChooser is shared
+    // FileChoosers are shared
     FileFilter[] filters = {new FileManager.HDF5ExtFilter(), new FileManager.NetcdfExtFilter()};
     fileChooser = new FileManager(parentFrame, null, filters, (PreferencesExt) prefs.node("FileManager"));
+    dirChooser = new FileManager(parentFrame, null, null, (PreferencesExt) prefs.node("FeatureScanFileManager"));
 
     OpPanel.setFileChooser(fileChooser);
 
@@ -235,8 +235,8 @@ public class ToolsUI extends JPanel {
     addListeners(bufrTabPane);
 
     // nested-2 tab - grib
-    // gribTabPane.addTab("CdmIndex", new JLabel("CdmIndex"));
     gribTabPane.addTab("CdmIndex4", new JLabel("CdmIndex4"));
+    gribTabPane.addTab("CdmIndexScan", new JLabel("CdmIndexScan"));
     gribTabPane.addTab("CdmIndexReport", new JLabel("CdmIndexReport"));
     gribTabPane.addTab("GribIndex", new JLabel("GribIndex"));
     gribTabPane.addTab("WMO-COMMON", new JLabel("WMO-COMMON"));
@@ -267,6 +267,7 @@ public class ToolsUI extends JPanel {
     addListeners(hdf5TabPane);
 
     // nested tab - features
+    ftTabPane.addTab("FeatureScan", new JLabel("FeatureScan"));
     ftTabPane.addTab("Grids", new JLabel("Grids"));
     ftTabPane.addTab("Coverages", new JLabel("Coverages"));
     ftTabPane.addTab("SimpleGeometry", new JLabel("SimpleGeometry"));
@@ -441,6 +442,11 @@ public class ToolsUI extends JPanel {
         c = cdmIndexPanel;
         break;
 
+      case "CdmIndexScan":
+        cdmIndexScanOp = new CdmIndexScanOp((PreferencesExt) mainPrefs.node("cdmIndexScan"), dirChooser);
+        c = cdmIndexScanOp;
+        break;
+
       case "CdmIndexReport": {
         PreferencesExt prefs = (PreferencesExt) mainPrefs.node("CdmIndexReport");
         ReportPanel rp = new CdmIndexReportPanel(prefs);
@@ -506,7 +512,7 @@ public class ToolsUI extends JPanel {
         break;
 
       case "FeatureScan":
-        ftPanel = new FeatureScanOpPanel((PreferencesExt) mainPrefs.node("ftPanel"));
+        ftPanel = new FeatureScanOpPanel((PreferencesExt) mainPrefs.node("ftPanel"), dirChooser);
         c = ftPanel;
         break;
 
@@ -516,8 +522,8 @@ public class ToolsUI extends JPanel {
         break;
 
       case "Grids":
-        gridPanel = new GeoGridPanel((PreferencesExt) mainPrefs.node("grid"));
-        c = gridPanel;
+        geoGridPanel = new GeoGridPanel((PreferencesExt) mainPrefs.node("grid"));
+        c = geoGridPanel;
         break;
 
       case "SimpleGeometry":
@@ -671,7 +677,7 @@ public class ToolsUI extends JPanel {
 
     NetcdfFile.setDebugFlags(debugFlags);
     H5iosp.setDebugFlags(debugFlags);
-    ucar.nc2.ncml.NcMLReader.setDebugFlags(debugFlags);
+    NcmlReader.setDebugFlags(debugFlags);
     DODSNetcdfFile.setDebugFlags(debugFlags);
     CdmRemote.setDebugFlags(debugFlags);
     Nc4Iosp.setDebugFlags(debugFlags);
@@ -734,6 +740,9 @@ public class ToolsUI extends JPanel {
     }
     if (cdmIndexPanel != null) {
       cdmIndexPanel.save();
+    }
+    if (cdmIndexScanOp != null) {
+      cdmIndexScanOp.save();
     }
     if (cdmIndexReportPanel != null) {
       cdmIndexReportPanel.save();
@@ -798,8 +807,8 @@ public class ToolsUI extends JPanel {
     if (gribRewritePanel != null) {
       gribRewritePanel.save();
     }
-    if (gridPanel != null) {
-      gridPanel.save();
+    if (geoGridPanel != null) {
+      geoGridPanel.save();
     }
     if (hdf5ObjectPanel != null) {
       hdf5ObjectPanel.save();
@@ -1013,9 +1022,9 @@ public class ToolsUI extends JPanel {
 
   public void openGridDataset(String datasetName) {
     makeComponent(ftTabPane, "Grids");
-    gridPanel.doit(datasetName);
+    geoGridPanel.doit(datasetName);
     tabbedPane.setSelectedComponent(ftTabPane);
-    ftTabPane.setSelectedComponent(gridPanel);
+    ftTabPane.setSelectedComponent(geoGridPanel);
   }
 
 
@@ -1029,17 +1038,17 @@ public class ToolsUI extends JPanel {
 
   public void openGridDataset(NetcdfDataset dataset) {
     makeComponent(ftTabPane, "Grids");
-    gridPanel.setDataset(dataset);
+    geoGridPanel.setDataset(dataset);
     tabbedPane.setSelectedComponent(ftTabPane);
-    ftTabPane.setSelectedComponent(gridPanel);
+    ftTabPane.setSelectedComponent(geoGridPanel);
   }
 
 
   public void openGridDataset(GridDataset dataset) {
     makeComponent(ftTabPane, "Grids");
-    gridPanel.setDataset(dataset);
+    geoGridPanel.setDataset(dataset);
     tabbedPane.setSelectedComponent(ftTabPane);
-    ftTabPane.setSelectedComponent(gridPanel);
+    ftTabPane.setSelectedComponent(geoGridPanel);
   }
 
 
@@ -1056,6 +1065,14 @@ public class ToolsUI extends JPanel {
     wmsPanel.doit(datasetName);
     tabbedPane.setSelectedComponent(ftTabPane);
     ftTabPane.setSelectedComponent(wmsPanel);
+  }
+
+  public void openIndexFile(String datasetName) {
+    makeComponent(ftTabPane, "WMS");
+    cdmIndexPanel.doit(datasetName);
+    tabbedPane.setSelectedComponent(iospTabPane);
+    iospTabPane.setSelectedComponent(gribTabPane);
+    gribTabPane.setSelectedComponent(cdmIndexPanel);
   }
 
   /**
@@ -1078,7 +1095,8 @@ public class ToolsUI extends JPanel {
 
       if (wantsCoordSys) {
         NetcdfDataset ncd = threddsDataFactory.openDataset(invDataset, true, null, null);
-        ncd.enhance(); // make sure its enhanced
+        // make sure its enhanced
+        ncd = NetcdfDatasets.enhance(ncd, NetcdfDataset.getDefaultEnhanceMode(), null);
         openCoordSystems(ncd);
         return;
       }
@@ -1169,9 +1187,9 @@ public class ToolsUI extends JPanel {
         ftTabPane.setSelectedComponent(coveragePanel);
       } else if (threddsData.featureDataset instanceof GridDataset) {
         makeComponent(ftTabPane, "Grids");
-        gridPanel.setDataset((GridDataset) threddsData.featureDataset);
+        geoGridPanel.setDataset((GridDataset) threddsData.featureDataset);
         tabbedPane.setSelectedComponent(ftTabPane);
-        ftTabPane.setSelectedComponent(gridPanel);
+        ftTabPane.setSelectedComponent(geoGridPanel);
       }
     } else if (threddsData.featureType == FeatureType.IMAGE) {
       makeComponent(ftTabPane, "Images");
@@ -1220,15 +1238,20 @@ public class ToolsUI extends JPanel {
       if ((null == message) && (ioe instanceof EOFException)) {
         message = "Premature End of File";
       }
-      JOptionPane.showMessageDialog(null, "NetcdfDatasets.open cannot open " + location + "%n" + message);
+      JOptionPane.showMessageDialog(null, "NetcdfDatasets.open cannot open " + location + "\n" + message);
       if (!(ioe instanceof FileNotFoundException)) {
         ioe.printStackTrace();
       }
       ncfile = null;
     } catch (Exception e) {
-      JOptionPane.showMessageDialog(null, "NetcdfDatasets.open cannot open " + location + "%n" + e.getMessage());
+      StringWriter sw = new StringWriter(5000);
+      if (e.getCause() != null) {
+        e.getCause().printStackTrace(new PrintWriter(sw));
+      } else {
+        e.printStackTrace(new PrintWriter(sw));
+      }
+      JOptionPane.showMessageDialog(null, "NetcdfDatasets.open cannot open " + location + "\n" + sw.toString());
       log.error("NetcdfDatasets.open cannot open " + location, e);
-      e.printStackTrace();
 
       try {
         if (ncfile != null) {
@@ -1304,9 +1327,13 @@ public class ToolsUI extends JPanel {
     }
 
     done = true; // on some systems, still get a window close event
-    ucar.nc2.util.cache.FileCacheIF cache = NetcdfDataset.getNetcdfFileCache();
-    if (cache != null) {
-      cache.clearCache(true);
+    ucar.nc2.util.cache.FileCacheIF cache1 = NetcdfDataset.getNetcdfFileCache();
+    ucar.nc2.util.cache.FileCacheIF cache2 = NetcdfDatasets.getNetcdfFileCache();
+    if (cache1 != null) {
+      cache1.clearCache(true);
+    }
+    if (cache2 != null) {
+      cache2.clearCache(true);
     }
     FileCache.shutdown(); // shutdown threads
     DiskCache2.exit(); // shutdown threads
@@ -1504,7 +1531,6 @@ public class ToolsUI extends JPanel {
       if (f.exists()) {
         try (FileInputStream fis = new FileInputStream(filename)) {
           StringBuilder errlog = new StringBuilder();
-          RuntimeConfigParser.read(fis, errlog);
           System.out.println(errlog);
         } catch (IOException ioe) {
           log.warn("Error reading {} = {}", filename, ioe.getMessage());

--- a/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexPanel.java
@@ -23,6 +23,7 @@ import ucar.nc2.grib.coord.TimeCoordIntvValue;
 import ucar.nc2.grib.coord.VertCoordValue;
 import ucar.nc2.time.*;
 import ucar.nc2.ui.MFileTable;
+import ucar.nc2.util.Counters;
 import ucar.ui.widget.BAMutil;
 import ucar.ui.widget.IndependentWindow;
 import ucar.ui.widget.PopupMenu;
@@ -31,19 +32,15 @@ import ucar.nc2.util.Indent;
 import ucar.util.prefs.PreferencesExt;
 import ucar.ui.prefs.BeanTable;
 import javax.swing.*;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.List;
 
-/** Show info in GRIB ncx index files */
+/** Show info in GRIB ncx index files. */
 public class CdmIndexPanel extends JPanel {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CdmIndexPanel.class);
 
@@ -101,10 +98,8 @@ public class CdmIndexPanel extends JPanel {
     }
 
     PopupMenu varPopup;
-
     groupTable = new BeanTable<>(GroupBean.class, (PreferencesExt) prefs.node("GroupBean"), false, "GDS group",
         "GribCollectionImmutable.GroupHcs", null);
-
     groupTable.addListSelectionListener(e -> {
       GroupBean bean = groupTable.getSelectedBean();
       if (bean != null)
@@ -245,11 +240,11 @@ public class CdmIndexPanel extends JPanel {
 
     varPopup.addAction("Compare", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        List<CoordBean> beans = coordTable.getSelectedBeans();
+        List beans = coordTable.getSelectedBeans();
         if (beans.size() == 2) {
           Formatter f = new Formatter();
-          CoordBean bean1 = beans.get(0);
-          CoordBean bean2 = beans.get(1);
+          CoordBean bean1 = (CoordBean) beans.get(0);
+          CoordBean bean2 = (CoordBean) beans.get(1);
           if (bean1.coord.getType() == Coordinate.Type.time2D && bean2.coord.getType() == Coordinate.Type.time2D)
             compareCoords2D(f, (CoordinateTime2D) bean1.coord, (CoordinateTime2D) bean2.coord);
           else
@@ -346,7 +341,7 @@ public class CdmIndexPanel extends JPanel {
     f.format("Groups%n");
     List<GroupBean> groups = groupTable.getBeans();
     for (GroupBean bean : groups) {
-      f.format("%-50s %-50s %d%n", bean.getGroupId(), bean.getDescription(), bean.getGdsHash());
+      f.format("%-50s %d%n", bean.getGroupId(), bean.getGdsHash());
       bean.group.show(f);
     }
 
@@ -923,10 +918,6 @@ public class CdmIndexPanel extends JPanel {
       return group.getVariables().size();
     }
 
-    public String getDescription() {
-      return group.getDescription();
-    }
-
     public int getNmissing() {
       return nmissing;
     }
@@ -942,7 +933,7 @@ public class CdmIndexPanel extends JPanel {
     int idx;
     double start, end, resol;
     Comparable resolMode;
-    ucar.nc2.util.Counters counters;
+    Counters counters;
 
     // no-arg constructor
 
@@ -1140,24 +1131,6 @@ public class CdmIndexPanel extends JPanel {
       this.group = group;
       this.name = vindex.makeVariableName();
     }
-
-    /*
-     * public int getNRecords() {
-     * return v.nrecords;
-     * }
-     * 
-     * public int getNMissing() {
-     * return v.missing;
-     * }
-     * 
-     * public int getNDups() {
-     * return v.ndups;
-     * }
-     * 
-     * public float getDensity() {
-     * return v.density;
-     * }
-     */
 
     public String getIndexes() {
       Formatter f = new Formatter();

--- a/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexPanel.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.ui.grib;
 
 import thredds.featurecollection.FeatureCollectionConfig;
@@ -42,17 +43,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.List;
 
-/**
- * Show info in GRIB ncx index files.
- *
- * @author John
- * @since 12/5/13
- */
+/** Show info in GRIB ncx index files */
 public class CdmIndexPanel extends JPanel {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CdmIndexPanel.class);
 
   private PreferencesExt prefs;
-  private BeanTable groupTable, varTable, coordTable;
+  private BeanTable<GroupBean> groupTable;
+  private BeanTable<VarBean> varTable;
+  private BeanTable<CoordBean> coordTable;
   private JSplitPane split, split2, split3;
 
   private TextHistoryPane infoTA, extraTA;
@@ -90,7 +88,6 @@ public class CdmIndexPanel extends JPanel {
       });
       buttPanel.add(rawButton);
 
-
       AbstractButton checkAllButton = BAMutil.makeButtcon("Select", "Check entire file", false);
       rawButton.addActionListener(e -> {
         Formatter f = new Formatter();
@@ -103,25 +100,21 @@ public class CdmIndexPanel extends JPanel {
 
     }
 
-    ////////////////////////////
-
     PopupMenu varPopup;
 
-    ////////////////
-    groupTable = new BeanTable(GroupBean.class, (PreferencesExt) prefs.node("GroupBean"), false, "GDS group",
+    groupTable = new BeanTable<>(GroupBean.class, (PreferencesExt) prefs.node("GroupBean"), false, "GDS group",
         "GribCollectionImmutable.GroupHcs", null);
-    groupTable.addListSelectionListener(new ListSelectionListener() {
-      public void valueChanged(ListSelectionEvent e) {
-        GroupBean bean = (GroupBean) groupTable.getSelectedBean();
-        if (bean != null)
-          setGroup(bean);
-      }
+
+    groupTable.addListSelectionListener(e -> {
+      GroupBean bean = groupTable.getSelectedBean();
+      if (bean != null)
+        setGroup(bean);
     });
 
     varPopup = new PopupMenu(groupTable.getJTable(), "Options");
     varPopup.addAction("Show Group Info", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        GroupBean bean = (GroupBean) groupTable.getSelectedBean();
+        GroupBean bean = groupTable.getSelectedBean();
         if (bean != null && bean.group != null) {
           Formatter f = new Formatter();
           bean.group.show(f);
@@ -133,14 +126,14 @@ public class CdmIndexPanel extends JPanel {
     });
     varPopup.addAction("Show Files Used", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        GroupBean bean = (GroupBean) groupTable.getSelectedBean();
+        GroupBean bean = groupTable.getSelectedBean();
         if (bean != null && bean.group != null) {
           showFileTable(gc, bean.group);
         }
       }
     });
 
-    varTable = new BeanTable(VarBean.class, (PreferencesExt) prefs.node("Grib2Bean"), false, "Variables in group",
+    varTable = new BeanTable<>(VarBean.class, (PreferencesExt) prefs.node("Grib2Bean"), false, "Variables in group",
         "GribCollectionImmutable.VariableIndex", null);
 
     varPopup = new PopupMenu(varTable.getJTable(), "Options");
@@ -156,7 +149,7 @@ public class CdmIndexPanel extends JPanel {
     });
     varPopup.addAction("Show Sparse Array", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        VarBean bean = (VarBean) varTable.getSelectedBean();
+        VarBean bean = varTable.getSelectedBean();
         if (bean != null) {
           Formatter f = new Formatter();
           bean.showSparseArray(f);
@@ -180,13 +173,13 @@ public class CdmIndexPanel extends JPanel {
     });
 
 
-    coordTable = new BeanTable(CoordBean.class, (PreferencesExt) prefs.node("CoordBean"), false, "Coordinates in group",
-        "Coordinates", null);
+    coordTable = new BeanTable<>(CoordBean.class, (PreferencesExt) prefs.node("CoordBean"), false,
+        "Coordinates in group", "Coordinates", null);
     varPopup = new PopupMenu(coordTable.getJTable(), "Options");
 
     varPopup.addAction("Show", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        CoordBean bean = (CoordBean) coordTable.getSelectedBean();
+        CoordBean bean = coordTable.getSelectedBean();
         if (bean != null) {
           Formatter f = new Formatter();
           bean.coord.showCoords(f);
@@ -199,7 +192,7 @@ public class CdmIndexPanel extends JPanel {
 
     varPopup.addAction("ShowCompact", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        CoordBean bean = (CoordBean) coordTable.getSelectedBean();
+        CoordBean bean = coordTable.getSelectedBean();
         if (bean != null) {
           Formatter f = new Formatter();
           bean.coord.showInfo(f, new Indent(2));
@@ -212,7 +205,7 @@ public class CdmIndexPanel extends JPanel {
 
     varPopup.addAction("Test Time2D isOrthogonal", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        CoordBean bean = (CoordBean) coordTable.getSelectedBean();
+        CoordBean bean = coordTable.getSelectedBean();
         if (bean != null) {
           Formatter f = new Formatter();
           testOrthogonal(f, bean.coord);
@@ -225,7 +218,7 @@ public class CdmIndexPanel extends JPanel {
 
     varPopup.addAction("Test Time2D isRegular", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        CoordBean bean = (CoordBean) coordTable.getSelectedBean();
+        CoordBean bean = coordTable.getSelectedBean();
         if (bean != null) {
           Formatter f = new Formatter();
           testRegular(f, bean.coord);
@@ -239,7 +232,7 @@ public class CdmIndexPanel extends JPanel {
 
     varPopup.addAction("Show Resolution distribution", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        CoordBean bean = (CoordBean) coordTable.getSelectedBean();
+        CoordBean bean = coordTable.getSelectedBean();
         if (bean != null) {
           Formatter f = new Formatter();
           bean.showResolution(f);
@@ -252,11 +245,11 @@ public class CdmIndexPanel extends JPanel {
 
     varPopup.addAction("Compare", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        List beans = coordTable.getSelectedBeans();
+        List<CoordBean> beans = coordTable.getSelectedBeans();
         if (beans.size() == 2) {
           Formatter f = new Formatter();
-          CoordBean bean1 = (CoordBean) beans.get(0);
-          CoordBean bean2 = (CoordBean) beans.get(1);
+          CoordBean bean1 = beans.get(0);
+          CoordBean bean2 = beans.get(1);
           if (bean1.coord.getType() == Coordinate.Type.time2D && bean2.coord.getType() == Coordinate.Type.time2D)
             compareCoords2D(f, (CoordinateTime2D) bean1.coord, (CoordinateTime2D) bean2.coord);
           else
@@ -270,11 +263,11 @@ public class CdmIndexPanel extends JPanel {
 
     varPopup.addAction("Try to Merge", new AbstractAction() {
       public void actionPerformed(ActionEvent e) {
-        List beans = coordTable.getSelectedBeans();
+        List<CoordBean> beans = coordTable.getSelectedBeans();
         if (beans.size() == 2) {
           Formatter f = new Formatter();
-          CoordBean bean1 = (CoordBean) beans.get(0);
-          CoordBean bean2 = (CoordBean) beans.get(1);
+          CoordBean bean1 = beans.get(0);
+          CoordBean bean2 = beans.get(1);
           if (bean1.coord.getType() == Coordinate.Type.time2D && bean2.coord.getType() == Coordinate.Type.time2D)
             mergeCoords2D(f, (CoordinateTime2D) bean1.coord, (CoordinateTime2D) bean2.coord);
           else
@@ -288,12 +281,8 @@ public class CdmIndexPanel extends JPanel {
 
     // file popup window
     fileTable = new MFileTable((PreferencesExt) prefs.node("MFileTable"), true);
-    fileTable.addPropertyChangeListener(new PropertyChangeListener() {
-      @Override
-      public void propertyChange(PropertyChangeEvent evt) {
-        firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
-      }
-    });
+    fileTable.addPropertyChangeListener(
+        evt -> firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue()));
 
     /////////////////////////////////////////
     // the info windows
@@ -385,7 +374,6 @@ public class CdmIndexPanel extends JPanel {
     }
   }
 
-
   private void checkAll(Formatter f) {
     if (gc == null)
       return;
@@ -435,8 +423,7 @@ public class CdmIndexPanel extends JPanel {
         }
       }
       int noSA = bytesTotal - bytesSATotal;
-      f.format("%n total KBytes=%d kbSATotal=%d kbNoSA=%d coordsAllTotal=%d%n", bytesTotal / 1000, bytesSATotal / 1000,
-          noSA / 1000, coordsAllTotal / 1000);
+      f.format("%n total KBytes=%d kbSATotal=%d kbNoSA=%d%n", bytesTotal / 1000, bytesSATotal / 1000, noSA / 1000);
       f.format("%n");
     }
   }

--- a/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexReportPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexReportPanel.java
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2014-2018 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.ui.grib;
 
-import com.google.common.base.MoreObjects;
 import thredds.featurecollection.FeatureCollectionConfig;
 import thredds.inventory.*;
 import ucar.nc2.grib.coord.SparseArray;
@@ -17,12 +16,7 @@ import ucar.util.prefs.PreferencesExt;
 import java.io.*;
 import java.util.*;
 
-/**
- * Run through GRIB ncx indices and make reports
- *
- * @author caron
- * @since 5/15/2014
- */
+/** Run through GRIB ncx indices and make reports */
 public class CdmIndexReportPanel extends ReportPanel {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Grib2ReportPanel.class);
 
@@ -67,8 +61,12 @@ public class CdmIndexReportPanel extends ReportPanel {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this).add("nrecords", nrecords).add("ndups", ndups).add("nmissing", nmissing)
-          .toString();
+      Formatter f = new Formatter();
+      f.format("Accum{nrecords=%d, ", nrecords);
+      double fn = (float) nrecords / 100.0;
+      f.format("ndups=%d (%3.1f %%), ", ndups, ndups / fn);
+      f.format("nmissing=%d (%3.1f %%)}", nmissing, nmissing / fn);
+      return f.toString();
     }
   }
 
@@ -79,7 +77,7 @@ public class CdmIndexReportPanel extends ReportPanel {
         doDupAndMissingEach(f, iter.next(), eachFile, extra, total);
       }
     }
-    f.format("total %s%n", total);
+    f.format("%n Grand Total %s%n", total);
   }
 
   // seperate report for each file in collection
@@ -113,7 +111,7 @@ public class CdmIndexReportPanel extends ReportPanel {
             accum.add(v);
           }
           if (each) {
-            f.format("total %s%n", groupAccum);
+            f.format(" total %s%n", groupAccum);
           }
         }
       }

--- a/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexReportPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexReportPanel.java
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2018 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.ui.grib;
 
 import thredds.featurecollection.FeatureCollectionConfig;
@@ -256,7 +257,7 @@ public class CdmIndexReportPanel extends ReportPanel {
 
           for (GribCollectionImmutable.VariableIndex vi : g.getVariables()) {
             String name = vi.makeVariableName(); // LOOK not actually right - some are partitioned by level
-            int nrecords = vi.getNRecords();
+            int nrecords = vi.countNRecords();
             f.format("  %7d: %s%n", nrecords, name);
             int hash = vi.hashCode() + g.getGdsHash().hashCode(); // must be both group and var
             VarInfo vinfo = varCount.get(hash);
@@ -298,11 +299,12 @@ public class CdmIndexReportPanel extends ReportPanel {
           for (GribCollectionImmutable.VariableIndex vi : g.getVariables()) {
             int hash = vi.hashCode() + g.getGdsHash().hashCode();
             VarInfo vinfo = varCount.get(hash);
-            if (vinfo == null)
+            if (vinfo == null) {
               f.format("ERROR on vi %s%n", vi);
-            else {
-              if (!vinfo.ok)
-                countMisplaced += vi.getNRecords();
+            } else {
+              if (!vinfo.ok) {
+                countMisplaced += vi.countNRecords();
+              }
             }
           }
         }

--- a/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexScan.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/grib/CdmIndexScan.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.ui.grib;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import thredds.featurecollection.FeatureCollectionConfig;
+import ucar.nc2.grib.collection.GribCdmIndex;
+import ucar.nc2.grib.collection.GribCollectionImmutable;
+import ucar.nc2.grib.coord.Coordinate;
+import ucar.nc2.grib.coord.CoordinateTime2D;
+import ucar.ui.prefs.BeanTable;
+import ucar.ui.widget.BAMutil;
+import ucar.ui.widget.IndependentWindow;
+import ucar.ui.widget.PopupMenu;
+import ucar.ui.widget.TextHistoryPane;
+import ucar.util.prefs.PreferencesExt;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.List;
+
+/** Scan for Feature Datasets */
+public class CdmIndexScan extends JPanel {
+  private static final Logger logger = LoggerFactory.getLogger(CdmIndexScan.class);
+
+  private final PreferencesExt prefs;
+
+  private final BeanTable<IndexScanBean> indexBeanTable;
+  private final JSplitPane split;
+  private final TextHistoryPane dumpTA;
+  private final IndependentWindow infoWindow;
+  private boolean subdirs = true;
+
+  public CdmIndexScan(PreferencesExt prefs) {
+    this.prefs = prefs;
+
+    indexBeanTable = new BeanTable<>(IndexScanBean.class, (PreferencesExt) prefs.node("IndexScanBeans"), false);
+    indexBeanTable.addListSelectionListener(e -> setSelectedBean(indexBeanTable.getSelectedBean()));
+
+    ucar.ui.widget.PopupMenu varPopup = new PopupMenu(indexBeanTable.getJTable(), "Options");
+    varPopup.addAction("Open Index File", new AbstractAction() {
+      public void actionPerformed(ActionEvent e) {
+        IndexScanBean ftb = indexBeanTable.getSelectedBean();
+        if (ftb != null) {
+          CdmIndexScan.this.firePropertyChange("openIndexFile", null, ftb.path);
+        }
+      }
+    });
+
+
+    // the info window
+    TextHistoryPane infoTA = new TextHistoryPane();
+    infoWindow = new IndependentWindow("Extra Information", BAMutil.getImage("nj22/NetcdfUI"), infoTA);
+    infoWindow.setBounds((Rectangle) prefs.getBean("InfoWindowBounds", new Rectangle(300, 300, 500, 300)));
+
+    dumpTA = new TextHistoryPane();
+    split = new JSplitPane(JSplitPane.VERTICAL_SPLIT, false, indexBeanTable, dumpTA);
+    split.setDividerLocation(prefs.getInt("splitPos", 500));
+
+    setLayout(new BorderLayout());
+    add(split, BorderLayout.CENTER);
+  }
+
+  public PreferencesExt getPrefs() {
+    return prefs;
+  }
+
+  public void save() {
+    indexBeanTable.saveState(false);
+    prefs.putInt("splitPos", split.getDividerLocation());
+    prefs.putBeanObject("InfoWindowBounds", infoWindow.getBounds());
+  }
+
+  public void clear() {
+    indexBeanTable.setBeans(new ArrayList<>()); // clear
+  }
+
+  public boolean setScanDirectory(String dirName) {
+    clear();
+
+    List<IndexScanBean> beans;
+    try {
+      beans = scan(dirName);
+    } catch (IOException e) {
+      e.printStackTrace();
+      dumpTA.setText(e.getMessage());
+      return false;
+    }
+    if (beans.isEmpty()) {
+      dumpTA.setText("No .ncx4 files were found");
+      return false;
+    }
+
+    indexBeanTable.setBeans(beans);
+    return true;
+  }
+
+  private void setSelectedBean(IndexScanBean ftb) {
+    if (ftb == null) {
+      return;
+    }
+    dumpTA.setText(ftb.toString());
+    dumpTA.gotoTop();
+  }
+
+  public java.util.List<IndexScanBean> scan(String topDir) throws IOException {
+    List<IndexScanBean> result = new ArrayList<>();
+    File topFile = new File(topDir);
+    if (!topFile.exists()) {
+      dumpTA.appendLine(String.format("File %s does not exist", topDir));
+      return result;
+    }
+
+    Formatter info = new Formatter();
+    if (topFile.isDirectory()) {
+      scanDirectory(topFile, result, info);
+    } else {
+      Accum accum = new Accum();
+      openCdmIndex(topFile.getPath(), accum, result, info);
+      info.format("%n%s%n", accum);
+    }
+    dumpTA.setText(info.toString());
+
+    return result;
+  }
+
+  private void scanDirectory(File dir, List<IndexScanBean> result, Formatter info) throws IOException {
+    if ((dir.getName().equals("exclude")) || (dir.getName().equals("problem"))) {
+      return;
+    }
+
+    // get list of files
+    File[] fila = dir.listFiles();
+    if (fila == null) {
+      return;
+    }
+
+    for (File f : fila) {
+      if (!f.isDirectory() && f.getName().endsWith(".ncx4")) {
+        Accum totalAccum = new Accum();
+        openCdmIndex(f.getPath(), totalAccum, result, info);
+        info.format("%n%s%n", totalAccum);
+      }
+    }
+
+    if (subdirs) {
+      for (File f : fila) {
+        if (f.isDirectory() && !f.getName().equals("exclude")) {
+          scanDirectory(f, result, info);
+        }
+      }
+    }
+  }
+
+  private void openCdmIndex(String path, Accum accum, List<IndexScanBean> result, Formatter info) throws IOException {
+
+    info.format("%nFile %s%n", path);
+    FeatureCollectionConfig config = new FeatureCollectionConfig();
+
+    try (GribCollectionImmutable gc = GribCdmIndex.openCdmIndex(path, config, false, logger)) {
+      if (gc == null) {
+        info.format("Not a grib collection index file=%s%n" + path);
+        return;
+      }
+
+      for (GribCollectionImmutable.Dataset ds : gc.getDatasets()) {
+        info.format("%nDataset %s%n", ds.getType());
+        int groupno = 0;
+        for (GribCollectionImmutable.GroupGC g : ds.getGroups()) {
+          if (g.getType() == GribCollectionImmutable.Type.Best) {
+            continue; // Best is deprecated.
+          }
+          Formatter localInfo = new Formatter();
+          localInfo.format("File %s%n", path);
+          Accum groupAccum = new Accum();
+          localInfo.format(" Group %s%n", g.getDescription());
+          for (GribCollectionImmutable.VariableIndex v : g.getVariables()) {
+            localInfo.format("  %s%n", v.toStringFrom());
+            showIfNonZero(info, v, path);
+
+            groupAccum.add(v);
+            accum.add(v);
+          }
+          info.format(" total %s%n", groupAccum);
+          localInfo.format(" total %s%n", groupAccum);
+          result.add(new IndexScanBean(path, ds, g, groupno++, groupAccum, localInfo.toString()));
+        }
+      }
+
+    }
+  }
+
+  String lastFilename;
+
+  void showIfNonZero(Formatter info, GribCollectionImmutable.VariableIndex v, String filename) {
+    if ((v.getNdups() != 0) || (v.getNmissing() != 0)) {
+      if (!filename.equals(lastFilename))
+        info.format(" %s%n  %s%n", filename, v.toStringFrom());
+      else
+        info.format("  %s%n", v.toStringFrom());
+      lastFilename = filename;
+    }
+  }
+
+  private static class Accum {
+    int nrecords, ndups, nmissing;
+
+    Accum add(GribCollectionImmutable.VariableIndex v) {
+      this.nrecords += v.getNrecords();
+      this.ndups += v.getNdups();
+      this.nmissing += (v.getSize() - v.getNrecords());
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      Formatter f = new Formatter();
+      f.format("Accum{nrecords=%d, ", nrecords);
+      double fn = (float) nrecords / 100.0;
+      f.format("ndups=%d (%3.1f %%), ", ndups, ndups / fn);
+      f.format("nmissing=%d (%3.1f %%)}", nmissing, nmissing / fn);
+      return f.toString();
+    }
+  }
+
+  public static class IndexScanBean {
+    public String path;
+    public String name;
+    public Accum accum;
+    public String info;
+    public String time2D;
+    public GribCollectionImmutable.Dataset ds;
+    public int groupno;
+
+    // no-arg constructor
+    public IndexScanBean() {}
+
+    public IndexScanBean(String path, GribCollectionImmutable.Dataset ds, GribCollectionImmutable.GroupGC group,
+        int groupno, Accum accum, String info) {
+      this.path = path;
+      int pos = path.lastIndexOf('/');
+      this.name = ".." + path.substring(pos);
+      this.accum = accum;
+      this.ds = ds;
+      this.groupno = groupno;
+      this.info = info;
+
+      // Show the most complicated type of Time2D coordinate
+      boolean hasTime2D = false;
+      boolean hasOrthogonal = false;
+      boolean hasRegular = false;
+      for (Coordinate coord : group.getCoordinates()) {
+        if (coord.getType() == Coordinate.Type.time2D) {
+          hasTime2D = true;
+          CoordinateTime2D c2d = (CoordinateTime2D) coord;
+          if (c2d.isOrthogonal())
+            hasOrthogonal = true;
+          if (c2d.isRegular())
+            hasRegular = true;
+        }
+      }
+      time2D = hasRegular ? "reg" : hasOrthogonal ? "orth" : hasTime2D ? "time2D" : "";
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getNrecords() {
+      return accum.nrecords;
+    }
+
+    public int getNdups() {
+      return accum.ndups;
+    }
+
+    public float getNdupPct() {
+      return accum.nrecords == 0 ? 0 : 100.0f * accum.ndups / (float) accum.nrecords;
+    }
+
+    public int getNmissing() {
+      return accum.nmissing;
+    }
+
+    public float getNmissPct() {
+      return accum.nrecords == 0 ? 0 : 100.0f * accum.nmissing / (float) accum.nrecords;
+    }
+
+    public String getType() {
+      return ds.getType().toString();
+    }
+
+    public int getGroupNo() {
+      return groupno;
+    }
+
+    public String getTime2D() {
+      return time2D;
+    }
+
+    public String toString() {
+      return info;
+    }
+  }
+}

--- a/uicdm/src/main/java/ucar/nc2/ui/grib/Grib1CollectionPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/grib/Grib1CollectionPanel.java
@@ -1,33 +1,6 @@
 /*
- * Copyright (c) 1998 - 2012. University Corporation for Atmospheric Research/Unidata
- * Portions of this software were developed by the Unidata Program at the
- * University Corporation for Atmospheric Research.
- *
- * Access and use of this software shall impose the following obligations
- * and understandings on the user. The user is granted the right, without
- * any fee or cost, to use, copy, modify, alter, enhance and distribute
- * this software, and any derivative works thereof, and its supporting
- * documentation for any purpose whatsoever, provided that this entire
- * notice appears in all copies of the software, derivative works and
- * supporting documentation. Further, UCAR requests that the user credit
- * UCAR/Unidata in any publications that result from the use of this
- * software or in any product that includes this software. The names UCAR
- * and/or Unidata, however, may not be used in any advertising or publicity
- * to endorse or promote any products or commercial entity unless specific
- * written permission is obtained from UCAR/Unidata. The user also
- * understands that UCAR/Unidata is not obligated to provide the user with
- * any support, consulting, training or assistance of any kind with regard
- * to the use, operation and performance of this software nor to provide
- * the user with any updates, revisions, new versions or "bug fixes."
- *
- * THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- * WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Copyright (c) 2011-2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
  */
 
 package ucar.nc2.ui.grib;
@@ -63,12 +36,7 @@ import java.io.*;
 import java.util.*;
 import java.util.List;
 
-/**
- * Refactored Grib1 raw access
- *
- * @author John
- * @since 9/3/11
- */
+/** Refactored Grib1 raw access */
 public class Grib1CollectionPanel extends JPanel {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Grib1CollectionPanel.class);
 
@@ -402,7 +370,7 @@ public class Grib1CollectionPanel extends JPanel {
     String h1 = bean1.getHeader();
     String h2 = bean2.getHeader();
     if (!h1.equals(h2))
-      f.format("WMO headers differ %s != %s %n", h1, h2);
+      f.format("WMO headers differ%n  %s%n  %s%n%n", h1, h2);
 
     f.format("1 cdmHash = %d%n", cdmVariableHash(cust, bean1.gr));
     f.format("2 cdmHash = %d%n", cdmVariableHash(cust, bean2.gr));
@@ -417,7 +385,8 @@ public class Grib1CollectionPanel extends JPanel {
     f.format("%nCompare Gds%n");
     byte[] raw1 = gdss1.getRawBytes();
     byte[] raw2 = gdss2.getRawBytes();
-    Misc.compare(raw1, raw2, f);
+    boolean same = Misc.compare(raw1, raw2, f);
+    f.format(" exact byte compare= %s%n%n", same ? "True" : "False");
 
     Grib1Gds gds1 = gdss1.getGDS();
     Grib1Gds gds2 = gdss2.getGDS();
@@ -444,7 +413,8 @@ public class Grib1CollectionPanel extends JPanel {
     f.format("%nCompare Pds%n");
     byte[] raw1 = pds1.getRawBytes();
     byte[] raw2 = pds2.getRawBytes();
-    Misc.compare(raw1, raw2, f);
+    boolean same = Misc.compare(raw1, raw2, f);
+    f.format(" exact byte compare= %s%n%n", same ? "True" : "False");
   }
 
   private void compareData(RecordBean bean1, RecordBean bean2, Formatter f) {

--- a/uicdm/src/main/java/ucar/nc2/ui/grib/Grib2CollectionPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/grib/Grib2CollectionPanel.java
@@ -1,33 +1,6 @@
 /*
- * Copyright (c) 1998 - 2011. University Corporation for Atmospheric Research/Unidata
- * Portions of this software were developed by the Unidata Program at the
- * University Corporation for Atmospheric Research.
- *
- * Access and use of this software shall impose the following obligations
- * and understandings on the user. The user is granted the right, without
- * any fee or cost, to use, copy, modify, alter, enhance and distribute
- * this software, and any derivative works thereof, and its supporting
- * documentation for any purpose whatsoever, provided that this entire
- * notice appears in all copies of the software, derivative works and
- * supporting documentation. Further, UCAR requests that the user credit
- * UCAR/Unidata in any publications that result from the use of this
- * software or in any product that includes this software. The names UCAR
- * and/or Unidata, however, may not be used in any advertising or publicity
- * to endorse or promote any products or commercial entity unless specific
- * written permission is obtained from UCAR/Unidata. The user also
- * understands that UCAR/Unidata is not obligated to provide the user with
- * any support, consulting, training or assistance of any kind with regard
- * to the use, operation and performance of this software nor to provide
- * the user with any updates, revisions, new versions or "bug fixes."
- *
- * THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- * WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Copyright (c) 2008-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
  */
 
 package ucar.nc2.ui.grib;
@@ -901,23 +874,24 @@ public class Grib2CollectionPanel extends JPanel {
     f.format("%nCompare Gds%n");
     byte[] raw1 = gdss1.getRawBytes();
     byte[] raw2 = gdss2.getRawBytes();
-    Misc.compare(raw1, raw2, f);
+    boolean same = Misc.compare(raw1, raw2, f);
+    f.format(" exact byte compare= %s%n%n", same ? "True" : "False");
 
     Grib2Gds gds1 = gdss1.getGDS();
     Grib2Gds gds2 = gdss2.getGDS();
     GdsHorizCoordSys gdsh1 = gds1.makeHorizCoordSys();
     GdsHorizCoordSys gdsh2 = gds2.makeHorizCoordSys();
 
-    f.format("%ncompare gds1 - gds22%n");
-    f.format(" Start x diff : %f%n", gdsh1.getStartX() - gdsh2.getStartX());
-    f.format(" Start y diff : %f%n", gdsh1.getStartY() - gdsh2.getStartY());
-    f.format(" End x diff : %f%n", gdsh1.getEndX() - gdsh2.getEndX());
-    f.format(" End y diff : %f%n", gdsh1.getEndY() - gdsh2.getEndY());
+    f.format(" compare gds1 - gds22%n");
+    f.format("  Start x diff : %f%n", gdsh1.getStartX() - gdsh2.getStartX());
+    f.format("  Start y diff : %f%n", gdsh1.getStartY() - gdsh2.getStartY());
+    f.format("  End x diff : %f%n", gdsh1.getEndX() - gdsh2.getEndX());
+    f.format("  End y diff : %f%n", gdsh1.getEndY() - gdsh2.getEndY());
 
     LatLonPoint pt1 = gdsh1.getCenterLatLon();
     LatLonPoint pt2 = gdsh2.getCenterLatLon();
-    f.format(" Center lon diff : %f%n", pt1.getLongitude() - pt2.getLongitude());
-    f.format(" Center lat diff : %f%n", pt1.getLatitude() - pt2.getLatitude());
+    f.format("  Center lon diff : %f%n", pt1.getLongitude() - pt2.getLongitude());
+    f.format("  Center lat diff : %f%n", pt1.getLatitude() - pt2.getLatitude());
   }
 
 
@@ -925,7 +899,8 @@ public class Grib2CollectionPanel extends JPanel {
     f.format("%nCompare Pds%n");
     byte[] raw1 = pds1.getRawBytes();
     byte[] raw2 = pds2.getRawBytes();
-    Misc.compare(raw1, raw2, f);
+    boolean same = Misc.compare(raw1, raw2, f);
+    f.format(" exact byte compare= %s%n%n", same ? "True" : "False");
   }
 
   public static void compareData(Grib2RecordBean bean1, Grib2RecordBean bean2, Formatter f) {

--- a/uicdm/src/main/java/ucar/nc2/ui/op/CdmIndexOpPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/op/CdmIndexOpPanel.java
@@ -20,13 +20,10 @@ import java.io.StringWriter;
 import java.nio.file.Paths;
 import javax.swing.JOptionPane;
 
-/**
- *
- */
+/** Show ncx4 indices. */
 public class CdmIndexOpPanel extends OpPanel {
   private CdmIndexPanel indexPanel;
 
-  /** */
   public CdmIndexOpPanel(PreferencesExt p) {
     super(p, "index file:", true, false);
 
@@ -43,7 +40,6 @@ public class CdmIndexOpPanel extends OpPanel {
     add(indexPanel, BorderLayout.CENTER);
   }
 
-  /** */
   @Override
   public boolean process(Object o) {
     String command = (String) o;
@@ -66,13 +62,11 @@ public class CdmIndexOpPanel extends OpPanel {
     return !err;
   }
 
-  /** */
   @Override
   public void closeOpenFiles() throws IOException {
     indexPanel.clear();
   }
 
-  /** */
   @Override
   public void save() {
     indexPanel.save();

--- a/uicdm/src/main/java/ucar/nc2/ui/op/CdmIndexScanOp.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/op/CdmIndexScanOp.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.ui.op;
+
+import ucar.nc2.ui.OpPanel;
+import ucar.nc2.ui.ToolsUI;
+import ucar.nc2.ui.grib.CdmIndexScan;
+import ucar.ui.widget.BAMutil;
+import ucar.ui.widget.FileManager;
+import ucar.util.prefs.PreferencesExt;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+public class CdmIndexScanOp extends OpPanel {
+  private CdmIndexScan cdmIndexScan;
+  final FileManager dirChooser;
+
+  public CdmIndexScanOp(PreferencesExt prefs, FileManager dirChooser) {
+    super(prefs, "dir:", false, false);
+    this.dirChooser = dirChooser;
+
+    cdmIndexScan = new CdmIndexScan(prefs);
+    add(cdmIndexScan, BorderLayout.CENTER);
+
+    dirChooser.getFileChooser().setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+    dirChooser.setCurrentDirectory(prefs.get("currDir", "."));
+    AbstractAction fileAction = new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        String filename = dirChooser.chooseFilename();
+        if (filename == null) {
+          return;
+        }
+        cb.setSelectedItem(filename);
+      }
+    };
+    BAMutil.setActionProperties(fileAction, "FileChooser", "open Local dataset...", false, 'L', -1);
+    BAMutil.addActionToContainer(buttPanel, fileAction);
+
+    cdmIndexScan.addPropertyChangeListener(new PropertyChangeListener() {
+      @Override
+      public void propertyChange(PropertyChangeEvent e) {
+        if (!(e.getNewValue() instanceof String))
+          return;
+
+        String datasetName = (String) e.getNewValue();
+
+        switch (e.getPropertyName()) {
+          case "openIndexFile":
+            ToolsUI.getToolsUI().openIndexFile(datasetName);
+            break;
+        }
+      }
+    });
+  }
+
+  @Override
+  public boolean process(Object o) {
+    String command = (String) o;
+    return cdmIndexScan.setScanDirectory(command);
+  }
+
+  @Override
+  public void closeOpenFiles() {
+    cdmIndexScan.clear();
+  }
+
+  @Override
+  public void save() {
+    dirChooser.save();
+    cdmIndexScan.save();
+    prefs.put("currDir", dirChooser.getCurrentDirectory());
+    super.save();
+  }
+}

--- a/uicdm/src/main/java/ucar/nc2/ui/op/FeatureScanOpPanel.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/op/FeatureScanOpPanel.java
@@ -17,21 +17,13 @@ import java.beans.PropertyChangeListener;
 import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
 
-/**
- *
- */
 public class FeatureScanOpPanel extends OpPanel {
   private FeatureScanPanel ftTable;
   final FileManager dirChooser;
 
-  /**
-   *
-   */
-  public FeatureScanOpPanel(PreferencesExt prefs) {
+  public FeatureScanOpPanel(PreferencesExt prefs, FileManager dirChooser) {
     super(prefs, "dir:", false, false);
-
-    dirChooser =
-        new FileManager(ToolsUI.getToolsFrame(), null, null, (PreferencesExt) prefs.node("FeatureScanFileManager"));
+    this.dirChooser = dirChooser;
 
     ftTable = new FeatureScanPanel(prefs);
     add(ftTable, BorderLayout.CENTER);
@@ -86,20 +78,17 @@ public class FeatureScanOpPanel extends OpPanel {
     BAMutil.addActionToContainer(buttPanel, fileAction);
   }
 
-  /** */
   @Override
   public boolean process(Object o) {
     String command = (String) o;
     return ftTable.setScanDirectory(command);
   }
 
-  /** */
   @Override
   public void closeOpenFiles() {
     ftTable.clear();
   }
 
-  /** */
   @Override
   public void save() {
     dirChooser.save();


### PR DESCRIPTION
Welcome to Backportapoloza! This PR contains the following backports from `develop`:

* Speed up OPeNDAP `InputStream` parsing (Unidata/netcdf-java#551)
* Tasks from Unidata/netcdf-java#557 discussion regarding the addition and removal of deprecations in `maint-5.x`
* Implement TimeOffset Regular axes for grib collections, Grib Eta coordinate not scalar (Unidata/netcdf-java#561)
* Fix interval grib coordinate, add `CdmIndexScan` to ToolsUI, deal with Grib2 percentile variables (Unidata/netcdf-java#564)

Also snagged a few more "HEY" messages, because some of the backports above included some already.

Ran on [Jenkins](https://jenkins-aws.unidata.ucar.edu/view/Sean/job/sean-netcdf-java/103/) with zero failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/569)
<!-- Reviewable:end -->
