### PR TITLE
Valid min/max for packed data

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/EnhanceScaleMissingUnsignedImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/EnhanceScaleMissingUnsignedImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.dataset;
@@ -243,6 +243,14 @@ class EnhanceScaleMissingUnsignedImpl implements EnhanceScaleMissingUnsigned {
           if (hasValidRange || hasValidMax) {
             validMax = applyScaleOffset(validMax);
           }
+        }
+        // During the scaling process, it is possible that the valid minimum and maximum values have effectively been
+        // swapped (for example, when the scale value is negative). Go ahead and check to make sure the valid min is
+        // actually less than the valid max, and if not, fix it. See https://github.com/Unidata/netcdf-java/issues/572.
+        if (validMin > validMax) {
+          double tmp = validMin;
+          validMin = validMax;
+          validMax = tmp;
         }
       }
     }

--- a/cdm/core/src/main/java/ucar/nc2/dataset/VariableEnhancer.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/VariableEnhancer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2019-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
 package ucar.nc2.dataset;
 
 import static ucar.ma2.DataType.DOUBLE;
@@ -218,7 +223,7 @@ public class VariableEnhancer implements EnhanceScaleMissingUnsigned {
       }
     }
 
-    /// assign convertedDataType if needed
+    // assign convertedDataType if needed
     if (hasScaleOffset) {
       scaledOffsetType = largestOf(unsignedConversionType, scaleType, offsetType).withSignedness(signedness);
       logger.debug("assign scaledOffsetType = {}", scaledOffsetType);
@@ -239,6 +244,14 @@ public class VariableEnhancer implements EnhanceScaleMissingUnsigned {
           if (hasValidRange || hasValidMax) {
             validMax = applyScaleOffset(validMax);
           }
+        }
+        // During the scaling process, it is possible that the valid minimum and maximum values have effectively been
+        // swapped (for example, when the scale value is negative). Go ahead and check to make sure the valid min is
+        // actually less than the valid max, and if not, fix it. See https://github.com/Unidata/netcdf-java/issues/572.
+        if (validMin > validMax) {
+          double tmp = validMin;
+          validMin = validMax;
+          validMax = tmp;
         }
       }
     }

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissing.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissing.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 1998-2020 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.dataset;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.lang.Float.NaN;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestScaleOffsetMissing {
+
+  private static final float fpTol = 0.000001f;
+  // Packed values are {-1, 0, 100, 101} with a valid_range of 0 to 100, scale is 0.01, add_offset is 1.
+  // Unpacked values are {-0.99, 1, 2, 2.01} with a valid_range of 1 to 2.
+  // First and last values are outside of valid_range, which shows up as NaN.
+  // See cdm/core/src/test/resources/ucar/nc2/dataset/testScaleOffsetMissing.ncml
+  private static final float[] expected = new float[] {NaN, 1.0f, 2.0f, NaN};
+  private static final byte expectedValidMin = 1;
+  private static final byte expectedValidMax = 2;
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void testScaleOffsetValidMaxMin() throws URISyntaxException, IOException {
+    File testResource = new File(getClass().getResource("testScaleOffsetMissing.ncml").toURI());
+
+    try (NetcdfDataset ncd = NetcdfDatasets.openDataset(testResource.getAbsolutePath(), true, null)) {
+      VariableDS var = (VariableDS) ncd.findVariable("scaleOffsetValidMaxMin");
+
+      assertThat(var.getValidMin()).isWithin(fpTol).of(expectedValidMin);
+      assertThat(var.getValidMax()).isWithin(fpTol).of(expectedValidMax);
+
+      float[] actual = (float[]) var.read().getStorage();
+      for (int i = 0; i < actual.length; i++) {
+        if (var.isInvalidData(actual[i])) {
+          assertThat(actual[i]).isNaN();
+          assertThat(expected[i]).isNaN();
+        } else {
+          assertThat(actual[i]).isNotNaN();
+          assertThat(actual[i]).isWithin(fpTol).of(expected[i]);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testScaleOffsetValidRange() throws URISyntaxException, IOException {
+    File testResource = new File(getClass().getResource("testScaleOffsetMissing.ncml").toURI());
+
+    try (NetcdfDataset ncd = NetcdfDatasets.openDataset(testResource.getAbsolutePath(), true, null)) {
+      // same as scaleOffsetValidMaxMin, but uses valid_range attribute instead of valid_min and valid_max attributes.
+      VariableDS var = (VariableDS) ncd.findVariable("scaleOffsetValidRange");
+
+      assertThat(var.getValidMin()).isWithin(fpTol).of(expectedValidMin);
+      assertThat(var.getValidMax()).isWithin(fpTol).of(expectedValidMax);
+
+      float[] actual = (float[]) var.read().getStorage();
+      for (int i = 0; i < actual.length; i++) {
+        if (var.isInvalidData(actual[i])) {
+          assertThat(actual[i]).isNaN();
+          assertThat(expected[i]).isNaN();
+        } else {
+          assertThat(actual[i]).isNotNaN();
+          assertThat(actual[i]).isWithin(fpTol).of(expected[i]);
+        }
+      }
+    }
+  }
+
+  // This test demonstrated the bug in https://github.com/Unidata/netcdf-java/issues/572.
+  @Test
+  public void testNegScaleOffsetValidRange() throws URISyntaxException, IOException {
+    File testResource = new File(getClass().getResource("testScaleOffsetMissing.ncml").toURI());
+
+    try (NetcdfDataset ncd = NetcdfDatasets.openDataset(testResource.getAbsolutePath(), true, null)) {
+      // Same as scaleOffsetValidRange, but uses negative scale and offset values (same magnitude).
+      // The net effect is that the sign of the expected values should be flipped when doing comparisons against what
+      // is stored in this variable.
+      VariableDS var = (VariableDS) ncd.findVariable("negScaleOffsetValidRange");
+
+      // Note: checking that the actual valid min/max is the negative of the expected valid max/min.
+      assertThat(var.getValidMin()).isWithin(fpTol).of(-expectedValidMax);
+      assertThat(var.getValidMax()).isWithin(fpTol).of(-expectedValidMin);
+
+      float[] actual = (float[]) var.read().getStorage();
+      for (int i = 0; i < actual.length; i++) {
+        if (var.isInvalidData(actual[i])) {
+          assertThat(actual[i]).isNaN();
+          assertThat(expected[i]).isNaN();
+        } else {
+          assertThat(actual[i]).isNotNaN();
+          assertThat(actual[i]).isWithin(fpTol).of(-expected[i]);
+        }
+      }
+    }
+  }
+}

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissing.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissing.java
@@ -103,4 +103,29 @@ public class TestScaleOffsetMissing {
       }
     }
   }
+
+  // Same as testNegScaleOffsetValidRange, but using the old NetcdfDataset.openDataset API.
+  // TODO: Remove in 6
+  @Test
+  public void testNegScaleOffsetValidRangeDeprecatedApi() throws URISyntaxException, IOException {
+    File testResource = new File(getClass().getResource("testScaleOffsetMissing.ncml").toURI());
+
+    try (NetcdfDataset ncd = NetcdfDataset.openDataset(testResource.getAbsolutePath(), true, null)) {
+      VariableDS var = (VariableDS) ncd.findVariable("negScaleOffsetValidRange");
+
+      assertThat(var.getValidMin()).isWithin(fpTol).of(-expectedValidMax);
+      assertThat(var.getValidMax()).isWithin(fpTol).of(-expectedValidMin);
+
+      float[] actual = (float[]) var.read().getStorage();
+      for (int i = 0; i < actual.length; i++) {
+        if (var.isInvalidData(actual[i])) {
+          assertThat(actual[i]).isNaN();
+          assertThat(expected[i]).isNaN();
+        } else {
+          assertThat(actual[i]).isNotNaN();
+          assertThat(actual[i]).isWithin(fpTol).of(-expected[i]);
+        }
+      }
+    }
+  }
 }

--- a/cdm/core/src/test/resources/ucar/nc2/dataset/testScaleOffsetMissing.ncml
+++ b/cdm/core/src/test/resources/ucar/nc2/dataset/testScaleOffsetMissing.ncml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <variable name="scaleOffsetValidMaxMin" shape="4" type="byte">
+    <attribute name="scale_factor" type="float" value="0.01" />
+    <attribute name="add_offset" type="int" value="1" />
+    <attribute name="valid_min" type="byte" value="0" />
+    <attribute name="valid_max" type="byte" value="100" />
+    <values>-1 0 100 101</values>
+  </variable>
+  <variable name="scaleOffsetValidRange" shape="4" type="byte">
+    <!-- Only difference between this variable and scaleOffsetValidMaxMin is that this variable uses valid_range
+         instead of valid_min, valid_max -->
+    <attribute name="valid_range" type="byte" value="0 100" />
+
+    <attribute name="scale_factor" type="float" value="0.01" />
+    <attribute name="add_offset" type="int" value="1" />
+    <values>-1 0 100 101</values>
+  </variable>
+  <variable name="negScaleOffsetValidRange" shape="4" type="byte">
+    <!-- The differences between this variable and scaleOffsetValidRange is that this variable has negative
+         scale and offset vales. Unpacked values should be the same magnitude, but opposite sign, of the unpacked
+         values in scaleOffsetValidRange. -->
+    <attribute name="scale_factor" type="float" value="-0.01" />
+    <attribute name="add_offset" type="int" value="-1" />
+
+    <attribute name="valid_range" type="byte" value="0 100" />
+    <values>-1 0 100 101</values>
+  </variable>
+</netcdf>

--- a/cdm/core/src/test/resources/ucar/nc2/dataset/testScaleOffsetMissingUnsigned.ncml
+++ b/cdm/core/src/test/resources/ucar/nc2/dataset/testScaleOffsetMissingUnsigned.ncml
@@ -23,7 +23,22 @@
         
         <values>-107 -106 -6 -5 -1 80</values>
     </variable>
-    
+
+    <variable name="scaleOffsetMissingUnsignedValidRange" shape="6" type="byte">
+        <!-- The difference between the scaleOffsetMissingUnsigned and scaleOffsetMissingUnsignedRange vars is basically
+        making the scale factor and offset negative, and combining valid_min, valid_max into valid_range.
+        However, because we are setting the scale factor and offset to be negative, we need to set their type to a non
+        integral type, otherwise they will be interpreted as unsigned thanks to _Unsigned=true. -->
+        <attribute name="scale_factor" type="float" value="-100" />
+        <attribute name="add_offset" type="float" value="-1" />
+        <attribute name="valid_range" type="byte" value="-6 -106" />
+
+        <attribute name="_Unsigned" value="true" />
+        <attribute name="_FillValue" type="byte" value="-1" />
+        <attribute name="missing_value" type="byte" value="-1" />
+        <values>-107 -106 -6 -5 -1 80</values>
+    </variable>
+
     <variable name="scaleValidRange" shape="5" type="ushort">
         <attribute name="scale_factor" type="float" value="0.01" />
         <attribute name="valid_range" type="ushort" value="990 1010" />


### PR DESCRIPTION
Properly unpack and set valid min/max when scale is negative.

Fixes Unidata/netcdf-java#572

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/575)
<!-- Reviewable:end -->
