### PR TITLE
v5.4.1 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ allprojects {
   // <prerelease version> may be SNAPSHOT, alphax, betax, etc.
   // Note - if bumping to a new major or minor version, be sure to update the docs (see step 1 in
   // docs/src/private/internal/release.md for details)
-  version = '5.4.1-SNAPSHOT'
-  status = 'development'
+  version = '5.4.1'
+  status = 'release'
 }
 
 // Matches Maven's "project.description".

--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ allprojects {
   // <prerelease version> may be SNAPSHOT, alphax, betax, etc.
   // Note - if bumping to a new major or minor version, be sure to update the docs (see step 1 in
   // docs/src/private/internal/release.md for details)
-  version = '5.4.1'
-  status = 'release'
+  version = '5.4.2-SNAPSHOT'
+  status = 'development'
 }
 
 // Matches Maven's "project.description".

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -4,7 +4,17 @@ apply from: "$rootDir/gradle/any/publishing.gradle"
 
 // All dependencies used by the netCDF-Java library are defined here
 
+javaPlatform {
+  allowDependencies()
+}
+
 dependencies {
+  // Results in upgrading jackson-databind to 2.10.5.1, which contains a fix for
+  // CVE-2020-25649 (https://nvd.nist.gov/vuln/detail/CVE-2020-25649)
+  // See https://github.com/FasterXML/jackson-databind/issues/2589#issuecomment-736973925
+  // jackson-databind is pulled in by AWS SDK (true as of version 2.15.40), so once they update to
+  // a newer version, we can get rid of this (and the javaPlatform allowDependencies() block above).
+  api enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.10.5.20201202')
   constraints {
     // Note: The depVersion variable is defined in gradle/any/shared-mvn-coords.gradle and is used for dependencies
     // that are used in different configurations of a build that need access to the full maven coordinates.
@@ -39,8 +49,10 @@ dependencies {
     api 'edu.wisc.ssec:visad:2.0-20130124'
 
     // cdm-s3 (S3RandomAccessFile)
-    api 'software.amazon.awssdk:s3:2.13.52'
-    api 'software.amazon.awssdk:apache-client:2.13.52'
+    // If updating from 2.15.40, see note the note at the top of this dependencies block regarding
+    // the use of jackson-databind enforcedPlatform.
+    api 'software.amazon.awssdk:s3:2.15.40'
+    api 'software.amazon.awssdk:apache-client:2.15.40'
 
     // apache httpclient
     api 'org.apache.httpcomponents:httpclient:4.5.13'

--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -10,4 +10,12 @@
     <packageUrl regex="true">^pkg:maven/junit/junit@.*$</packageUrl>
     <vulnerabilityName>CVE-2020-15250</vulnerabilityName>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+       file name: jackson-databind-2.10.4.jar
+       reason: Fixed in 2.10.5.1 (see https://github.com/FasterXML/jackson-databind/issues/2589
+      ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <cve>CVE-2020-25649</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
`5.4.1` release, and move to `5.4.1-SNAPSHOT` on `maint-5.x` branch. Release job on Jenkins was [successful](https://jenkins-aws.unidata.ucar.edu/view/Release%20Jobs/job/netcdf-java-release/22/). After `v5.4.0` was published, a new CVE started showing up in a transitive dependency (`jackson-databind`, as pulled in by the AWS SDK). Since the artifacts, docs, links, etc. had already been updated, we decided to cut a new point release (even though `v5.4.0` had not been announced).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/587)
<!-- Reviewable:end -->
