### PR TITLE
Fix sourceSet issue and improve dependency management

### DIFF
--- a/cdm-lite/build.gradle
+++ b/cdm-lite/build.gradle
@@ -10,6 +10,7 @@ apply from: "$rootDir/gradle/any/gretty.gradle"
 
 dependencies {
   api enforcedPlatform(project(':netcdf-java-platform'))
+  api enforcedPlatform('org.springframework:spring-framework-bom:5.3.2')
 
   api project(':cdm:cdm-core')
   api project(':httpservices')
@@ -20,11 +21,11 @@ dependencies {
   compile 'com.google.code.findbugs:jsr305'
   compile 'org.slf4j:slf4j-api'
 
-  compile "org.springframework:spring-core:5.2.6.RELEASE"
-  compile "org.springframework:spring-context:5.2.6.RELEASE"
-  compile "org.springframework:spring-beans:5.2.6.RELEASE"
-  compile "org.springframework:spring-web:5.2.6.RELEASE"
-  compile "org.springframework:spring-webmvc:5.2.6.RELEASE"
+  compile "org.springframework:spring-core"
+  compile "org.springframework:spring-context"
+  compile "org.springframework:spring-beans"
+  compile "org.springframework:spring-web"
+  compile "org.springframework:spring-webmvc"
 
   runtime 'org.slf4j:slf4j-api'
   runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.3'
@@ -36,7 +37,7 @@ dependencies {
   testRuntimeOnly 'ch.qos.logback:logback-classic'
 
   testCompile "javax.servlet:javax.servlet-api:3.1.0"
-  testCompile "org.springframework:spring-test:5.2.6.RELEASE"
+  testCompile "org.springframework:spring-test"
 }
 
 war {

--- a/cdmr/build.gradle
+++ b/cdmr/build.gradle
@@ -44,8 +44,8 @@ protobuf {
 sourceSets {
   main {
     java {
+      // not needed for proto generated source
       srcDirs 'build/generated/source/proto/main/grpc'
-      srcDirs 'build/generated/source/proto/main/java'
     }
   }
 }

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -4,7 +4,17 @@ apply from: "$rootDir/gradle/any/publishing.gradle"
 
 // All dependencies used by the netCDF-Java library are defined here
 
+javaPlatform {
+  allowDependencies()
+}
+
 dependencies {
+  // Results in upgrading jackson-databind to 2.10.5.1, which contains a fix for
+  // CVE-2020-25649 (https://nvd.nist.gov/vuln/detail/CVE-2020-25649)
+  // See https://github.com/FasterXML/jackson-databind/issues/2589#issuecomment-736973925
+  // jackson-databind is pulled in by AWS SDK (true as of version 2.15.40), so once they update to
+  // a newer version, we can get rid of this (and the javaPlatform allowDependencies() block above).
+  api enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.10.5.20201202')
   constraints {
     // Note: The depVersion variable is defined in gradle/any/shared-mvn-coords.gradle and is used for dependencies
     // that are used in different configurations of a build that need access to the full maven coordinates.
@@ -42,12 +52,14 @@ dependencies {
     api 'edu.wisc.ssec:visad:2.0-20130124'
 
     // cdm-s3 (S3RandomAccessFile)
-    api 'software.amazon.awssdk:s3:2.13.52'
-    api 'software.amazon.awssdk:apache-client:2.13.52'
+    // If updating from 2.15.40, see note the note at the top of this dependencies block regarding
+    // the use of jackson-databind enforcedPlatform.
+    api 'software.amazon.awssdk:s3:2.15.46'
+    api 'software.amazon.awssdk:apache-client:2.15.46'
 
     // apache httpclient
-    api 'org.apache.httpcomponents:httpclient:4.5.12'
-    api 'org.apache.httpcomponents:httpmime:4.5.12'
+    api 'org.apache.httpcomponents:httpclient:4.5.13'
+    api 'org.apache.httpcomponents:httpmime:4.5.13'
     // version of httpcore matches the one used by httpclient
     // so if updating httpclient, look in its pom for the version of http core to use
     api 'org.apache.httpcomponents:httpcore:4.4.13'


### PR DESCRIPTION
The generated proto source was getting added to the `sourceSet` twice for the `cdmr` module, which was causes the Jenkins run to fail (so no longer add it specifically). Also bump some dependencies (OWAPS dependency scan failures), and move to using the `spring-framework-bom` to manage the spring dependencies for `cdm-lite`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/596)
<!-- Reviewable:end -->
