### PR TITLE
For Experimental HRRR GRIB2 tables, use NCLName

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCreationOptions.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCreationOptions.java
@@ -52,8 +52,8 @@ public class TestGribCreationOptions {
 
     String dataset = TestDir.cdmUnitTestDir + "gribCollections/hrrr/DewpointTempFromGsdHrrrrConus3surface.grib2";
     try (NetcdfDataset ds = NetcdfDatasets.openDataset(dataset)) {
-      Variable v = ds.findVariable("DPT_height_above_ground");
-      Assert.assertNotNull("DPT_height_above_ground", v);
+      Variable v = ds.findVariable("DPT_P0_L103_GLC0_height_above_ground");
+      Assert.assertNotNull("DPT_P0_L103_GLC0_height_above_ground", v);
       Dimension d = v.getDimension(0);
       Assert.assertEquals(57, d.getLength());
     }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/FslHrrrLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/FslHrrrLocalTables.java
@@ -144,7 +144,7 @@ public class FslHrrrLocalTables extends NcepLocalTables {
           VerticalLevels, Units);
     }
 
-    String name = !WGrib2Name.equals("var") ? WGrib2Name : FieldType;
+    String name = !NCLName.equals("var") ? NCLName : FieldType;
     return new Grib2Parameter(disciplineNumber, categoryNumber, parameterNumber, name, Units, null, FieldType);
   }
 
@@ -168,7 +168,7 @@ public class FslHrrrLocalTables extends NcepLocalTables {
           categoryNumber, parameterNumber, WGrib2Name, NCLName, FieldType, Description, Units);
     }
 
-    String name = !WGrib2Name.equals("var") ? WGrib2Name : FieldType;
+    String name = !NCLName.equals("var") ? NCLName : FieldType;
     return new Grib2Parameter(disciplineNumber, categoryNumber, parameterNumber, name, Units, null, Description);
   }
 

--- a/grib/src/test/java/ucar/nc2/grib/grib2/TestRotatedPole.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib2/TestRotatedPole.java
@@ -83,7 +83,7 @@ public class TestRotatedPole {
       Assert.assertEquals(36.0, projVar.findAttribute("grid_north_pole_latitude").getNumericValue().doubleValue(),
           DELTA);
       // check data variable
-      Variable dataVar = nc.findVariable("TMP_surface");
+      Variable dataVar = nc.findVariable("TMP_P0_L100_GLC0_surface");
       Assert.assertNotNull(dataVar);
       Assert.assertEquals("RotatedLatLon32769_Projection", dataVar.findAttribute("grid_mapping").getStringValue());
       Assert.assertEquals("K", dataVar.findAttribute("units").getStringValue());


### PR DESCRIPTION
Previously we were using the `WGrib2Name` from the HRRR Grib2 table, which is not even close to being unique (multiple
discipline, category, parameter combinations share the same `WGrib2Name` in their table). The `NCLName` isn't unique either,
but at least we don't see collisions in the data we currently receive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/614)
<!-- Reviewable:end -->
