### PR TITLE
pull out changes to raf provider API from zarr work

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -381,6 +381,8 @@ public class NetcdfFiles {
     copy(raf, new FileOutputStream(uriString), 1 << 20);
     try {
       String uncompressedFileName = makeUncompressed(uriString);
+      // LOOK - this will only return one type of RandomAccessFile, which is OK for now,
+      // but needs to be addressed with RandomAccessDirectory
       return ucar.unidata.io.RandomAccessFile.acquire(uncompressedFileName, buffer_size);
     } catch (Exception e) {
       throw new IOException();
@@ -396,7 +398,7 @@ public class NetcdfFiles {
 
     for (RandomAccessFileProvider provider : registeredRandomAccessFileProviders) {
       if (provider.isOwnerOf(location)) {
-        raf = provider.open(location);
+        raf = provider.open(location, buffer_size);
         // might cause issues if the end of a resource location string
         // cannot be reliably used to determine compression
         if (looksCompressed(uriString)) {
@@ -410,7 +412,7 @@ public class NetcdfFiles {
       // look for dynamically loaded RandomAccessFile Providers
       for (RandomAccessFileProvider provider : ServiceLoader.load(RandomAccessFileProvider.class)) {
         if (provider.isOwnerOf(location)) {
-          raf = provider.open(location);
+          raf = provider.open(location, buffer_size);
           // might cause issues if the end of a resource location string
           // cannot be used to determine compression
           if (looksCompressed(uriString)) {

--- a/cdm/core/src/main/java/ucar/unidata/io/InMemoryRandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/InMemoryRandomAccessFile.java
@@ -45,7 +45,7 @@ public class InMemoryRandomAccessFile extends ucar.unidata.io.RandomAccessFile {
     return dataEnd;
   }
 
-  // @Override LOOK weird error
+  @Override
   public void setBufferSize(int bufferSize) {
     // do nothing
   }
@@ -87,5 +87,5 @@ public class InMemoryRandomAccessFile extends ucar.unidata.io.RandomAccessFile {
       return new InMemoryRandomAccessFile(location, contents.get());
     }
   }
-
 }
+

--- a/cdm/core/src/main/java/ucar/unidata/io/http/HTTPRandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/http/HTTPRandomAccessFile.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
 import ucar.httpservices.HTTPSession;
-import ucar.unidata.io.InMemoryRandomAccessFile;
 import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.io.RemoteRandomAccessFile;
 import ucar.unidata.io.spi.RandomAccessFileProvider;

--- a/cdm/core/src/main/java/ucar/unidata/io/http/HTTPRandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/http/HTTPRandomAccessFile.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
 import ucar.httpservices.HTTPSession;
+import ucar.unidata.io.InMemoryRandomAccessFile;
 import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.io.RemoteRandomAccessFile;
 import ucar.unidata.io.spi.RandomAccessFileProvider;
@@ -244,11 +245,16 @@ public final class HTTPRandomAccessFile extends RemoteRandomAccessFile {
 
     @Override
     public RandomAccessFile open(String location) throws IOException {
+      return this.open(location, httpBufferSize);
+    }
+
+    @Override
+    public RandomAccessFile open(String location, int bufferSize) throws IOException {
       String scheme = location.split(":")[0];
       if (!scheme.equalsIgnoreCase("https") && !scheme.equalsIgnoreCase("http")) {
         location = location.replace(scheme, "http");
       }
-      return new HTTPRandomAccessFile(location);
+      return new HTTPRandomAccessFile(location, bufferSize, httpMaxCacheSize);
     }
   }
 }

--- a/cdm/core/src/main/java/ucar/unidata/io/spi/RandomAccessFileProvider.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/spi/RandomAccessFileProvider.java
@@ -15,4 +15,19 @@ public interface RandomAccessFileProvider {
 
   /** Open a location that this Provider is the owner of. */
   RandomAccessFile open(String location) throws IOException;
+
+  /** Open a location that this Provider is the owner of, with the given buffer size */
+  default RandomAccessFile open(String location, int bufferSize) throws IOException {
+    return this.open(location); // avoid breaking an existing 3rd party implementations
+  }
+
+  /** Acquire a file for a location from a cache, if available **/
+  default RandomAccessFile acquire(String location) throws IOException {
+    return this.open(location); // avoid breaking an existing 3rd party implementations
+  }
+
+  /** Acquire a file for a location, with the given buffer size, from a cache, if available **/
+  default RandomAccessFile acquire(String location, int bufferSize) throws IOException {
+    return this.open(location, bufferSize); // avoid breaking an existing 3rd party implementations
+  }
 }

--- a/cdm/s3/src/main/java/ucar/unidata/io/s3/S3RandomAccessFile.java
+++ b/cdm/s3/src/main/java/ucar/unidata/io/s3/S3RandomAccessFile.java
@@ -46,7 +46,12 @@ public final class S3RandomAccessFile extends RemoteRandomAccessFile implements 
   private HeadObjectResponse objectHeadResponse;
 
   private S3RandomAccessFile(String url) throws IOException {
-    super(url, s3BufferSize, s3MaxReadCacheSize);
+    this(url, s3BufferSize);
+  }
+
+  private S3RandomAccessFile(String url, int bufferSize) throws IOException {
+
+    super(url, bufferSize, s3MaxReadCacheSize);
 
     try {
       uri = new CdmS3Uri(url);
@@ -149,6 +154,11 @@ public final class S3RandomAccessFile extends RemoteRandomAccessFile implements 
     @Override
     public RandomAccessFile open(String location) throws IOException {
       return new S3RandomAccessFile(location);
+    }
+
+    @Override
+    public RandomAccessFile open(String location, int bufferSize) throws IOException {
+      return new S3RandomAccessFile(location, bufferSize);
     }
   }
 }

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -71,10 +71,10 @@ gretty {
 farm {
   jvmArgs = ["-Dlog4j.configurationFile=$rootDir/gradle/gretty/log4j2Config.xml"]
   // used by :dap4 test
-  webapp 'edu.ucar:d4ts:5.0.0-SNAPSHOT@war', contextPath: '/d4ts'
+  webapp 'edu.ucar:d4ts:5.0.0-beta8@war', contextPath: '/d4ts'
 
   // :opendap and :httpservices test.
-  webapp 'edu.ucar:dtswar:5.0.0-SNAPSHOT@war', contextPath: '/dts'
+  webapp 'edu.ucar:dtswar:5.0.0-beta8@war', contextPath: '/dts'
   integrationTestTask = 'test'
 
   // Enable TLS


### PR DESCRIPTION
Pullled out updates to the RandomAccessFile provider API from other zarr work:

1. propagate "buffer_size" passed to `NetcdfFiles.open` into `provider.open`
2. add open with buffer size and aquire methods to provider interface (defaults to `open` if not implemented)
3. existing provider implementations:
       a. InMemoryRandomAccessFile -  doesn't implement acquire or allow users to set buffer size, so no changes to provider
       b. HttpRandomAccessFile and S3RandomAccessFile - don't implement acquire, so no acquire implementation added to provider, but open with buffer size is implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/629)
<!-- Reviewable:end -->
