### PR TITLE
Spin-up a local cdmr server for testing

### DIFF
--- a/cdmr/build.gradle
+++ b/cdmr/build.gradle
@@ -1,7 +1,10 @@
+import com.github.psxpaul.task.JavaExecFork
+
 plugins {
   // Provide convenience executables for testing
   id 'application'
   id "com.google.protobuf"
+  id 'com.github.psxpaul.execfork' version '0.1.13'
 }
 
 description = 'CDM remote access using gRPC.'
@@ -59,3 +62,16 @@ sourceSets {
     }
   }
 }
+
+task startDaemon(type: JavaExecFork) {
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'ucar.cdmr.server.CdmrServer'
+  jvmArgs = [ '-Xmx512m', '-Djava.awt.headless=true' ]
+  standardOutput = "$buildDir/cdmr_logs/cdmr.log"
+  errorOutput = "$buildDir/cdmr_logs/cdmr-error.log"
+  stopAfter = test
+  waitForPort = 16111
+  waitForOutput = 'Server started, listening on 16111'
+}
+
+test.dependsOn(startDaemon)

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrGridDataset.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrGridDataset.java
@@ -1,12 +1,11 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.cdmr.client;
 
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import ucar.array.InvalidRangeException;
@@ -14,8 +13,6 @@ import ucar.nc2.grid.*;
 import ucar.nc2.internal.util.CompareArrayToArray;
 import ucar.nc2.time.CalendarDate;
 import ucar.unidata.util.test.TestDir;
-import ucar.unidata.util.test.category.NeedsExternalResource;
-import ucar.unidata.util.test.category.NotJenkins;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +25,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 /** Test {@link CdmrNetcdfFile} */
 @RunWith(Parameterized.class)
-@Category({NeedsExternalResource.class, NotJenkins.class}) // Needs CmdrServer to be started up
 public class TestCdmrGridDataset {
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrNetcdf4.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrNetcdf4.java
@@ -34,8 +34,8 @@ public class TestCdmrNetcdf4 {
       // these files are removed because they cause an OutOfMemeoryError
       // todo: why do these cause an OutOfMemeoryError?
       String fname = (String) filenameParam[0];
-      return !(fname.endsWith("/e562p1_fp.inst3_3d_asm_Nv.20100907_00z+20100909_1200z.nc4") ||
-          fname.endsWith("/tiling.nc4"));
+      return !(fname.endsWith("/e562p1_fp.inst3_3d_asm_Nv.20100907_00z+20100909_1200z.nc4")
+          || fname.endsWith("/tiling.nc4"));
     }
   };
 
@@ -45,9 +45,7 @@ public class TestCdmrNetcdf4 {
     try {
       FileFilter ff = new SuffixFileFilter(".nc4");
       TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/netcdf4", ff, result, false);
-      result = result.stream()
-          .filter(filesToSkip)
-          .collect(Collectors.toList());
+      result = result.stream().filter(filesToSkip).collect(Collectors.toList());
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrNetcdf4.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrNetcdf4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.cdmr.client;
@@ -10,6 +10,8 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -20,20 +22,32 @@ import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.internal.util.CompareArrayToMa2;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
-import ucar.unidata.util.test.category.NeedsExternalResource;
-import ucar.unidata.util.test.category.NotJenkins;
 
 /** Test {@link CdmrNetcdfFile} */
 @RunWith(Parameterized.class)
-@Category({NeedsExternalResource.class, NotJenkins.class, NeedsCdmUnitTest.class}) // Needs CmdrServer to be started up
+@Category(NeedsCdmUnitTest.class)
 public class TestCdmrNetcdf4 {
+
+  private static final Predicate<Object[]> filesToSkip = new Predicate<Object[]>() {
+    @Override
+    public boolean test(Object[] filenameParam) {
+      // these files are removed because they cause an OutOfMemeoryError
+      // todo: why do these cause an OutOfMemeoryError?
+      String fname = (String) filenameParam[0];
+      return !(fname.endsWith("/e562p1_fp.inst3_3d_asm_Nv.20100907_00z+20100909_1200z.nc4") ||
+          fname.endsWith("/tiling.nc4"));
+    }
+  };
+
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {
     List<Object[]> result = new ArrayList<>(500);
     try {
       FileFilter ff = new SuffixFileFilter(".nc4");
       TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "formats/netcdf4", ff, result, false);
-
+      result = result.stream()
+          .filter(filesToSkip)
+          .collect(Collectors.toList());
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrNetcdfFile.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrNetcdfFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.cdmr.client;
@@ -11,19 +11,15 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.internal.util.CompareArrayToMa2;
 import ucar.unidata.util.test.TestDir;
-import ucar.unidata.util.test.category.NeedsExternalResource;
-import ucar.unidata.util.test.category.NotJenkins;
 
 /** Test {@link CdmrNetcdfFile} */
 @RunWith(Parameterized.class)
-@Category({NeedsExternalResource.class, NotJenkins.class}) // Needs CmdrServer to be started up
 public class TestCdmrNetcdfFile {
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblem.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.cdmr.client;
@@ -12,11 +12,9 @@ import ucar.nc2.NetcdfFile;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.internal.util.CompareArrayToMa2;
 import ucar.unidata.util.test.TestDir;
-import ucar.unidata.util.test.category.NeedsExternalResource;
-import ucar.unidata.util.test.category.NotJenkins;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 /** Test {@link CdmrNetcdfFile} */
-@Category({NeedsExternalResource.class, NotJenkins.class}) // Needs CmdrServer to be started up
 public class TestCdmrProblem {
 
   // Send one chunk u(0:2, 0:39, 0:90997) size=43679040 bytes
@@ -24,6 +22,7 @@ public class TestCdmrProblem {
   // Send one chunk u(6:8, 0:39, 0:90997) size=43679040 bytes
   // Send one chunk u(0:0, 0:39, 0:90997) size=14559680 bytes
   @Test
+  @Category(NeedsCdmUnitTest.class)
   public void testChunkProblem() throws Exception {
     String localFilename = "formats/netcdf4/multiDimscale.nc4";
     doOne(TestDir.cdmUnitTestDir + localFilename, "u");

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblemNeeds.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblemNeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.cdmr.client;
@@ -14,11 +14,9 @@ import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.internal.util.CompareArrayToMa2;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
-import ucar.unidata.util.test.category.NeedsExternalResource;
-import ucar.unidata.util.test.category.NotJenkins;
 
 /** Test {@link CdmrNetcdfFile} */
-@Category({NeedsExternalResource.class, NotJenkins.class, NeedsCdmUnitTest.class}) // Needs CmdrServer to be started up
+@Category(NeedsCdmUnitTest.class)
 public class TestCdmrProblemNeeds {
   private final String filename;
   private final String cdmrUrl;

--- a/cdmr/src/test/java/ucar/cdmr/client/TimeCdmr.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TimeCdmr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.cdmr.client;
@@ -15,13 +15,10 @@ import ucar.array.Array;
 import ucar.nc2.Variable;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
-import ucar.unidata.util.test.category.NeedsExternalResource;
-import ucar.unidata.util.test.category.NotJenkins;
 import ucar.unidata.util.test.category.Slow;
 
 /** Time {@link CdmrNetcdfFile} takes ~ 3 minutes */
-@Category({NeedsCdmUnitTest.class, Slow.class, NeedsExternalResource.class, NotJenkins.class}) // Needs CmdrServer to be
-                                                                                               // started up
+@Category({NeedsCdmUnitTest.class, Slow.class})
 public class TimeCdmr {
   String localFilename =
       TestDir.cdmUnitTestDir + "formats/netcdf4/e562p1_fp.inst3_3d_asm_Nv.20100907_00z+20100909_1200z.nc4";


### PR DESCRIPTION
Run a local cdmr server in a forked process for use by the cdmr client tests. Note that a couple of files used by `cdmr/src/test/java/ucar/cdmr/client/TestCdmrNetcdf4.java` result in an `OutOfMemoryError`, but not entirely sure why quite yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/642)
<!-- Reviewable:end -->
