### PR TITLE
fix issues with update existing nc4

### DIFF
--- a/.github/workflows/tds-check.yml
+++ b/.github/workflows/tds-check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fetch latest AdoptOpenJDK 8 (hotspot) built for linux"
         run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk8-hs.tar.gz
       - name: Setup Latest AdoptOpenJDK (hotspot) 8
-        uses: actions/setup-java@master
+        uses: actions/setup-java@v1
         with:
           java-version: 8
           architecture: x64
@@ -65,7 +65,7 @@ jobs:
       - name: Fetch latest AdoptOpenJDK 8 (hotspot) built for linux"
         run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk8-hs.tar.gz
       - name: Setup Latest AdoptOpenJDK (hotspot) 8
-        uses: actions/setup-java@master
+        uses: actions/setup-java@v1
         with:
           java-version: 8
           architecture: x64

--- a/.github/workflows/tds-check.yml
+++ b/.github/workflows/tds-check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fetch latest AdoptOpenJDK 8 (hotspot) built for linux"
         run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk8-hs.tar.gz
       - name: Setup Latest AdoptOpenJDK (hotspot) 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@master
         with:
           java-version: 8
           architecture: x64
@@ -65,7 +65,7 @@ jobs:
       - name: Fetch latest AdoptOpenJDK 8 (hotspot) built for linux"
         run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk8-hs.tar.gz
       - name: Setup Latest AdoptOpenJDK (hotspot) 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@master
         with:
           java-version: 8
           architecture: x64

--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -355,6 +355,9 @@ public class NetcdfFiles {
    * @return a canonical URI string.
    */
   public static String canonicalizeUriString(String location) {
+    if (location == null) {
+      return null;
+    }
     // get rid of file prefix, if any
     String uriString = location.trim();
     if (uriString.startsWith("file://"))

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3iospWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3iospWriter.java
@@ -18,11 +18,7 @@ import ucar.ma2.Range;
 import ucar.ma2.Section;
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureMembers;
-import ucar.nc2.Attribute;
-import ucar.nc2.Dimension;
-import ucar.nc2.NetcdfFile;
-import ucar.nc2.Structure;
-import ucar.nc2.Variable;
+import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.iosp.IOServiceProvider;
 import ucar.nc2.iosp.IOServiceProviderWriter;
@@ -65,9 +61,11 @@ public class N3iospWriter extends N3iospNew implements IOServiceProviderWriter {
     }
 
     raf.order(RandomAccessFile.BIG_ENDIAN);
-    N3headerWriter headerw = new N3headerWriter(this, raf, ncfile);
-    headerw.initFromExisting((N3iospNew) this.iosp); // hack-a-whack
-    this.header = headerw;
+    this.header = new N3headerWriter(this, raf, ncfile);
+    Group.Builder rootGroup = Group.builder().setName("").setNcfile(ncfile);
+    header.read(raf, rootGroup, null);
+    ncfile.setRootGroup(rootGroup.build());
+    ncfile.finish();
   }
 
   @Override

--- a/cdm/core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
@@ -26,7 +26,6 @@ import ucar.nc2.Dimensions;
 import ucar.nc2.Group;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFileWriter;
-import ucar.nc2.NetcdfFiles;
 import ucar.nc2.Structure;
 import ucar.nc2.Variable;
 import ucar.nc2.internal.iosp.netcdf3.N3iospWriter;
@@ -59,11 +58,8 @@ public class NetcdfFormatWriter implements Closeable {
    * @return existing file that can be written to
    * @throws IOException on I/O error
    */
-  public static NetcdfFormatWriter.Builder openExisting(String location) throws IOException {
-    try (NetcdfFile ncfile = NetcdfFiles.open(location)) {
-      Group.Builder root = ncfile.getRootGroup().toBuilder();
-      return builder().setRootGroup(root).setLocation(location).setIosp(ncfile.getIosp());
-    }
+  public static NetcdfFormatWriter.Builder openExisting(String location) {
+    return builder().setNewFile(false).setLocation(location);
   }
 
   /**
@@ -289,7 +285,7 @@ public class NetcdfFormatWriter implements Closeable {
     this.chunker = builder.chunker;
     this.useJna = builder.useJna || format.isNetdf4format();
 
-    this.ncout = NetcdfFile.builder().setRootGroup(builder.rootGroup).build();
+    this.ncout = NetcdfFile.builder().setRootGroup(builder.rootGroup).setLocation(builder.location).build();
     this.rootGroup = this.ncout.getRootGroup();
 
     if (!isNewFile) {

--- a/cdm/core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
@@ -20,14 +20,8 @@ import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Section;
 import ucar.ma2.StructureData;
-import ucar.nc2.Attribute;
-import ucar.nc2.Dimension;
-import ucar.nc2.Dimensions;
-import ucar.nc2.Group;
-import ucar.nc2.NetcdfFile;
-import ucar.nc2.NetcdfFileWriter;
-import ucar.nc2.Structure;
-import ucar.nc2.Variable;
+import ucar.nc2.*;
+import ucar.nc2.internal.iosp.netcdf3.N3iospNew;
 import ucar.nc2.internal.iosp.netcdf3.N3iospWriter;
 import ucar.nc2.iosp.IOServiceProvider;
 import ucar.nc2.iosp.IOServiceProviderWriter;
@@ -316,7 +310,7 @@ public class NetcdfFormatWriter implements Closeable {
       }
       spiw = spi;
     } else {
-      spiw = new N3iospWriter(builder.getIosp());
+      spiw = new N3iospWriter(new N3iospNew());
     }
 
     // If anything fails, make sure that resources are closed.

--- a/docs/src/test/java/examples/cdmdatasets/WritingNetcdfTutorial.java
+++ b/docs/src/test/java/examples/cdmdatasets/WritingNetcdfTutorial.java
@@ -303,11 +303,10 @@ public class WritingNetcdfTutorial {
    * @param strategyType
    * @param dl
    * @param shfl
-   * @param nc4format
    * @return created netCDF-4 file
    */
   public static NetcdfFile writeWithCompression(NetcdfFile inFile, String outFilePath,
-      Nc4Chunking.Strategy strategyType, int dl, boolean shfl, NetcdfFileFormat nc4format) {
+      Nc4Chunking.Strategy strategyType, int dl, boolean shfl) {
     // 1) Create an Nc4Chunking object
     Nc4Chunking.Strategy type = strategyType;
     int deflateLevel = dl;
@@ -315,7 +314,6 @@ public class WritingNetcdfTutorial {
     Nc4Chunking chunker = Nc4ChunkingStrategy.factory(type, deflateLevel, shuffle);
 
     // 3) Create a new netCDF-4 file builder with the given path and file name and Nc4Chunking object
-    NetcdfFileFormat format = nc4format;
     NetcdfFormatWriter.Builder builder =
         NetcdfFormatWriter.createNewNetcdf4(NetcdfFileFormat.NETCDF4, outFilePath, chunker);
 

--- a/docs/src/test/java/tests/cdmdatasets/TestWritingNetcdfTutorial.java
+++ b/docs/src/test/java/tests/cdmdatasets/TestWritingNetcdfTutorial.java
@@ -214,7 +214,7 @@ public class TestWritingNetcdfTutorial {
 
     String datasetOut = tempFolder.newFile().getAbsolutePath();
     NetcdfFile ncOut = WritingNetcdfTutorial.writeWithCompression(ncIn, datasetOut,
-        Nc4Chunking.Strategy.standard, 0, false, NetcdfFileFormat.NETCDF4);
+        Nc4Chunking.Strategy.standard, 0, false);
 
     assertThat(ncOut).isNotNull();
     assertThat(new CompareNetcdf2().compare(ncIn, ncOut)).isTrue();


### PR DESCRIPTION
closes #644 

- sets location property for ncfile in NetcdfFormatWriter (fixes null pointer)
- sets newFile property to false when openExisting is called
- removes call to NetcdfFiles.open within openExisting (rootGroup is now set within nc3iosp._open)
- removes unused line in WritingNetcdfTutorial code snippet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/645)
<!-- Reviewable:end -->
