### PR TITLE
Fix jdk14 logging.

### DIFF
--- a/cdm-test-utils/src/main/java/ucar/unidata/util/test/TestDir.java
+++ b/cdm-test-utils/src/main/java/ucar/unidata/util/test/TestDir.java
@@ -73,7 +73,6 @@ public class TestDir {
   private static final String testdataDirPropName = "unidata.testdata.path";
 
   /** Path to the Unidata test data. see "https://github.com/Unidata/thredds-test-data". */
-  // -Dunidata.testdata.path=D:/testData/thredds-test-data/local/thredds-test-data/
   private static String testdataDir;
 
   /** Unidata test data for the CDM. testdataDir + CdmUnitTest. */

--- a/cdm/core/src/main/java/ucar/nc2/internal/util/CompareArrayToMa2.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/util/CompareArrayToMa2.java
@@ -75,7 +75,7 @@ public class CompareArrayToMa2 {
     } else {
       ucar.ma2.Array org = vorg.read();
       Array<?> array = vnew.readArray();
-      System.out.printf("  read cariable %s %s%n", vorg.getDataType(), vorg.getNameAndDimensions());
+      System.out.printf("  read variable %s %s%n", vorg.getDataType(), vorg.getNameAndDimensions());
       Formatter f = new Formatter();
       boolean ok1 = CompareArrayToMa2.compareData(f, vorg.getShortName(), org, array, justOne, true);
       if (!ok1) {

--- a/cdm/core/src/main/java/ucar/nc2/util/Misc.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/Misc.java
@@ -202,4 +202,13 @@ public class Misc {
       f.format("Misc.compare %d ints, %d are different%n", len, ndiff);
     return ok;
   }
+
+  public static void showClassPath() {
+    System.out.println("Working Directory = " + System.getProperty("user.dir"));
+    String classpath = System.getProperty("java.class.path");
+    System.out.printf("Classpath =%n");
+    for (String cp : classpath.split(":")) {
+      System.out.printf("  %s%n", cp);
+    }
+  }
 }

--- a/cdmr/build.gradle
+++ b/cdmr/build.gradle
@@ -26,7 +26,9 @@ dependencies {
   compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
 
   runtimeOnly "io.grpc:grpc-netty-shaded:${depVersion.grpc}"
+  runtimeOnly "org.slf4j:slf4j-jdk14"
 
+  testRuntimeOnly "org.slf4j:slf4j-jdk14:${depVersion.slf4j}"
   testImplementation enforcedPlatform(project(':netcdf-java-testing-platform'))
   testImplementation project(':cdm-test-utils')
   testImplementation 'com.google.truth:truth'
@@ -34,8 +36,6 @@ dependencies {
   testImplementation 'commons-io:commons-io'
   testImplementation "org.mockito:mockito-core"
   testImplementation "io.grpc:grpc-testing:${depVersion.grpc}"
-
-  testRuntimeOnly 'ch.qos.logback:logback-classic'
 }
 
 protobuf {

--- a/cdmr/src/main/java/ucar/cdmr/server/CdmrServer.java
+++ b/cdmr/src/main/java/ucar/cdmr/server/CdmrServer.java
@@ -84,6 +84,12 @@ public class CdmrServer {
   /** Main launches the server from the command line. */
   public static void main(String[] args) throws IOException, InterruptedException {
     System.out.println("Working Directory = " + System.getProperty("user.dir"));
+    String classpath = System.getProperty("java.class.path");
+    System.out.printf("Classpath =%n");
+    for (String cp : classpath.split(":")) {
+      System.out.printf("  %s%n", cp);
+    }
+
     final CdmrServer server = new CdmrServer();
     server.start();
     server.blockUntilShutdown();

--- a/cdmr/src/main/resources/logging.cfg
+++ b/cdmr/src/main/resources/logging.cfg
@@ -1,0 +1,6 @@
+handlers=java.util.logging.ConsoleHandler
+.level = FINE
+io.grpc.level=INFO
+ucar.nc2.level=INFO
+java.util.logging.ConsoleHandler.level=FINE
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblem.java
+++ b/cdmr/src/test/java/ucar/cdmr/client/TestCdmrProblem.java
@@ -14,6 +14,9 @@ import ucar.nc2.internal.util.CompareArrayToMa2;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /** Test {@link CdmrNetcdfFile} */
 public class TestCdmrProblem {
 
@@ -24,26 +27,29 @@ public class TestCdmrProblem {
   @Test
   @Category(NeedsCdmUnitTest.class)
   public void testChunkProblem() throws Exception {
-    String localFilename = "formats/netcdf4/multiDimscale.nc4";
-    doOne(TestDir.cdmUnitTestDir + localFilename, "u");
+    String localFilename = TestDir.cdmUnitTestDir + "formats/netcdf4/multiDimscale.nc4";
+    Path path = Paths.get(localFilename);
+    doOne(path, "u");
   }
 
   @Test
   public void testOpaqueDataType() throws Exception {
-    String localFilename = "hdf5/test_atomic_types.nc";
-    doOne(TestDir.cdmLocalFromTestDataDir + localFilename);
+    String localFilename = TestDir.cdmLocalFromTestDataDir + "hdf5/test_atomic_types.nc";
+    Path path = Paths.get(localFilename);
+    doOne(path);
   }
 
   @Test
   public void testCdmrProblem2() throws Exception {
-    String localFilename = "dataset/SimpleGeos/hru_soil_moist_vlen_3hru_5timestep.nc";
-    doOne(TestDir.cdmLocalFromTestDataDir + localFilename);
+    String localFilename = TestDir.cdmLocalFromTestDataDir + "dataset/SimpleGeos/hru_soil_moist_vlen_3hru_5timestep.nc";
+    Path path = Paths.get(localFilename);
+    doOne(path);
   }
 
-  public void doOne(String filename) throws Exception {
+  public void doOne(Path path) throws Exception {
     // LOOK kludge for now. Also, need to auto start up CmdrServer
-    String cdmrUrl = "cdmr://localhost:16111/" + filename;
-    try (NetcdfFile ncfile = NetcdfDatasets.openFile(filename, null);
+    String cdmrUrl = "cdmr://localhost:16111/" + path.toAbsolutePath();
+    try (NetcdfFile ncfile = NetcdfDatasets.openFile(path.toString(), null);
         CdmrNetcdfFile cdmrFile = CdmrNetcdfFile.builder().setRemoteURI(cdmrUrl).build()) {
 
       boolean ok = CompareArrayToMa2.compareFiles(ncfile, cdmrFile);
@@ -51,10 +57,10 @@ public class TestCdmrProblem {
     }
   }
 
-  public void doOne(String filename, String varName) throws Exception {
+  public void doOne(Path path, String varName) throws Exception {
     // LOOK kludge for now. Also, need to auto start up CmdrServer
-    String cdmrUrl = "cdmr://localhost:16111/" + filename;
-    try (NetcdfFile ma2File = NetcdfDatasets.openFile(filename, null);
+    String cdmrUrl = "cdmr://localhost:16111/" + path.toAbsolutePath();
+    try (NetcdfFile ma2File = NetcdfDatasets.openFile(path.toString(), null);
         CdmrNetcdfFile arrayFile = CdmrNetcdfFile.builder().setRemoteURI(cdmrUrl).build()) {
 
       boolean ok = CompareArrayToMa2.compareVariable(ma2File, arrayFile, varName, true);

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -47,6 +47,7 @@ repositories {
 // Executes the given closure against all objects in this collection, and any objects subsequently added to this
 // collection. See org.gradle.api.DomainObjectCollection.all(Closure)
 
+/*
 configurations.all {
   resolutionStrategy.dependencySubstitution {
     // Replace every instance of "commons-logging" in the dependency tree with "jcl-over-slf4j". This effectively
@@ -61,4 +62,4 @@ configurations.all {
     //
     substitute module('commons-logging:commons-logging') because 'we want to control JCL logging with slf4j' with module("org.slf4j:jcl-over-slf4j:${depVersion.slf4j}")
   }
-}
+} */

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     // netcdf-java logging
     api "org.slf4j:slf4j-api:${depVersion.slf4j}"
     runtime 'ch.qos.logback:logback-classic:1.2.3'
+    runtime "org.slf4j:slf4j-jdk14:${depVersion.slf4j}"
 
     ///////////////////////
     // toolsUI GUI stuff //


### PR DESCRIPTION
Remove "Replace every instance of "commons-logging" in the dependency tree with "jcl-over-slf4j" in dependencies.gradle. This interferes with ability to control grpc logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/650)
<!-- Reviewable:end -->
