### PR TITLE
update reading/writing cdm pages to explain immutable Array types

### DIFF
--- a/docs/userguide/src/site/pages/cdmdatasets/readingcdm.md
+++ b/docs/userguide/src/site/pages/cdmdatasets/readingcdm.md
@@ -7,8 +7,8 @@ toc: false
 ---
 ## Tutorial: Working with NetcdfFile
 
-A `NetcdfFile` provides read-only access to datasets through the netCDF API (to write data, use `NetcdfFileWriteable`).
-Use the static `NetcdfFiles.open` methods to open a netCDF file, an HDF5 file, or any other file which has an &nbsp;[`IOServiceProvider`](writing_iosp.html) implementation that can read the file with the NetCDF API.
+A `NetcdfFile` provides read-only access to datasets through the netCDF API (to write data, use `NetcdfFormatWriter`).
+Use the static `NetcdfFiles.open` methods to open a netCDF file, an HDF5 file, or any other file which has an [`IOServiceProvider`](writing_iosp.html) implementation that can read the file with the NetCDF API.
 Use [`NetcdfDataset.openFile`](netcdf_dataset.html) for more general reading capabilities, including **OPeNDAP**, **NcML**, and **THREDDS** datasets.
 
 Read access for some file types is provided through optional modules and must be included in your netCDF build as [artifacts](using_netcdf_java_artifacts.html).
@@ -132,6 +132,16 @@ lists of `Ranges` and origin, shape arrays. To create a `Section` from a list of
 {% endcapture %}
 {{ rmd | markdownify }}
 
+#### Reading scalar data
+
+Data from a `Variable` is always read into an `Array`, however the `getScalar` convenience method converts the`Array` to a scalar. 
+If you know the data type, you can read any `Variable` into a scalar numeric:
+
+{% capture rmd %}
+{% includecodeblock netcdf-java&docs/userguide/src/test/java/examples/cdmdatasets/ReadingCdmTutorial.java&readScalars %}
+{% endcapture %}
+{{ rmd | markdownify }}
+
 ## Iterating data in Arrays
 
 Once you have read the data in, you usually have an `Array` object to work with.
@@ -155,6 +165,16 @@ If you know the Array's rank and type, you can cast to the appropriate subclass 
 
 {% capture rmd %}
 {% includecodeblock netcdf-java&docs/userguide/src/test/java/examples/cdmdatasets/ReadingCdmTutorial.java&castDataArray %}
+{% endcapture %}
+{{ rmd | markdownify }}
+
+## Working with data read from a NetCDF (6.0+)
+
+As of netCDF-Java 6.0, all objects used for reads and writes are immutable. Data read by netCDF-Java is returned as an immutable `ucar.array.Array<T>` object. 
+If you would like to do any data manipulation on the read data, you will need to use the `Arrays.copyPrimitiveArray` method, which will return a 1D primitive array of the data:
+
+{% capture rmd %}
+{% includecodeblock netcdf-java&docs/userguide/src/test/java/examples/cdmdatasets/ReadingCdmTutorial.java&copyData %}
 {% endcapture %}
 {{ rmd | markdownify }}
 

--- a/docs/userguide/src/site/pages/cdmdatasets/writing_netcdf.md
+++ b/docs/userguide/src/site/pages/cdmdatasets/writing_netcdf.md
@@ -77,6 +77,11 @@ To open an existing CDM file for writing:
 #### Writing data to a new or existing file
 
 In both cases (new and existing files) the data writing is the same. 
+
+*Note:* As of netCDF-Java 6.0, all objects used by read and writes are immutable, to ensure you data is not changed. 
+The `ucar.ma2.Array` has been deprecated and replaced by the immutable `ucar.array.Array` class, which does not support data manipulation (e.g. permute, transpose, etc.). 
+This means that users must handle data manipulation prior to beginning write operations, as the netCDF-Java library expects to be given a `ucar.array.Array` object that is ready to be written. 
+
 The following examples demonstrate several ways to write data to an opened file.
 
 1) Writing numeric data:

--- a/docs/userguide/src/test/java/examples/cdmdatasets/ReadingCdmTutorial.java
+++ b/docs/userguide/src/test/java/examples/cdmdatasets/ReadingCdmTutorial.java
@@ -178,8 +178,7 @@ public class ReadingCdmTutorial {
 
   /**
    * Tutorial code snippet to convert Range to origin and size
-   * 
-   * @param v: variable to be read
+   *
    * @return array of read data
    * @throws IOException
    * @throws InvalidRangeException
@@ -191,6 +190,20 @@ public class ReadingCdmTutorial {
     int[] origins = section.getOrigin();
     int[] shape = section.getShape();
     return Arrays.asList(origins, shape); /* DOCS-IGNORE */
+  }
+
+  /**
+   * Tutorial code snippet to read numeric scalar
+   *
+   * @param intVar
+   * @param doubleVar
+   * @return array scalar values as double, float, and int types
+   * @throws IOException
+   */
+  public static List<Object> readScalars(Variable intVar, Variable doubleVar) throws IOException {
+    int ival = ((Array<Integer>)intVar.readArray()).getScalar();
+    double dval = ((Array<Double>)doubleVar.readArray()).getScalar();
+    return Arrays.asList(ival, dval); /* DOCS-IGNORE */
   }
 
   /**
@@ -257,6 +270,17 @@ public class ReadingCdmTutorial {
       }
     }
     return list; /* DOCS-IGNORE */
+  }
+
+  /**
+   * Tutorial code snippet to copy array data
+   */
+  public static double[] copyData(Variable v) throws IOException {
+    Array<Double> dataSrc = (Array<Double>) v.readArray(); // data to be copied
+    double[] dest = (double[])ucar.array.Arrays.copyPrimitiveArray(dataSrc);
+    // do something with copied data here
+    // ...
+    return dest; /* DOCS-IGNORE */
   }
 
   /**

--- a/docs/userguide/src/test/java/examples/cdmdatasets/WritingNetcdfTutorial.java
+++ b/docs/userguide/src/test/java/examples/cdmdatasets/WritingNetcdfTutorial.java
@@ -127,11 +127,15 @@ public class WritingNetcdfTutorial {
       a[i] = (i * 1000000);
     }
 
-    // 2) Create an Array of doubles from the primitive array
+    // 2) Create an immutable Array<Double> from the primitive array
     Array<Double> A = Arrays.factory(ArrayType.DOUBLE, shape, a);
 
-    // 2) Write the data to the temperature Variable, with origin all zeros.
-    // origin array is coeverted ti immutable Index with `Index.of`
+    // 3) Or create an evenly spaced Array of doubles
+    // public Array<T> makeArray(ArrayType type, int npts, double start, double incr, int... shape)
+    Array<Double> A2 = Arrays.makeArray(ArrayType.DOUBLE, 20, 0, 5, 4,5 );
+
+    // 4) Write the data to the temperature Variable, with origin all zeros.
+    // origin array is converted to an immutable Index with `Index.of`
     int[] origin = new int[2]; // initialized to zeros
     try {
       writer.write(v, Index.of(origin), A);
@@ -149,14 +153,13 @@ public class WritingNetcdfTutorial {
   public static void writeCharData(NetcdfFormatWriter writer, String varName) {
     // write char variable as String
     Variable v = writer.findVariable(varName);
-    int[] shape = v.getShape();
 
-    // 1) Create an Array of Chars
+    // 1) Create an immutable Array<char>> from primitive strings
     Array<Character> ac = Arrays.factory(ArrayType.CHAR, new int[]{someStringValue.length()}, someStringValue.toCharArray());
 
     // 2) Write the data. The origin parameter is initilized with zeros using the rank of the variable
     try {
-      writer.write(v, Index.ofRank(shape.length), ac);
+      writer.write(v, Index.ofRank(v.getRank()), ac);
     } catch (IOException | InvalidRangeException e) {
       logger.log(yourWriteNetcdfFileErrorMsgTxt);
     }

--- a/docs/userguide/src/test/java/tests/cdmdatasets/TestReadingCdmTutorial.java
+++ b/docs/userguide/src/test/java/tests/cdmdatasets/TestReadingCdmTutorial.java
@@ -146,6 +146,14 @@ public class TestReadingCdmTutorial {
   }
 
   @Test
+  public void testReadScalarTutorial() throws IOException {
+    // test double, float, and int scalars
+    List data = ReadingCdmTutorial.readScalars(varScalar, var3d);
+    assertThat(data.get(0)).isInstanceOf(Integer.class);
+    assertThat(data.get(1)).isInstanceOf(Double.class);
+  }
+
+  @Test
   public void testReadInLoopRangesTutorial() throws IOException, InvalidRangeException {
     ReadingCdmTutorial.logger.clearLog();
     ReadingCdmTutorial.readInLoopRanges(var3d);
@@ -182,6 +190,13 @@ public class TestReadingCdmTutorial {
   public void testCastDataArrayTutorial() throws IOException {
     List list = ReadingCdmTutorial.castDataArray(var3d);
     assertThat(list.size()).isEqualTo(var3d.getSize());
+  }
+
+  @Test
+  public void testCopyToPrimitiveTutorial() throws IOException {
+    double[] data = ReadingCdmTutorial.copyData(var3d);
+    assertThat(data).isNotEmpty();
+    assertThat(data.length).isEqualTo(var3d.getSize());
   }
 
   @Test


### PR DESCRIPTION
Reading

- add getScalar tutorial back in
- explain immutability of read data
- Tutorial on copying read data into mutable, primitive type

Writing

- explain immutability of writes
- include example of `Arrays.makeArray` along with `Arrays.factory`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/675)
<!-- Reviewable:end -->
