### PR TITLE
Fix nested Aggregations.

### DIFF
--- a/cdm-core/src/main/java/ucar/nc2/dataset/DatasetUrl.java
+++ b/cdm-core/src/main/java/ucar/nc2/dataset/DatasetUrl.java
@@ -118,7 +118,7 @@ public class DatasetUrl {
     if (serviceType == ServiceType.NCML) { // ??
       // If lead protocol was null, then pretend it was a file
       // Note that technically, this should be 'file://'
-      trueUrl = (allProtocols.isEmpty() ? "file:" + trueUrl : location);
+      trueUrl = (allProtocols.isEmpty() ? "file:" + trueUrl : trueUrl);
     }
 
     // Add back the query and fragment (if any)

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
@@ -189,8 +189,7 @@ class AggDatasetOuter extends AggDataset {
           throw new IllegalArgumentException("Dimension not found= " + aggregationOuter.dimName);
 
         if (debugOpenFile)
-          System.out.printf("  --getNcoords for location %s getNcoords %d%n",
-                this.cacheLocation, ncoord);
+          System.out.printf("  --getNcoords for location %s getNcoords %d%n", this.cacheLocation, ncoord);
       }
     }
     return ncoord;

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
@@ -27,6 +27,8 @@ import ucar.nc2.util.CancelTask;
 
 /** Encapsulates a NetcdfFile that is a component of the aggregation. */
 class AggDatasetOuter extends AggDataset {
+  private static final boolean debugOpenFile = true;
+
   private final AggregationOuter aggregationOuter;
   @Nullable
   final String coordValue; // if theres a coordValue on the netcdf element - may be multiple, blank seperated
@@ -185,6 +187,10 @@ class AggDatasetOuter extends AggDataset {
           ncoord = d.getLength();
         else
           throw new IllegalArgumentException("Dimension not found= " + aggregationOuter.dimName);
+
+        if (debugOpenFile)
+          System.out.printf("  --getNcoords for location %s getNcoords %d%n",
+                this.cacheLocation, ncoord);
       }
     }
     return ncoord;

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/Aggregation.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/Aggregation.java
@@ -20,7 +20,7 @@ import java.util.*;
 import java.util.concurrent.Executor;
 
 /**
- * Superclass for NcML Aggregation Builder.
+ * Superclass for NcML Aggregation Builders.
  * An Aggregation acts as a ProxyReader for VariableDS. That, is it must implement:
  * 
  * <pre>
@@ -439,7 +439,7 @@ public abstract class Aggregation {
     setDatasetAcquireProxy(proxy, newds.rootGroup);
   }
 
-  private void setDatasetAcquireProxy(AggProxyReader proxy, Group.Builder g) throws IOException {
+  private void setDatasetAcquireProxy(AggProxyReader proxy, Group.Builder g) {
 
     // all normal (non agg) variables must use a proxy to lock the file
     for (Variable.Builder<?> vb : g.vbuilders) {

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggregationOuter.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggregationOuter.java
@@ -42,7 +42,7 @@ import ucar.nc2.util.CancelTask;
 
 import javax.annotation.Nullable;
 
-/** Superclass for Aggregations on the outer dimension: joinNew, joinExisting, Fmrc, FmrcSingle */
+/** Superclass for Aggregations on the outer dimension: joinNew, joinExisting */
 abstract class AggregationOuter extends Aggregation implements ProxyReader {
   protected static boolean debugCache, debugInvocation, debugStride;
   public static int invocation; // debugging
@@ -304,46 +304,6 @@ abstract class AggregationOuter extends Aggregation implements ProxyReader {
       promotedVar.setSPobject(pv);
     }
   }
-
-  /*
-   * protected void rebuildDataset() throws IOException {
-   * buildCoords(null);
-   * Group.Builder rootGroup = ncDataset.rootGroup;
-   * 
-   * // reset dimension length
-   * rootGroup.resetDimensionLength(dimName, getTotalCoords());
-   * 
-   * // reset coordinate var
-   * Variable.Builder joinAggCoord = rootGroup.findVariable(dimName).orElseThrow(IllegalStateException::new);
-   * joinAggCoord.setDimensionsByName(dimName); // reset its dimension LOOK is this needed?
-   * joinAggCoord.resetCache(); // get rid of any cached data, since its now wrong
-   * 
-   * // reset agg variables LOOK is this needed?
-   * for (Variable.Builder aggVar : aggVars) {
-   * // aggVar.setDimensions(dimName); // reset its dimension
-   * aggVar.resetDimensions(); // reset its dimensions
-   * aggVar.invalidateCache(); // get rid of any cached data, since its now wrong
-   * }
-   * 
-   * // reset the typical dataset, where non-agg variables live
-   * AggDataset typicalDataset = getTypicalDataset();
-   * for (Variable.Builder var : rootGroup.vbuilders) {
-   * if (aggVars.contains(var) || dimName.equals(var.shortName))
-   * continue;
-   * AggProxyReader proxy = new AggProxyReader(typicalDataset);
-   * var.setProxyReader(proxy);
-   * }
-   * 
-   * // reset cacheVars
-   * for (CacheVar cv : cacheList) {
-   * cv.reset();
-   * }
-   * 
-   * if (timeUnitsChange) {
-   * readTimeCoordinates(joinAggCoord, null);
-   * }
-   * }
-   */
 
   /////////////////////////////////////////////////////////////////////////////////////
 
@@ -899,7 +859,5 @@ abstract class AggregationOuter extends Aggregation implements ProxyReader {
     for (Variable.Builder<?> v : ncDataset.rootGroup.vbuilders) {
       f.format("   %20s proxy %s%n", v.shortName, v.proxyReader == null ? "" : v.proxyReader.getClass().getName());
     }
-
-
   }
 }

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlElementReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlElementReader.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ *  See LICENSE for license information.
+ */
+
+package ucar.nc2.internal.ncml;
+
+import org.jdom2.Element;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.dataset.DatasetUrl;
+import ucar.nc2.util.CancelTask;
+
+import java.io.IOException;
+
+class NcmlElementReader extends NcmlReader implements ucar.nc2.internal.cache.FileFactory {
+  private final Element netcdfElem;
+  private final String ncmlLocation;
+  private final String location;
+
+  NcmlElementReader(String ncmlLocation, String location, Element netcdfElem) {
+    this.ncmlLocation = ncmlLocation;
+    this.location = location;
+    this.netcdfElem = netcdfElem;
+  }
+
+  public NetcdfFile open(DatasetUrl cacheName, int buffer_size, CancelTask cancelTask, Object spiObject)
+          throws IOException {
+    NetcdfFile.Builder<?> result = readNcml(ncmlLocation, location, netcdfElem, cancelTask);
+    result.setLocation(cacheName.getTrueurl());
+    return result.build();
+  }
+}

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlElementReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlElementReader.java
@@ -1,6 +1,6 @@
 /*
- *  Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
- *  See LICENSE for license information.
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
  */
 
 package ucar.nc2.internal.ncml;
@@ -23,8 +23,9 @@ class NcmlElementReader extends NcmlReader implements ucar.nc2.internal.cache.Fi
     this.netcdfElem = netcdfElem;
   }
 
+  @Override
   public NetcdfFile open(DatasetUrl cacheName, int buffer_size, CancelTask cancelTask, Object spiObject)
-          throws IOException {
+      throws IOException {
     NetcdfFile.Builder<?> result = readNcml(ncmlLocation, location, netcdfElem, cancelTask);
     result.setLocation(cacheName.getTrueurl());
     return result.build();

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -343,19 +343,18 @@ public class NcmlReader {
   private final Formatter errlog = new Formatter();
 
   /**
-   * This sets up the target dataset and the referenced dataset. only place that iospParam is processed, so everything
-   * must go through here
+   * This sets up the target dataset and the referenced dataset.
+   * This is only place that iospParam is processed, so everything must go through here
    *
    * @param ncmlLocation the URL location string of the NcML document, used to resolve reletive path of the referenced
-   *        dataset, or
-   *        may be just a unique name for caching purposes.
+   *        dataset, or may be just a unique name for caching purposes.
    * @param referencedDatasetUri refers to this dataset (may be null)
    * @param netcdfElem JDOM netcdf element
    * @param cancelTask allow user to cancel the task; may be null
    * @return NetcdfDataset the constructed dataset
    * @throws IOException on read error, or bad referencedDatasetUri URI
    */
-  private NetcdfDataset.Builder<?> readNcml(String ncmlLocation, @Nullable String referencedDatasetUri,
+  NetcdfDataset.Builder<?> readNcml(String ncmlLocation, @Nullable String referencedDatasetUri,
       Element netcdfElem, @Nullable CancelTask cancelTask) throws IOException {
 
     // get ncml namespace and set namespace variable
@@ -1320,76 +1319,6 @@ public class NcmlReader {
     } else if (type.equalsIgnoreCase("union")) {
       agg = new AggregationUnion(builder, dimName, recheck);
 
-      /*
-       * } else if (type.equalsIgnoreCase("tiled")) {
-       * agg = new AggregationTiled(builder, dimName, recheck);
-       *
-       * } else if (type.equalsIgnoreCase("forecastModelRunCollection")
-       * || type.equalsIgnoreCase("forecastModelRunSingleCollection")) {
-       * AggregationFmrc aggc = new AggregationFmrc(newds, dimName, recheck);
-       * agg = aggc;
-       *
-       * // nested scanFmrc elements
-       * java.util.List<Element> scan2List = aggElem.getChildren("scanFmrc", ncNS);
-       * for (Element scanElem : scan2List) {
-       * String dirLocation = scanElem.getAttributeValue("location");
-       * if (dirLocation != null)
-       * dirLocation = AliasTranslator.translateAlias(dirLocation);
-       * String regexpPatternString = scanElem.getAttributeValue("regExp");
-       * String suffix = scanElem.getAttributeValue("suffix");
-       * String subdirs = scanElem.getAttributeValue("subdirs");
-       * String olderS = scanElem.getAttributeValue("olderThan");
-       *
-       * String runMatcher = scanElem.getAttributeValue("runDateMatcher");
-       * String forecastMatcher = scanElem.getAttributeValue("forecastDateMatcher");
-       * String offsetMatcher = scanElem.getAttributeValue("forecastOffsetMatcher");
-       *
-       * // possible relative location
-       * dirLocation = URLnaming.resolve(ncmlLocation, dirLocation);
-       *
-       * if (dirLocation != null) {
-       * aggc.addDirectoryScanFmrc(dirLocation, suffix, regexpPatternString, subdirs, olderS, runMatcher,
-       * forecastMatcher, offsetMatcher);
-       * }
-       *
-       * if ((cancelTask != null) && cancelTask.isCancel())
-       * return agg;
-       * if (debugAggDetail)
-       * System.out.println(" debugAgg: nested dirLocation = " + dirLocation);
-       * }
-       *
-       * // add explicit files to the agg (i.e. not from a scanned directory)
-       * Map<String, String> realLocationRunTimeMap = new HashMap<>();
-       * List<String> realLocationList = new ArrayList<>();
-       * java.util.List<Element> ncList = aggElem.getChildren("netcdf", ncNS);
-       * for (Element netcdfElemNested : ncList) {
-       * String location = netcdfElemNested.getAttributeValue("location");
-       * if (location == null)
-       * location = netcdfElemNested.getAttributeValue("url");
-       * if (location != null)
-       * location = AliasTranslator.translateAlias(location);
-       *
-       * String runTime = netcdfElemNested.getAttributeValue("coordValue");
-       * if (runTime == null) {
-       * Formatter f = new Formatter();
-       * f.format("runtime must be explicitly defined for each netcdf element using the attribute coordValue");
-       * log.error(f.toString());
-       * }
-       *
-       * String realLocation = URLnaming.resolveFile(ncmlLocation, location);
-       * realLocationRunTimeMap.put(realLocation, runTime);
-       * realLocationList.add(realLocation);
-       *
-       * if ((cancelTask != null) && cancelTask.isCancel())
-       * return aggc;
-       * if (debugAggDetail)
-       * System.out.println(" debugAgg: nested dataset = " + location);
-       * }
-       *
-       * if (!realLocationRunTimeMap.isEmpty()) {
-       * aggc.addExplicitFilesAndRunTimes(realLocationRunTimeMap);
-       * }
-       */
     } else {
       throw new IllegalArgumentException("Unsupported aggregation type=" + type);
     }
@@ -1535,28 +1464,6 @@ public class NcmlReader {
     }
 
     return agg;
-  }
-
-  private class NcmlElementReader implements ucar.nc2.internal.cache.FileFactory {
-    private final Element netcdfElem;
-    private final String ncmlLocation;
-    private final String location;
-
-    NcmlElementReader(String ncmlLocation, String location, Element netcdfElem) {
-      this.ncmlLocation = ncmlLocation;
-      this.location = location;
-      this.netcdfElem = netcdfElem;
-    }
-
-    public NetcdfFile open(DatasetUrl cacheName, int buffer_size, CancelTask cancelTask, Object spiObject)
-        throws IOException {
-      if (debugAggDetail) {
-        System.out.println(" NcmlElementReader open nested dataset " + cacheName);
-      }
-      NetcdfFile.Builder<?> result = readNcml(ncmlLocation, location, netcdfElem, cancelTask);
-      result.setLocation(ncmlLocation + "#" + location);
-      return result.build();
-    }
   }
 
   /////////////////////////////////////////////

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -223,7 +223,7 @@ public class NcmlReader {
    * @param ncmlElem parent element - usually the aggregation element of the ncml
    * @return new dataset with the merged info
    */
-  public static NetcdfDataset.Builder<?> mergeNcml(NetcdfFile ref, @Nullable Element ncmlElem) {
+  static NetcdfDataset.Builder<?> mergeNcml(NetcdfFile ref, @Nullable Element ncmlElem) {
     NetcdfDataset.Builder<?> targetDS = NetcdfDataset.builder().copyFrom(ref).setOrgFile(ref);
     if (ncmlElem != null) {
       NcmlReader reader = new NcmlReader();
@@ -354,8 +354,8 @@ public class NcmlReader {
    * @return NetcdfDataset the constructed dataset
    * @throws IOException on read error, or bad referencedDatasetUri URI
    */
-  NetcdfDataset.Builder<?> readNcml(String ncmlLocation, @Nullable String referencedDatasetUri,
-      Element netcdfElem, @Nullable CancelTask cancelTask) throws IOException {
+  NetcdfDataset.Builder<?> readNcml(String ncmlLocation, @Nullable String referencedDatasetUri, Element netcdfElem,
+      @Nullable CancelTask cancelTask) throws IOException {
 
     // get ncml namespace and set namespace variable
     this.ncNS = ncNSHttp;

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/package-info.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/package-info.java
@@ -1,0 +1,7 @@
+/*
+ *  Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ *  See LICENSE for license information.
+ */
+
+/** Implementation of NcML. */
+package ucar.nc2.internal.ncml;

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/package-info.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/package-info.java
@@ -1,6 +1,6 @@
 /*
- *  Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
- *  See LICENSE for license information.
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
  */
 
 /** Implementation of NcML. */

--- a/cdm-test/src/test/java/ucar/nc2/ncml/TestAggNested.java
+++ b/cdm-test/src/test/java/ucar/nc2/ncml/TestAggNested.java
@@ -6,7 +6,6 @@ package ucar.nc2.ncml;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -24,7 +23,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
 /** Test opening nested NcML with and without use of NetcdfDataset.initNetcdfFileCache. */
-@Ignore("Nested aggreations are not working")
 @Category(NeedsCdmUnitTest.class)
 @RunWith(JUnit4.class)
 public class TestAggNested {


### PR DESCRIPTION
Make NcmlElementReader a subclass instead of an inner class of NcmlReader.
Cleanup the DatasetUrl.trueUrl of nested Aggregations.
MFiles.create() doesnt allow null location.
Fix Issue #552

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/681)
<!-- Reviewable:end -->
