### PR TITLE
6.0.0 beta1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,9 @@ allprojects {
   // <prerelease version> may be SNAPSHOT, alphax, betax, etc.
   // Note - if bumping to a new major or minor version, be sure to update the docs (see step 1 in
   // docs/src/private/internal/release.md for details)
-  version = '6.0.0-beta1'
+  version = '7.0.0-SNAPSHOT'
   // Eventually, we'll stop appending "SNAPSHOT" to our versions and just use this.
-  status = 'release'
+  status = 'development'
 }
 
 // Matches Maven's "project.description".

--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,9 @@ allprojects {
   // <prerelease version> may be SNAPSHOT, alphax, betax, etc.
   // Note - if bumping to a new major or minor version, be sure to update the docs (see step 1 in
   // docs/src/private/internal/release.md for details)
-  version = '6.0.0-SNAPSHOT'
+  version = '6.0.0-beta1'
   // Eventually, we'll stop appending "SNAPSHOT" to our versions and just use this.
-  status = 'development'
+  status = 'release'
 }
 
 // Matches Maven's "project.description".

--- a/cdm-core/build.gradle
+++ b/cdm-core/build.gradle
@@ -41,4 +41,9 @@ dependencies {
   testRuntimeOnly 'ch.qos.logback:logback-classic'
 }
 
-jar.manifest.attributes 'Main-Class': 'ucar.nc2.writer.Ncdump'
+jar {
+  manifest {
+    attributes 'Main-Class': 'ucar.nc2.writer.Ncdump'
+  }
+  exclude 'cdmrfeature.proto', 'ncStream.proto', 'pointStream.proto'
+}

--- a/docs/developer/src/site/_config.yml
+++ b/docs/developer/src/site/_config.yml
@@ -2,7 +2,7 @@
 theme: unidata-jekyll-theme
 
 # this will appear in an HTML meta tag, sidebar, and perhaps elsewhere
-docset_version: 6.0
+docset_version: 7.0
 
 # this appears on the top navigation bar next to the home button
 topnav_title: netCDF-Java

--- a/docs/userguide/src/site/_config.yml
+++ b/docs/userguide/src/site/_config.yml
@@ -2,7 +2,7 @@
 theme: unidata-jekyll-theme
 
 # this will appear in an HTML meta tag, sidebar, and perhaps elsewhere
-docset_version: 6.0
+docset_version: 7.0
 
 # this appears on the top navigation bar next to the home button
 topnav_title: netCDF-Java


### PR DESCRIPTION
One quick fix related to keeping the legacy proto files out of `cdm-core`, and then 1) cutting the first 6.0.0 beta and 2) moving the develop branch to 7. Once this is in, I will make a `6.x` branch starting with commit `08e6451`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/686)
<!-- Reviewable:end -->
