### PR TITLE
Deprecate and remove uses of NetcdfFile.getGlobalAttributes, findGlobalAttributes.

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrConfig.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrConfig.java
@@ -201,7 +201,7 @@ public class BufrConfig {
       hasDate = standardFields.hasTime();
 
       ncd = NetcdfFiles.open(raf.getLocation()); // LOOK opening another raf
-      Attribute centerAtt = ncd.findGlobalAttribute(BufrIosp.centerId);
+      Attribute centerAtt = ncd.findAttribute(BufrIosp.centerId);
       int center = (centerAtt == null) ? 0 : centerAtt.getNumericValue().intValue();
 
       Sequence seq = (Sequence) ncd.getRootGroup().findVariableLocal(BufrIosp.obsRecordName);

--- a/cdm-core/src/main/java/ucar/nc2/ft/FeatureDatasetImpl.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft/FeatureDatasetImpl.java
@@ -137,22 +137,6 @@ public abstract class FeatureDatasetImpl implements FeatureDataset {
         : new AttributeContainerMutable(title).toImmutable();
   }
 
-  /** @deprecated use attributes() */
-  @Deprecated
-  public List<Attribute> getGlobalAttributes() {
-    if (netcdfDataset == null)
-      return new ArrayList<>();
-    return netcdfDataset.getGlobalAttributes();
-  }
-
-  /** @deprecated use attributes() */
-  @Deprecated
-  public Attribute findGlobalAttributeIgnoreCase(String name) {
-    if (netcdfDataset == null)
-      return null;
-    return netcdfDataset.findGlobalAttributeIgnoreCase(name);
-  }
-
   public void getDetailInfo(java.util.Formatter sf) {
     sf.format("FeatureDataset on location= %s%n", getLocation());
     sf.format("  featureType= %s%n", getFeatureType());

--- a/cdm-core/src/main/java/ucar/nc2/ft/point/collection/CompositeDatasetFactory.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft/point/collection/CompositeDatasetFactory.java
@@ -119,7 +119,6 @@ public class CompositeDatasetFactory {
       return dataVariables;
     }
 
-    @Override
     public List<Attribute> getGlobalAttributes() {
       if (globalAttributes == null) {
         if (pfc instanceof CompositePointCollection)

--- a/cdm-core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageDataset.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageDataset.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
 import ucar.nc2.Attribute;
 import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
@@ -243,7 +245,7 @@ public class DtCoverageDataset implements Closeable {
   }
 
   public List<Attribute> getGlobalAttributes() {
-    return ncd.getGlobalAttributes();
+    return ImmutableList.copyOf(ncd.getRootGroup().attributes());
   }
 
   public Dimension findDimension(String name) {

--- a/cdm-core/src/main/java/ucar/nc2/ft2/scan/package-info.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft2/scan/package-info.java
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
- * See LICENSE for license information.
- */
-
-/**
- * DEPRECATED API - THIS AND ALL SUBPACKAGES WILL BE REPLACED
- */
-package ucar.nc2.ft2.scan;

--- a/cdm-core/src/main/java/ucar/nc2/ft2/simpgeometry/SimpleGeometryFeatureDataset.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft2/simpgeometry/SimpleGeometryFeatureDataset.java
@@ -113,18 +113,6 @@ public class SimpleGeometryFeatureDataset implements FeatureDataset {
     return ncd.getRootGroup().attributes();
   }
 
-  /** @deprecated use attributes() */
-  @Deprecated
-  public List<Attribute> getGlobalAttributes() {
-    return ncd.getGlobalAttributes();
-  }
-
-  /** @deprecated use attributes() */
-  @Deprecated
-  public Attribute findGlobalAttributeIgnoreCase(String name) {
-    return ncd.findGlobalAttributeIgnoreCase(name);
-  }
-
   @Override
   public List<VariableSimpleIF> getDataVariables() {
     return null;

--- a/cdm-core/src/main/java/ucar/nc2/ft2/simpgeometry/SimpleGeometryReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft2/simpgeometry/SimpleGeometryReader.java
@@ -35,8 +35,8 @@ public class SimpleGeometryReader {
     Polygon poly = null;
 
     // CFConvention
-    if (ds.findGlobalAttribute(CF.CONVENTIONS) != null)
-      if (CF1Convention.getVersion(ds.findGlobalAttribute(CF.CONVENTIONS).getStringValue()) >= 8)
+    if (ds.findAttribute(CF.CONVENTIONS) != null)
+      if (CF1Convention.getVersion(ds.findAttribute(CF.CONVENTIONS).getStringValue()) >= 8)
         poly = new CFPolygon();
 
     if (poly == null)
@@ -62,8 +62,8 @@ public class SimpleGeometryReader {
     Line line = null;
 
     // CFConvention
-    if (ds.findGlobalAttribute(CF.CONVENTIONS) != null)
-      if (CF1Convention.getVersion(ds.findGlobalAttribute(CF.CONVENTIONS).getStringValue()) >= 8)
+    if (ds.findAttribute(CF.CONVENTIONS) != null)
+      if (CF1Convention.getVersion(ds.findAttribute(CF.CONVENTIONS).getStringValue()) >= 8)
         line = new CFLine();
 
     if (line == null)
@@ -89,8 +89,8 @@ public class SimpleGeometryReader {
     Point pt = null;
 
     // CFConvention
-    if (ds.findGlobalAttribute(CF.CONVENTIONS) != null)
-      if (CF1Convention.getVersion(ds.findGlobalAttribute(CF.CONVENTIONS).getStringValue()) >= 8)
+    if (ds.findAttribute(CF.CONVENTIONS) != null)
+      if (CF1Convention.getVersion(ds.findAttribute(CF.CONVENTIONS).getStringValue()) >= 8)
         pt = new CFPoint();
 
     if (pt == null)
@@ -112,8 +112,8 @@ public class SimpleGeometryReader {
       return null;
 
     // CFConvention
-    if (ds.findGlobalAttribute(CF.CONVENTIONS) != null)
-      if (CF1Convention.getVersion(ds.findGlobalAttribute(CF.CONVENTIONS).getStringValue()) >= 8) {
+    if (ds.findAttribute(CF.CONVENTIONS) != null)
+      if (CF1Convention.getVersion(ds.findAttribute(CF.CONVENTIONS).getStringValue()) >= 8) {
         Attribute geometryTypeAttr;
         String geometry_type;
 

--- a/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/AWIPSConvention.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/AWIPSConvention.java
@@ -60,7 +60,7 @@ public class AWIPSConvention extends CoordSystemBuilder {
 
     @Override
     public boolean isMine(NetcdfFile ncfile) {
-      return (null != ncfile.findGlobalAttribute("projName")) && (null != ncfile.findDimension("charsPerLevel"))
+      return (null != ncfile.findAttribute("projName")) && (null != ncfile.findDimension("charsPerLevel"))
           && (null != ncfile.findDimension("x")) && (null != ncfile.findDimension("y"));
     }
 

--- a/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/AWIPSSatConvention.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/AWIPSSatConvention.java
@@ -54,10 +54,10 @@ public class AWIPSSatConvention extends AWIPSConvention {
 
     @Override
     public boolean isMine(NetcdfFile ncfile) {
-      return (null != ncfile.findGlobalAttribute("projName")) && (null != ncfile.findGlobalAttribute("lon00"))
-          && (null != ncfile.findGlobalAttribute("lat00")) && (null != ncfile.findGlobalAttribute("lonNxNy"))
-          && (null != ncfile.findGlobalAttribute("latNxNy")) && (null != ncfile.findGlobalAttribute("centralLon"))
-          && (null != ncfile.findGlobalAttribute("centralLat")) && (null != ncfile.findDimension("x"))
+      return (null != ncfile.findAttribute("projName")) && (null != ncfile.findAttribute("lon00"))
+          && (null != ncfile.findAttribute("lat00")) && (null != ncfile.findAttribute("lonNxNy"))
+          && (null != ncfile.findAttribute("latNxNy")) && (null != ncfile.findAttribute("centralLon"))
+          && (null != ncfile.findAttribute("centralLat")) && (null != ncfile.findDimension("x"))
           && (null != ncfile.findDimension("y")) && (null != ncfile.findVariable("image"));
     }
 

--- a/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/IFPSConvention.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/IFPSConvention.java
@@ -62,7 +62,7 @@ public class IFPSConvention extends CoordSystemBuilder {
       // check that there is a global attribute called fileFormatVersion, and that it has one
       // of two known values
       boolean fileFormatCheck;
-      Attribute ff = ncfile.findGlobalAttributeIgnoreCase("fileFormatVersion");
+      Attribute ff = ncfile.findAttribute("fileFormatVersion");
       if (ff != null && ff.getStringValue() != null) {
         String ffValue = ff.getStringValue();
         // two possible values (as of now)

--- a/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/M3IOConvention.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/M3IOConvention.java
@@ -59,9 +59,9 @@ public class M3IOConvention extends CoordSystemBuilder {
 
     @Override
     public boolean isMine(NetcdfFile ncfile) {
-      return (null != ncfile.findGlobalAttribute("XORIG")) && (null != ncfile.findGlobalAttribute("YORIG"))
-          && (null != ncfile.findGlobalAttribute("XCELL")) && (null != ncfile.findGlobalAttribute("YCELL"))
-          && (null != ncfile.findGlobalAttribute("NCOLS")) && (null != ncfile.findGlobalAttribute("NROWS"));
+      return (null != ncfile.findAttribute("XORIG")) && (null != ncfile.findAttribute("YORIG"))
+          && (null != ncfile.findAttribute("XCELL")) && (null != ncfile.findAttribute("YCELL"))
+          && (null != ncfile.findAttribute("NCOLS")) && (null != ncfile.findAttribute("NROWS"));
     }
 
     @Override

--- a/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/Suomi.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/Suomi.java
@@ -44,9 +44,9 @@ public class Suomi extends CoordSystemBuilder {
           && !desc.equals("PWV window midpoint time delta from start_time")))
         return false;
 
-      if (null == ncfile.findGlobalAttribute("start_date"))
+      if (null == ncfile.findAttribute("start_date"))
         return false;
-      return null != ncfile.findGlobalAttribute("start_time");
+      return null != ncfile.findAttribute("start_time");
     }
 
     @Override

--- a/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/WRFConvention.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/dataset/conv/WRFConvention.java
@@ -141,7 +141,7 @@ public class WRFConvention extends CoordSystemBuilder {
         if (!gridType.equalsIgnoreCase("null") && !gridType.equalsIgnoreCase("C") && !gridType.equalsIgnoreCase("E"))
           return false;
       }
-      return ncfile.findGlobalAttribute("MAP_PROJ") != null;
+      return ncfile.findAttribute("MAP_PROJ") != null;
     }
 
     @Override

--- a/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggregationOuter.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/ncml/AggregationOuter.java
@@ -755,7 +755,7 @@ abstract class AggregationOuter extends Aggregation implements ProxyReader {
       if (data != null)
         return data;
 
-      Attribute att = ncfile.findGlobalAttribute(gattName);
+      Attribute att = ncfile.findAttribute(gattName);
       if (att == null)
         throw new IllegalArgumentException("Unknown attribute name= " + gattName);
       data = att.getValues();
@@ -806,7 +806,7 @@ abstract class AggregationOuter extends Aggregation implements ProxyReader {
 
       List<Object> vals = new ArrayList<>();
       for (String gattName : gattNames) {
-        Attribute att = ncfile.findGlobalAttribute(gattName);
+        Attribute att = ncfile.findAttribute(gattName);
         if (att == null)
           throw new IllegalArgumentException("Unknown attribute name= " + gattName);
         vals.add(att.getValue(0));

--- a/cdm-core/src/test/java/ucar/nc2/TestNetcdfFile.java
+++ b/cdm-core/src/test/java/ucar/nc2/TestNetcdfFile.java
@@ -149,7 +149,8 @@ public class TestNetcdfFile {
     assertThat(att.getStringValue()).isEqualTo("rootGroup");
 
     att = ncfile.findAttribute("attName");
-    assertThat(att).isNull();
+    assertThat(att).isNotNull();
+    assertThat(att.getStringValue()).isEqualTo("rootGroup");
 
     att = ncfile.findAttribute("/child/@attName");
     assertThat(att).isNotNull();

--- a/cdm-core/src/test/java/ucar/nc2/TestUnsigned.java
+++ b/cdm-core/src/test/java/ucar/nc2/TestUnsigned.java
@@ -169,7 +169,7 @@ public class TestUnsigned {
         + "</netcdf>";
 
     try (NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), null, null)) {
-      Attribute att = ncd.findGlobalAttribute("gatt");
+      Attribute att = ncd.findAttribute("gatt");
       Assert.assertNotNull(att);
       Assert.assertEquals(DataType.UBYTE, att.getDataType());
 
@@ -194,7 +194,7 @@ public class TestUnsigned {
         + "  <attribute name='gatt' type='byte' isUnsigned='true'>1 0 -1</attribute>" + "</netcdf>";
 
     try (NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), null, null)) {
-      Attribute att = ncd.findGlobalAttribute("gatt");
+      Attribute att = ncd.findAttribute("gatt");
       Assert.assertNotNull(att);
       Assert.assertEquals(DataType.UBYTE, att.getDataType());
 
@@ -219,7 +219,7 @@ public class TestUnsigned {
         + "</netcdf>";
 
     try (NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), null, null)) {
-      Attribute att = ncd.findGlobalAttribute("gatt");
+      Attribute att = ncd.findAttribute("gatt");
       Assert.assertNotNull(att);
       Assert.assertEquals(DataType.UBYTE, att.getDataType());
 

--- a/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestAggUnion.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestAggUnion.java
@@ -156,7 +156,7 @@ public class TestAggUnion {
   public void testMetadata() {
     logger.debug("TestNested = \n{}", ncfile);
 
-    Attribute att = ncfile.findGlobalAttribute("title");
+    Attribute att = ncfile.findAttribute("title");
     assert null != att;
     assert !att.isArray();
     assert att.isString();

--- a/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestAggUnionSimple.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestAggUnionSimple.java
@@ -167,7 +167,7 @@ public class TestAggUnionSimple {
   public void testStructure() {
     logger.debug("TestNested = \n{}", ncfile);
 
-    Attribute att = ncfile.findGlobalAttribute("title");
+    Attribute att = ncfile.findAttribute("title");
     assert null != att;
     assert !att.isArray();
     assert att.isString();

--- a/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyAtts.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyAtts.java
@@ -40,7 +40,7 @@ public class TestNcmlModifyAtts {
 
   @Test
   public void testGlobalAtt() {
-    Attribute att = ncfile.findGlobalAttribute("Conventions");
+    Attribute att = ncfile.findAttribute("Conventions");
     assert null != att;
     assert !att.isArray();
     assert att.isString();
@@ -76,7 +76,7 @@ public class TestNcmlModifyAtts {
 
   @Test
   public void testStructure() {
-    Attribute att = ncfile.findGlobalAttribute("title");
+    Attribute att = ncfile.findAttribute("title");
     assert null == att;
 
     Dimension latDim = ncfile.findDimension("lat");

--- a/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyVars.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyVars.java
@@ -48,7 +48,7 @@ public class TestNcmlModifyVars {
   @Test
   public void testReplaceAtt() {
     // System.out.println("\nncfile = "+ncfile);
-    Attribute att = ncfile.findGlobalAttribute("title");
+    Attribute att = ncfile.findAttribute("title");
     assert null != att;
     assert !att.isArray();
     assert att.isString();

--- a/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRead.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRead.java
@@ -62,7 +62,7 @@ public class TestNcmlRead {
   public void testStructure() {
     System.out.println("ncfile opened = " + ncmlLocation + "\n" + ncfile);
 
-    Attribute att = ncfile.findGlobalAttribute("title");
+    Attribute att = ncfile.findAttribute("title");
     assert null != att;
     assert !att.isArray();
     assert att.isString();
@@ -71,7 +71,7 @@ public class TestNcmlRead {
     assert att.getNumericValue() == null;
     assert att.getNumericValue(3) == null;
 
-    att = ncfile.findGlobalAttribute("testFloat");
+    att = ncfile.findAttribute("testFloat");
     assert null != att;
     assert att.isArray();
     assert !att.isString();

--- a/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRenameVar.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/ncml/TestNcmlRenameVar.java
@@ -46,7 +46,7 @@ public class TestNcmlRenameVar {
 
   @Test
   public void testStructure() {
-    Attribute att = ncfile.findGlobalAttribute("title");
+    Attribute att = ncfile.findAttribute("title");
     assert null != att;
     assert !att.isArray();
     assert att.isString();
@@ -55,7 +55,7 @@ public class TestNcmlRenameVar {
     assert att.getNumericValue() == null;
     assert att.getNumericValue(3) == null;
 
-    att = ncfile.findGlobalAttribute("testFloat");
+    att = ncfile.findAttribute("testFloat");
     assert null != att;
     assert att.isArray();
     assert !att.isString();

--- a/cdm-core/src/test/java/ucar/nc2/write/TestWriteRecord.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestWriteRecord.java
@@ -171,7 +171,7 @@ public class TestWriteRecord {
 
     try (NetcdfFile ncfile = NetcdfFiles.open(filename)) {
       /* Get the value of the global attribute named "title" */
-      Attribute title = ncfile.findGlobalAttribute("title");
+      Attribute title = ncfile.findAttribute("title");
       assert title != null;
       assert title.getStringValue().equals("Example Data") : title;
 

--- a/cdm-lite/src/main/java/thredds/server/opendap/NcDAS.java
+++ b/cdm-lite/src/main/java/thredds/server/opendap/NcDAS.java
@@ -43,7 +43,7 @@ public class NcDAS extends opendap.dap.DAS {
 
     // Global attributes
     opendap.dap.AttributeTable gtable = new opendap.dap.AttributeTable("NC_GLOBAL");
-    int count = addAttributes(gtable, null, ncfile.getGlobalAttributes());
+    int count = addAttributes(gtable, null, ncfile.getRootGroup().attributes());
     if (count > 0)
       try {
         addAttributeTable("NC_GLOBAL", gtable);

--- a/cdm-s3/src/test/java/ucar/unidata/io/s3/TestS3Read.java
+++ b/cdm-s3/src/test/java/ucar/unidata/io/s3/TestS3Read.java
@@ -477,7 +477,7 @@ public class TestS3Read {
     String key = "netcdf-java/test/GFS_Global_0p25deg_20200326_1200_apparent_temperature.nc4";
     String s3Uri = "cdms3://" + NCAR_PROFILE_NAME + "@" + host + "/" + bucket + "?" + key;
     try (NetcdfFile ncfile = NetcdfFiles.open(s3Uri)) {
-      Attribute conv = ncfile.findGlobalAttributeIgnoreCase("Conventions");
+      Attribute conv = ncfile.getRootGroup().attributes().findAttributeIgnoreCase("Conventions");
       assertThat(conv).isNotNull();
       assertThat(conv.getStringValue()).ignoringCase().isEqualTo("CF-1.6");
     }
@@ -492,7 +492,7 @@ public class TestS3Read {
     String key = "ds262.0/CERFACS/uo_Omon_NEMO3-2_FRCCORE2_f_r1i1p1_199801-200712.nc";
     String s3Uri = "cdms3://" + host + "/" + bucket + "?" + key;
     try (NetcdfFile ncfile = NetcdfFiles.open(s3Uri)) {
-      Attribute conv = ncfile.findGlobalAttributeIgnoreCase("Conventions");
+      Attribute conv = ncfile.getRootGroup().attributes().findAttributeIgnoreCase("Conventions");
       assertThat(conv).isNotNull();
       assertThat(conv.getStringValue()).ignoringCase().isEqualTo("CF-1.4");
     }

--- a/cdm-test/src/test/java/thredds/metadata/TestMetadataExtractor.java
+++ b/cdm-test/src/test/java/thredds/metadata/TestMetadataExtractor.java
@@ -46,7 +46,7 @@ public class TestMetadataExtractor {
     DatasetBuilder dsb = new DatasetBuilder(null);
     dsb.setName("testAcdd");
     dsb.put(Dataset.Id, "testAcdd");
-    ThreddsMetadataAcdd acdd = new ThreddsMetadataAcdd(makeMap(ncfile.getGlobalAttributes()), dsb);
+    ThreddsMetadataAcdd acdd = new ThreddsMetadataAcdd(makeMap(ncfile.getRootGroup().attributes()), dsb);
     acdd.extract();
     ncfile.close();
 
@@ -98,13 +98,14 @@ public class TestMetadataExtractor {
     assert voc.getVocabulary().startsWith("GCMD Earth Science Keywords. Version 5.3.3");
   }
 
-  public static Map<String, Attribute> makeMap(List<Attribute> atts) {
-    int size = (atts == null) ? 1 : atts.size();
-    Map<String, Attribute> result = new HashMap<>(size);
-    if (atts == null)
+  public static Map<String, Attribute> makeMap(Iterable<Attribute> atts) {
+    Map<String, Attribute> result = new HashMap<>();
+    if (atts == null) {
       return result;
-    for (Attribute att : atts)
+    }
+    for (Attribute att : atts) {
       result.put(att.getShortName(), att);
+    }
     return result;
   }
 }

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribBasics.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribBasics.java
@@ -1,0 +1,35 @@
+package ucar.nc2.grib;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.nc2.Attribute;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@Category(NeedsCdmUnitTest.class)
+public class TestGribBasics {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Test
+  public void testGroupAttributes() throws IOException {
+    String filename = "gribCollections/dgex/20141011/dgex_46-20141011.ncx4";
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(TestDir.cdmUnitTestDir + filename)) {
+      Attribute att = ds.findAttribute("TwoD/@GribCollectionType");
+      assertThat(att).isNotNull();
+      assertThat(att.getStringValue()).isEqualTo("TwoD");
+
+      att = ds.findAttribute("Best/@GribCollectionType");
+      assertThat(att).isNotNull();
+      assertThat(att.getStringValue()).isEqualTo("Best");
+    }
+  }
+}

--- a/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5Vlength.java
+++ b/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5Vlength.java
@@ -46,7 +46,7 @@ public class TestH5Vlength {
   @Test
   public void testVlengthAttribute() throws IOException {
     try (NetcdfFile ncfile = TestH5.openH5("support/vlstra.h5")) {
-      Attribute att = ncfile.findGlobalAttribute("test_scalar");
+      Attribute att = ncfile.findAttribute("test_scalar");
       assert (null != att);
       assert (!att.isArray());
       assert (att.isString());

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
@@ -72,6 +72,7 @@ class GribIospBuilder {
     } else {
       g = parent;
     }
+    g.addAttribute(new Attribute("GribCollectionType", gctype.toString()));
 
     makeGroup(g, group, gctype);
   }

--- a/netcdf4/src/test/groovy/ucar/nc2/jni/netcdf/Nc4IospMiscSpec.groovy
+++ b/netcdf4/src/test/groovy/ucar/nc2/jni/netcdf/Nc4IospMiscSpec.groovy
@@ -151,19 +151,19 @@ class Nc4IospMiscSpec extends Specification {
         NetcdfFile ncFile = NetcdfFiles.open(tempFile.absolutePath)
 
         expect: "the value of the attributes are null"
-        Attribute attrNumAfter = ncFile.findGlobalAttribute(attrNumBefore.getShortName())
+        Attribute attrNumAfter = ncFile.findAttribute(attrNumBefore.getShortName())
         attrNumBefore.getValues().equals attrNumAfter.getValues()
         attrNumBefore.getValues() == null
 
-        Attribute attrStrAfter = ncFile.findGlobalAttribute(attrStrBefore.getShortName())
+        Attribute attrStrAfter = ncFile.findAttribute(attrStrBefore.getShortName())
         attrStrBefore.getValues().equals attrStrAfter.getValues()
         attrStrBefore.getValues() == null
 
-        Attribute attrCharAfter = ncFile.findGlobalAttribute(attrCharBefore.getShortName())
+        Attribute attrCharAfter = ncFile.findAttribute(attrCharBefore.getShortName())
         attrCharBefore.getValues().equals attrCharAfter.getValues()
         attrCharBefore.getValues() == null
 
-        Attribute attrNullCharAfter = ncFile.findGlobalAttribute(attrNullCharBefore.getShortName())
+        Attribute attrNullCharAfter = ncFile.findAttribute(attrNullCharBefore.getShortName())
         attrNullCharBefore.getValues().getSize() == attrNullCharAfter.getValues().getSize()
         attrNullCharBefore.getValues().getSize() == 1
         String val1 = attrNullCharBefore.getStringValue();

--- a/opendap/src/test/java/ucar/nc2/dataset/TestBinaryFile.java
+++ b/opendap/src/test/java/ucar/nc2/dataset/TestBinaryFile.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import ucar.array.Array;
 import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Section;
+import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 
@@ -39,7 +40,8 @@ public class TestBinaryFile {
   @Test
   public void testGlobalMetadata() throws IOException {
     try (NetcdfFile ncf = NetcdfDatasets.openFile(filename, null)) {
-      assertThat(ncf.findGlobalAttributeIgnoreCase("conventions")).isNotNull();
+      Attribute conv = ncf.getRootGroup().attributes().findAttributeIgnoreCase("conventions");
+      assertThat(conv).isNotNull();
     }
   }
 

--- a/toolsui/uibase/src/test/java/ucar/util/memory/memory/MemoryCounterAgentTest.java
+++ b/toolsui/uibase/src/test/java/ucar/util/memory/memory/MemoryCounterAgentTest.java
@@ -128,8 +128,9 @@ public class MemoryCounterAgentTest {
       }
     }
 
-    for (Attribute att : ncfile.getGlobalAttributes())
+    for (Attribute att : ncfile.getRootGroup().attributes()) {
       measureSize(att.getShortName(), att, null, false);
+    }
 
     Group root = ncfile.getRootGroup();
     measureSize("rootGroup", root, null, false);

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/DatasetViewer.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/DatasetViewer.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 import javax.swing.*;
+
+import ucar.nc2.Group;
 import ucar.nc2.NetcdfFiles;
 import ucar.nc2.constants._Coordinate;
 import ucar.nc2.ui.StructureArrayTable;
@@ -291,11 +293,18 @@ public class DatasetViewer extends JPanel {
     }
 
     List<AttributeBean> attlist = new ArrayList<>();
-    for (Attribute att : ds.getGlobalAttributes()) {
-      attlist.add(new AttributeBean(att));
-    }
+    addAttributes(attlist, ds.getRootGroup());
     attTable.setBeans(attlist);
     attWindow.show();
+  }
+
+  private void addAttributes(List<AttributeBean> attlist, Group g) {
+    for (Attribute att : g.attributes()) {
+      attlist.add(new AttributeBean(g, att));
+    }
+    for (Group nested : g.getGroups()) {
+      addAttributes(attlist, nested);
+    }
   }
 
   public NetcdfFile getDataset() {
@@ -816,15 +825,17 @@ public class DatasetViewer extends JPanel {
   }
 
   public static class AttributeBean {
+    private final Group group;
     private final Attribute att;
 
     // create from a dataset
-    public AttributeBean(Attribute att) {
+    public AttributeBean(Group group, Attribute att) {
+      this.group = group;
       this.att = att;
     }
 
     public String getName() {
-      return att.getShortName();
+      return group.isRoot() ? att.getName() : group.getFullName() + "/" + att.getName();
     }
 
     public String getValue() {
@@ -832,7 +843,6 @@ public class DatasetViewer extends JPanel {
       return NcdumpArray.printArray(value, null, null);
     }
   }
-
 
   /*
    * public class StructureBean {

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/FeatureScanPanel.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/FeatureScanPanel.java
@@ -4,7 +4,6 @@
  */
 package ucar.nc2.ui.op;
 
-import ucar.nc2.ft2.scan.FeatureScan;
 import ucar.ui.widget.BAMutil;
 import ucar.ui.widget.IndependentWindow;
 import ucar.ui.widget.PopupMenu;

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/VariablePlot.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/VariablePlot.java
@@ -132,7 +132,7 @@ public class VariablePlot extends JPanel {
     Dimension dim = v.getDimension(0);
     String dimName = dim.getShortName();
 
-    Attribute title = file.findGlobalAttribute("title");
+    Attribute title = file.findAttribute("title");
     if (title != null)
       chart.setTitle(title.getStringValue());
 

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/VariableTable.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/op/VariableTable.java
@@ -264,8 +264,7 @@ public class VariableTable extends JPanel {
       pw.println("; file name : " + fds.getLocation());
 
       if (includeGlobals.isSelected()) {
-        List<Attribute> gAtts = fds.getGlobalAttributes();
-        for (Attribute a : gAtts) {
+        for (Attribute a : fds.getRootGroup().attributes()) {
           pw.println("; " + a.toString());
         }
       }


### PR DESCRIPTION
because we usually need to know the Group that the Attribute belongs to. Users need to do a recursive search down the group tree.

Add "GribCollectionType" attribute in GribIospBuilder, and detect that in FeatureScan.
Move FeatureScan to uicdm module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/713)
<!-- Reviewable:end -->
