### PR TITLE
String encoding and Group full names

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -930,6 +930,7 @@ public class NetcdfFiles {
       return EscapeStrings.backslashEscape(g.getShortName(), reservedFullName);
     StringBuilder sbuff = new StringBuilder();
     appendGroupName(sbuff, parent, reservedFullName);
+    sbuff.append(EscapeStrings.backslashEscape(g.getShortName(), reservedFullName));
     return sbuff.toString();
   }
 

--- a/dap4/d4lib/src/main/java/dap4/dap4lib/netcdf/Nc4Cursor.java
+++ b/dap4/d4lib/src/main/java/dap4/dap4lib/netcdf/Nc4Cursor.java
@@ -15,7 +15,10 @@ import ucar.nc2.jni.netcdf.Nc4prototypes;
 import ucar.nc2.jni.netcdf.SizeT;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import static dap4.dap4lib.netcdf.Nc4DSP.Nc4Pointer;
 import static dap4.dap4lib.netcdf.Nc4Notes.*;
@@ -26,6 +29,10 @@ public class Nc4Cursor extends AbstractCursor {
   //////////////////////////////////////////////////
 
   public static boolean DEBUG = false;
+
+  // if the default charset being used by java isn't UTF-8, then we will
+  // need to transcode any string read into netCDf-Java via netCDF-C
+  private static final boolean transcodeStrings = Charset.defaultCharset() != StandardCharsets.UTF_8;
 
   //////////////////////////////////////////////////
   // Instance variables
@@ -223,6 +230,9 @@ public class Nc4Cursor extends AbstractCursor {
     } else if (basetype.isStringType()) {
       String[] s = new String[1];
       readcheck(nc4, ret = nc4.nc_get_var_string(vi.gid, vi.id, s));
+      if (transcodeStrings) {
+        s = transcodeString(s);
+      }
       result = s;
     } else if (basetype.isOpaqueType()) {
       Nc4Pointer mem = Nc4Pointer.allocate(ti.getSize());
@@ -274,6 +284,9 @@ public class Nc4Cursor extends AbstractCursor {
       } else if (basetype.isStringType()) {
         String[] ss = new String[(int) edgecount];
         readcheck(nc4, ret = nc4.nc_get_vars_string(vi.gid, vi.id, startp, countp, stridep, ss));
+        if (transcodeStrings) {
+          ss = transcodeString(ss);
+        }
         partialresult = ss;
       } else if (basetype.isOpaqueType()) {
         long elemsize = ti.getSize();
@@ -611,6 +624,28 @@ public class Nc4Cursor extends AbstractCursor {
     DapVariable f0 = ds.getField(0);
     DapType f0type = f0.getBaseType();
     return (TypeNotes) ((Nc4DSP) this.dsp).find(f0type);
+  }
+
+  /**
+   * By default, JNA assumes strings coming into java from the C side are using
+   * the system encoding. However, netCDF-C encodes using UTF-8. Because of this,
+   * if we are on a platform where java is not using UTF-8 as the default encoding,
+   * we will need to transcode the incoming strings fix the incorrect assumption
+   * made by JNA.
+   *
+   * Note, we could set the system property jna.encode=UTF-8, but would impact the
+   * behavior of other libraries that use JNA, and would not be very nice of us to
+   * set globally (and often times isn't the right thing to set anyways, since the
+   * default in C to use the system encoding).
+   *
+   * @param systemStrings String array encoded using the default charset
+   * @return String array encoded using the UTF-8 charset
+   */
+  private String[] transcodeString(String[] systemStrings) {
+    return Arrays.stream(systemStrings).map(systemString -> {
+      byte[] byteArray = systemString.getBytes(Charset.defaultCharset());
+      return new String(byteArray, StandardCharsets.UTF_8);
+    }).toArray(String[]::new);
   }
 
   protected void debug() {

--- a/dap4/d4lib/src/main/java/dap4/dap4lib/netcdf/Nc4DMRCompiler.java
+++ b/dap4/d4lib/src/main/java/dap4/dap4lib/netcdf/Nc4DMRCompiler.java
@@ -12,6 +12,7 @@ import dap4.core.util.Convert;
 import dap4.core.util.DapContext;
 import dap4.core.util.DapException;
 import dap4.core.util.DapUtil;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.nc2.jni.netcdf.Nc4prototypes;
 import ucar.nc2.jni.netcdf.SizeTByReference;
 import static ucar.nc2.jni.netcdf.Nc4prototypes.*;
@@ -44,6 +45,8 @@ public class Nc4DMRCompiler {
   static int NC_POINTER_BYTES = (Native.POINTER_SIZE);
   static int NC_SIZET_BYTES = (Native.SIZE_T_SIZE);
 
+  protected static Nc4prototypes nc4 = NetcdfClibrary.getForeignFunctionInterface();
+
   //////////////////////////////////////////////////
   // Static methods
 
@@ -65,8 +68,6 @@ public class Nc4DMRCompiler {
   //////////////////////////////////////////////////
   // Instance Variables
 
-  protected Nc4prototypes nc4 = null;
-
   protected boolean trace = false;
   protected boolean closed = false;
 
@@ -86,7 +87,6 @@ public class Nc4DMRCompiler {
 
   public Nc4DMRCompiler(Nc4DSP dsp, int ncid, DMRFactory factory) throws DapException {
     this.dsp = dsp;
-    this.nc4 = dsp.getJNI();
     this.path = dsp.getLocation();
     this.ncid = ncid;
     this.factory = factory;

--- a/dap4/d4lib/src/main/java/dap4/dap4lib/netcdf/Nc4DSP.java
+++ b/dap4/d4lib/src/main/java/dap4/dap4lib/netcdf/Nc4DSP.java
@@ -62,6 +62,8 @@ public class Nc4DSP extends AbstractDSP {
   static int NC_POINTER_BYTES = (Native.POINTER_SIZE);
   static int NC_SIZET_BYTES = (Native.SIZE_T_SIZE);
 
+  protected static Nc4prototypes nc4 = NetcdfClibrary.getForeignFunctionInterface();
+
   //////////////////////////////////////////////////
   // com.sun.jna.Memory control
 
@@ -274,8 +276,6 @@ public class Nc4DSP extends AbstractDSP {
   //////////////////////////////////////////////////
   // Instance Variables
 
-  protected Nc4prototypes nc4 = null;
-
   protected boolean trace = false;
   protected boolean closed = false;
 
@@ -291,10 +291,8 @@ public class Nc4DSP extends AbstractDSP {
 
   public Nc4DSP() throws DapException {
     super();
-    if (this.nc4 == null) {
-      this.nc4 = NetcdfClibrary.getForeignFunctionInterface();
-      if (this.nc4 == null)
-        throw new DapException("Could not load libnetcdf");
+    if (nc4 == null) {
+      throw new DapException("Could not load libnetcdf");
     }
     dmrfactory = new DMRFactory();
     allnotesInit();
@@ -383,7 +381,7 @@ public class Nc4DSP extends AbstractDSP {
 
 
   public Nc4prototypes getJNI() {
-    return this.nc4;
+    return nc4;
   }
 
   @Override

--- a/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
+++ b/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -7,8 +7,6 @@ package ucar.nc2.ffi.netcdf;
 
 import com.google.common.base.Strings;
 import com.sun.jna.Native;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 import ucar.nc2.jni.netcdf.Nc4prototypes;
 import ucar.nc2.jni.netcdf.Nc4wrapper;
@@ -120,15 +118,6 @@ public class NetcdfClibrary {
   private static Nc4prototypes load() {
     if (nc4 == null) {
       if (jnaPath == null) {
-        // netCDF-C will return strings encoded as UTF-8 (not default C behavior).
-        // JNA assumes c code is returning using the system encoding by default
-        // So, if the system encoding isn't UTF_8 (hello, windows!), set the jna
-        // encoding to utf_8. LOOK: This might hose other application use JNA and
-        // not expect their c code to return UTF-8
-        if (!Charset.defaultCharset().equals(StandardCharsets.UTF_8)) {
-          log.info("Setting System Property jna.encoding to UTF8");
-          // System.setProperty("jna.encoding", StandardCharsets.UTF_8.name());
-        }
         setLibraryNameAndPath(null, null);
       }
       try {

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -58,6 +58,8 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   public static final String TRANSLATE_NONE = "none";
   public static final String TRANSLATE_NC4 = "nc4";
 
+  private static Nc4prototypes nc4 = NetcdfClibrary.getForeignFunctionInterface();
+
   // Define reserved attributes (see Nc4DSP)
   public static final String UCARTAGOPAQUE = "_edu.ucar.opaque.size";
   // Not yet implemented
@@ -104,7 +106,7 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   /** @deprecated use NetcdfClibrary.getNativeInterface */
   @Deprecated
   public static synchronized Nc4prototypes getCLibrary() {
-    return NetcdfClibrary.getForeignFunctionInterface();
+    return nc4;
   }
 
   /**
@@ -129,7 +131,6 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   //////////////////////////////////////////////////
   // Instance Variables
 
-  private Nc4prototypes nc4;
   private NetcdfFileWriter.Version version; // can use c library to create these different version files
   private boolean fill = true;
   private int ncid = -1; // file id
@@ -243,7 +244,6 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     if (!isClibraryPresent()) {
       throw new UnsupportedOperationException("Couldn't load NetCDF C library (see log for details).");
     }
-    this.nc4 = NetcdfClibrary.getForeignFunctionInterface();
 
     if (raf != null)
       raf.close(); // not used
@@ -2345,7 +2345,6 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
     if (!isClibraryPresent()) {
       throw new UnsupportedOperationException("Couldn't load NetCDF C library (see log for details).");
     }
-    this.nc4 = NetcdfClibrary.getForeignFunctionInterface();
 
     this.ncfile = ncfile;
 


### PR DESCRIPTION
Found a few more places that need to handle string encoding when reading from the netCDF-C library or local text files. Along the same lines as what was done in Unidata/netcdf-java#237. Also did a little cleanup (not much) in the `netcdf4` subproject, and fixed a bug in the code that creates a full name for a `Group`. These were all revealed by looking into failing TDS 5 tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/718)
<!-- Reviewable:end -->
