### PR TITLE
Full group name

### DIFF
--- a/cdm-core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm-core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -863,12 +863,13 @@ public class NetcdfFiles {
 
   /** Create a Groups's full name with appropriate backslash escaping. */
   public static String makeFullName(Group g) {
-    // return makeFullName(g, reservedFullName);
     Group parent = g.getParentGroup();
+    String groupName = EscapeStrings.backslashEscape(g.getShortName(), reservedFullName);
     if ((parent == null) || parent.isRoot()) // common case?
-      return EscapeStrings.backslashEscape(g.getShortName(), reservedFullName);
+      return groupName;
     StringBuilder sbuff = new StringBuilder();
     appendGroupName(sbuff, parent, reservedFullName);
+    sbuff.append(groupName);
     return sbuff.toString();
   }
 

--- a/cdm-core/src/test/java/ucar/nc2/TestNetcdfFiles.java
+++ b/cdm-core/src/test/java/ucar/nc2/TestNetcdfFiles.java
@@ -137,5 +137,33 @@ public class TestNetcdfFiles {
     }
   }
 
+  @Test
+  public void testMakeFullNameGroup() {
+    // root
+    // parent
+    // child
+    // grandchild
+    Group.Builder parent = Group.builder().setName("parent");
+    Group.Builder child = Group.builder().setName("child");
+    parent.addGroup(child);
+    Group.Builder grandchild = Group.builder().setName("grandchild");
+    child.addGroup(grandchild);
 
+    Group root = Group.builder().addGroup(parent).build();
+
+    assertThat(NetcdfFiles.makeFullName(root)).isEqualTo("");
+
+    assertThat(root.getGroups()).hasSize(1);
+    Group parentGroup = root.getGroups().get(0);
+    assertThat(NetcdfFiles.makeFullName(parentGroup)).isEqualTo("parent");
+
+    assertThat(parentGroup.getGroups()).hasSize(1);
+    Group childGroup = parentGroup.getGroups().get(0);
+    assertThat(NetcdfFiles.makeFullName(childGroup)).isEqualTo("parent/child");
+
+    assertThat(childGroup.getGroups()).hasSize(1);
+    Group grandchildGroup = childGroup.getGroups().get(0);
+    assertThat(NetcdfFiles.makeFullName(grandchildGroup)).isEqualTo("parent/child/grandchild");
+
+  }
 }


### PR DESCRIPTION
`NetcdfFiles.makeFullName(Group g)` was returning only the top-most group. This PR makes sure the full group name is returned. Fixed in `maint-5.x`, but will still need backported to `6.x`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/722)
<!-- Reviewable:end -->
