### PR TITLE
[5.x] Remove netcdf4 module from ncIdv shadowJar

### DIFF
--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -41,7 +41,6 @@ dependencies {
   ncIdv project(':cdm:cdm-misc')
   ncIdv project(':bufr')
   ncIdv project(':grib')
-  ncIdv project(':netcdf4')
   ncIdv project(':opendap')
   ncIdv project(':visad:cdm-mcidas')
   ncIdv project(':visad:cdm-vis5d')


### PR DESCRIPTION
## Description of Changes

Remove the `netcdf4` module from the `ncIdv` shadow jar. The 32-bit binaries included with `jna` mess with code signing for Mac platforms, and since they do not expose writing netCDF-4 files through the interface, so it's easier to just remove it all together.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [X] Link to any issues that the PR addresses
- [X] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/757)
<!-- Reviewable:end -->
