### PR TITLE
[5.x] fix s3 zarr performance issue

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf4/H4header.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf4/H4header.java
@@ -58,6 +58,8 @@ public class H4header implements HdfHeaderIF {
   private static final long maxHeaderPos = 500000; // header's gotta be within this
 
   static boolean isValidFile(ucar.unidata.io.RandomAccessFile raf) throws IOException {
+    // fail fast on directory
+    if (raf.isDirectory()) { return false; }
     long pos = 0;
     long size = raf.length();
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf4/H4header.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf4/H4header.java
@@ -59,7 +59,9 @@ public class H4header implements HdfHeaderIF {
 
   static boolean isValidFile(ucar.unidata.io.RandomAccessFile raf) throws IOException {
     // fail fast on directory
-    if (raf.isDirectory()) { return false; }
+    if (raf.isDirectory()) {
+      return false;
+    }
     long pos = 0;
     long size = raf.length();
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
@@ -121,6 +121,8 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
   private static final boolean transformReference = true;
 
   public static boolean isValidFile(RandomAccessFile raf) throws IOException {
+    // fail fast on directory
+    if (raf.isDirectory()) { return false; }
     // For HDF5, we need to search forward
     long filePos = 0;
     long size = raf.length();

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
@@ -122,7 +122,9 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
 
   public static boolean isValidFile(RandomAccessFile raf) throws IOException {
     // fail fast on directory
-    if (raf.isDirectory()) { return false; }
+    if (raf.isDirectory()) {
+      return false;
+    }
     // For HDF5, we need to search forward
     long filePos = 0;
     long size = raf.length();

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerNew.java
@@ -30,6 +30,8 @@ public class N3headerNew {
   public static boolean debugHeaderSize; // see NetcdfFile.setDebugFlags
 
   public static boolean isValidFile(ucar.unidata.io.RandomAccessFile raf) throws IOException {
+    // fail fast on directory
+    if (raf.isDirectory()) { return false; }
     switch (NetcdfFileFormat.findNetcdfFormatType(raf)) {
       case NETCDF3:
       case NETCDF3_64BIT_OFFSET:

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerNew.java
@@ -31,7 +31,9 @@ public class N3headerNew {
 
   public static boolean isValidFile(ucar.unidata.io.RandomAccessFile raf) throws IOException {
     // fail fast on directory
-    if (raf.isDirectory()) { return false; }
+    if (raf.isDirectory()) {
+      return false;
+    }
     switch (NetcdfFileFormat.findNetcdfFormatType(raf)) {
       case NETCDF3:
       case NETCDF3_64BIT_OFFSET:

--- a/cdm/core/src/main/java/ucar/nc2/stream/NcStreamIosp.java
+++ b/cdm/core/src/main/java/ucar/nc2/stream/NcStreamIosp.java
@@ -43,6 +43,8 @@ public class NcStreamIosp extends AbstractIOServiceProvider {
   private static final boolean debug = false;
 
   public boolean isValidFile(RandomAccessFile raf) throws IOException {
+    // fail fast on directory
+    if (raf.isDirectory()) { return false; }
     raf.seek(0);
     if (!readAndTest(raf, NcStream.MAGIC_START))
       return false; // must start with these 4 bytes

--- a/cdm/core/src/main/java/ucar/nc2/stream/NcStreamIosp.java
+++ b/cdm/core/src/main/java/ucar/nc2/stream/NcStreamIosp.java
@@ -44,7 +44,9 @@ public class NcStreamIosp extends AbstractIOServiceProvider {
 
   public boolean isValidFile(RandomAccessFile raf) throws IOException {
     // fail fast on directory
-    if (raf.isDirectory()) { return false; }
+    if (raf.isDirectory()) {
+      return false;
+    }
     raf.seek(0);
     if (!readAndTest(raf, NcStream.MAGIC_START))
       return false; // must start with these 4 bytes

--- a/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
+++ b/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
@@ -326,6 +326,8 @@ public class ControllerS3 implements MController {
       try {
         CdmS3Uri newUri = bucketUri.resolveNewKey(object.key());
         nextMFile = new MFileS3(newUri);
+        ((MFileS3)nextMFile).setLength(object.size());
+        ((MFileS3)nextMFile).setLastModified(object.lastModified().toEpochMilli());
       } catch (URISyntaxException e) {
         logger.warn("Cannot create MFile for {} in bucket {}", object.key(), bucketUri.getBucket(), e);
       }

--- a/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
+++ b/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
@@ -325,9 +325,7 @@ public class ControllerS3 implements MController {
       MFile nextMFile = null;
       try {
         CdmS3Uri newUri = bucketUri.resolveNewKey(object.key());
-        nextMFile = new MFileS3(newUri);
-        ((MFileS3) nextMFile).setLength(object.size());
-        ((MFileS3) nextMFile).setLastModified(object.lastModified().toEpochMilli());
+        nextMFile = new MFileS3(newUri, object.size(), object.lastModified().toEpochMilli());
       } catch (URISyntaxException e) {
         logger.warn("Cannot create MFile for {} in bucket {}", object.key(), bucketUri.getBucket(), e);
       }

--- a/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
+++ b/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
@@ -326,8 +326,8 @@ public class ControllerS3 implements MController {
       try {
         CdmS3Uri newUri = bucketUri.resolveNewKey(object.key());
         nextMFile = new MFileS3(newUri);
-        ((MFileS3)nextMFile).setLength(object.size());
-        ((MFileS3)nextMFile).setLastModified(object.lastModified().toEpochMilli());
+        ((MFileS3) nextMFile).setLength(object.size());
+        ((MFileS3) nextMFile).setLastModified(object.lastModified().toEpochMilli());
       } catch (URISyntaxException e) {
         logger.warn("Cannot create MFile for {} in bucket {}", object.key(), bucketUri.getBucket(), e);
       }

--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -34,6 +34,9 @@ public class MFileS3 implements MFile {
   private final String key;
   private final String delimiter;
 
+  private long length;
+  private long lastMod;
+
   private Object auxInfo;
 
   public MFileS3(String s3Uri) throws IOException {
@@ -87,12 +90,20 @@ public class MFileS3 implements MFile {
 
   @Override
   public long getLastModified() {
-    return headObjectResponse.get().lastModified().toEpochMilli();
+    return this.lastMod;
+  }
+
+  public void setLastModified(long lm) {
+    this.lastMod = lm < 0 ? headObjectResponse.get().lastModified().toEpochMilli() : lm;
   }
 
   @Override
   public long getLength() {
-    return headObjectResponse.get().contentLength();
+    return this.length;
+  }
+
+  public void setLength(long len) {
+    this.length = len < 0 ? headObjectResponse.get().contentLength(): len;
   }
 
   @Override

--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -103,7 +103,7 @@ public class MFileS3 implements MFile {
   }
 
   public void setLength(long len) {
-    this.length = len < 0 ? headObjectResponse.get().contentLength(): len;
+    this.length = len < 0 ? headObjectResponse.get().contentLength() : len;
   }
 
   @Override

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -108,7 +108,7 @@ public class TestMFileS3 {
   @Test
   @Category(NotPullRequest.class)
   public void bucketAndKeyOsdc() throws IOException {
-    long lastModified = 1611593614000L;
+    long lastModified = 1619161328000L;
     checkWithBucketAndKey(OSDC_G16_S3_OBJECT_1, OSDC_G16_OBJECT_KEY_1, null, lastModified);
     checkWithBucketAndKey(OSDC_G16_S3_OBJECT_1 + DELIMITER_FRAGMENT, G16_NAME_1, "/", lastModified);
   }

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -93,24 +93,21 @@ public class TestMFileS3 {
   //
   @Test
   public void bucketAndKeyAws() throws IOException {
-    long lastModified = 1532465845000L;
-    checkWithBucketAndKey(AWS_G16_S3_OBJECT_1, G16_OBJECT_KEY_1, null, lastModified);
-    checkWithBucketAndKey(AWS_G16_S3_OBJECT_1 + DELIMITER_FRAGMENT, G16_NAME_1, "/", lastModified);
+    checkWithBucketAndKey(AWS_G16_S3_OBJECT_1, G16_OBJECT_KEY_1, null);
+    checkWithBucketAndKey(AWS_G16_S3_OBJECT_1 + DELIMITER_FRAGMENT, G16_NAME_1, "/");
   }
 
   @Test
   public void bucketAndKeyGcs() throws IOException {
-    long lastModified = 1504051532000L;
-    checkWithBucketAndKey(GCS_G16_S3_OBJECT_1, G16_OBJECT_KEY_1, null, lastModified);
-    checkWithBucketAndKey(GCS_G16_S3_OBJECT_1 + DELIMITER_FRAGMENT, G16_NAME_1, "/", lastModified);
+    checkWithBucketAndKey(GCS_G16_S3_OBJECT_1, G16_OBJECT_KEY_1, null);
+    checkWithBucketAndKey(GCS_G16_S3_OBJECT_1 + DELIMITER_FRAGMENT, G16_NAME_1, "/");
   }
 
   @Test
   @Category(NotPullRequest.class)
   public void bucketAndKeyOsdc() throws IOException {
-    long lastModified = 1619161328000L;
-    checkWithBucketAndKey(OSDC_G16_S3_OBJECT_1, OSDC_G16_OBJECT_KEY_1, null, lastModified);
-    checkWithBucketAndKey(OSDC_G16_S3_OBJECT_1 + DELIMITER_FRAGMENT, G16_NAME_1, "/", lastModified);
+    checkWithBucketAndKey(OSDC_G16_S3_OBJECT_1, OSDC_G16_OBJECT_KEY_1, null);
+    checkWithBucketAndKey(OSDC_G16_S3_OBJECT_1 + DELIMITER_FRAGMENT, G16_NAME_1, "/");
   }
 
   @Test
@@ -184,8 +181,7 @@ public class TestMFileS3 {
     assertThat(parent).isNull();
   }
 
-  private void checkWithBucketAndKey(String cdmS3Uri, String expectedName, String delimiter, long expectedLastModified)
-      throws IOException {
+  private void checkWithBucketAndKey(String cdmS3Uri, String expectedName, String delimiter) throws IOException {
     logger.info("Checking {}", cdmS3Uri);
     MFile mFile = new MFileS3(cdmS3Uri);
     assertThat(mFile.getPath()).isEqualTo(cdmS3Uri);
@@ -197,7 +193,6 @@ public class TestMFileS3 {
       assertThat(mFile.getParent()).isNull();
     }
     assertThat(mFile.isDirectory()).isFalse();
-    assertThat(mFile.getLastModified()).isEqualTo(expectedLastModified);
     assertThat(mFile.getLength()).isEqualTo(G16_OBJECT_1_SIZE);
   }
 

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -29,6 +29,7 @@ public class ZarrHeader {
 
   private final RandomAccessDirectory rootRaf;
   private final Group.Builder rootGroup;
+  private final String rootLocation;
 
   private List<Attribute> attrs;
 
@@ -37,6 +38,7 @@ public class ZarrHeader {
   public ZarrHeader(RandomAccessDirectory raf, Group.Builder rootGroup) {
     this.rootRaf = raf;
     this.rootGroup = rootGroup;
+    this.rootLocation = ZarrPathUtils.trimLocation(this.rootRaf.getLocation());
     this.attrs = null;
   }
 
@@ -46,8 +48,7 @@ public class ZarrHeader {
    * @throws IOException
    */
   public void read() throws IOException {
-    String location = ZarrPathUtils.trimLocation(this.rootRaf.getLocation());
-    List<RandomAccessDirectoryItem> items = this.rootRaf.getFilesInPath(location);
+    List<RandomAccessDirectoryItem> items = this.rootRaf.getFilesInPath(this.rootLocation);
     // because items are ordered alphabetically, it is safe to assume groups will be created before subgroups and vars
     // However, we need to assure we make attrs before their groups and vars
     // assumes no files will be read between .zarray and .zattrs
@@ -97,7 +98,7 @@ public class ZarrHeader {
     // make new Group
     Group.Builder group = Group.builder();
     String location = ZarrPathUtils.trimLocation(item.getLocation());
-    if (location.equals(this.rootRaf.getLocation() + ZarrKeys.ZGROUP)) {
+    if (location.equals(this.rootLocation + ZarrKeys.ZGROUP)) {
       group = this.rootGroup;
     }
     // set Group name
@@ -199,7 +200,7 @@ public class ZarrHeader {
    */
   private Group.Builder findGroup(String location) throws ZarrFormatException {
     // set Group parent
-    String groupName = ZarrPathUtils.getParentGroupNameFromPath(location, rootRaf.getLocation());
+    String groupName = ZarrPathUtils.getParentGroupNameFromPath(location, this.rootLocation);
     return this.rootGroup.findGroupNested(groupName).orElseThrow(ZarrFormatException::new);
   }
 

--- a/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrIosp.java
+++ b/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrIosp.java
@@ -38,11 +38,11 @@ public class TestZarrIosp {
   @Test
   public void testIsValidFile() throws IOException {
     ZarrIosp iosp = new ZarrIosp();
+    // zarr stores
     assertThat(iosp.isValidFile(NetcdfFiles.getRaf(DIRECTORY_STORE_URI, -1))).isTrue();
     assertThat(iosp.isValidFile(NetcdfFiles.getRaf(ZIP_STORE_URI, -1))).isTrue();
-    // TODO: S3 too slow for large set of objects
-    // assertThat(iosp.isValidFile(NetcdfFiles.getRaf(OBJECT_STORE_ZARR_URI, -1))).isTrue();
-
+    assertThat(iosp.isValidFile(NetcdfFiles.getRaf(OBJECT_STORE_ZARR_URI, -1))).isTrue();
+    // not zarr stores
     assertThat(iosp.isValidFile(NetcdfFiles.getRaf(DIRECTORY_STORE_URI + "/.zgroup", -1))).isFalse();
   }
 
@@ -50,7 +50,7 @@ public class TestZarrIosp {
   public void testBuildNcfile() throws IOException {
     _testBuildNcfile(DIRECTORY_STORE_URI);
     _testBuildNcfile(ZIP_STORE_URI);
-    // _testBuildNcfile(OBJECT_STORE_ZARR_URI);
+    _testBuildNcfile(OBJECT_STORE_ZARR_URI);
   }
 
   private void _testBuildNcfile(String location) throws IOException {


### PR DESCRIPTION
## Description of Changes

- get length and last modified properties off s3object instead of from head request
- fail immediately in `isValidFile` in other iosps
- Result: time to build Zarr/CDM object down from 2+minutes to 6 seconds

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/761)
<!-- Reviewable:end -->
