### PR TITLE
Add GridHorizCurvilinear for curvilinear lat/lon (2d).

### DIFF
--- a/cdm-core/src/main/java/ucar/array/Arrays.java
+++ b/cdm-core/src/main/java/ucar/array/Arrays.java
@@ -525,7 +525,7 @@ public class Arrays {
     if (a instanceof ArrayDouble) {
       ArrayDouble ad = (ArrayDouble) a;
       for (double val : ad) {
-        if (hasEval && eval.isMissing(val)) {
+        if ((hasEval && eval.isMissing(val)) || Double.isNaN(val)) {
           continue;
         }
         if (val > max)
@@ -536,7 +536,7 @@ public class Arrays {
     } else {
       for (Number number : a) {
         double val = number.doubleValue();
-        if (hasEval && eval.isMissing(val)) {
+        if (hasEval && eval.isMissing(val) || Double.isNaN(val)) {
           continue;
         }
         if (val > max)

--- a/cdm-core/src/main/java/ucar/nc2/grid/CoordInterval.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/CoordInterval.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 /**
  * A Coordinate represented by an interval [start, end)
- * LOOK double ??
+ * LOOK double vs int ??
  */
 @AutoValue
 public abstract class CoordInterval {

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCoordinateSystem.java
@@ -154,8 +154,17 @@ public class GridHorizCoordinateSystem {
     LatLonRect llbb = params.getLatLonBoundingBox();
     ProjectionRect projbb = params.getProjectionBoundingBox();
 
-    // TODO GridSubset.latlonPoint
-    if (projbb != null) { // TODO ProjectionRect ok for isLatlon = true?
+    if (llbb != null && !isLatLon()) {
+      projbb = projection.latLonToProjBB(llbb);
+      llbb = null;
+    }
+
+    if (projbb != null && isLatLon()) {
+      llbb = projection.projToLatLonBB(projbb);
+      projbb = null;
+    }
+
+    if (projbb != null) {
       SubsetPointHelper yhelper = new SubsetPointHelper(yaxis);
       Optional<GridAxisPoint.Builder<?>> ybo =
           yhelper.subsetRange(projbb.getMinY(), projbb.getMaxY(), horizStride, errlog);
@@ -172,7 +181,7 @@ public class GridHorizCoordinateSystem {
       }
       xaxisSubset = xbo.get().build();
 
-    } else if (llbb != null && isLatLon()) { // TODO LatLonRect only used for isLatlon = true?
+    } else if (llbb != null) {
       SubsetPointHelper yhelper = new SubsetPointHelper(yaxis);
       Optional<GridAxisPoint.Builder<?>> ybo =
           yhelper.subsetRange(llbb.getLatMin(), llbb.getLatMax(), horizStride, errlog);
@@ -181,7 +190,8 @@ public class GridHorizCoordinateSystem {
       }
       yaxisSubset = ybo.get().build();
 
-      // TODO longitude wrapping
+      // TODO logitude wrapping, we have to port code from ucar.nc2.ft2.coverage.HorizCoordSys.
+      // see TestGridReadHorizSubset.testCrossLongitudeSeam and in ft2.coverage
       SubsetPointHelper xhelper = new SubsetPointHelper(xaxis);
       Optional<GridAxisPoint.Builder<?>> xbo =
           xhelper.subsetRange(llbb.getLonMin(), llbb.getLonMax(), horizStride, errlog);

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCoordinateSystem.java
@@ -1,10 +1,12 @@
 package ucar.nc2.grid2;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import ucar.array.InvalidRangeException;
 import ucar.array.Range;
 import ucar.nc2.constants.AxisType;
+import ucar.nc2.grid.CoordInterval;
 import ucar.nc2.grid.GridSubset;
 import ucar.nc2.internal.grid2.SubsetHelpers;
 import ucar.nc2.internal.grid2.SubsetPointHelper;
@@ -14,6 +16,7 @@ import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.Projection;
 import ucar.unidata.geoloc.ProjectionPoint;
 import ucar.unidata.geoloc.ProjectionRect;
+import ucar.unidata.geoloc.projection.Curvilinear;
 import ucar.unidata.geoloc.projection.LatLonProjection;
 import ucar.unidata.geoloc.projection.sat.Geostationary;
 import ucar.unidata.geoloc.projection.sat.MSGnavigation;
@@ -30,13 +33,11 @@ import java.util.Optional;
 public class GridHorizCoordinateSystem {
 
   /** Get the 1D X axis (either GeoX or Lon). */
-  @Nullable
   public GridAxisPoint getXHorizAxis() {
     return xaxis;
   }
 
   /** Get the 1D Y axis (either GeoY or Lat). */
-  @Nullable
   public GridAxisPoint getYHorizAxis() {
     return yaxis;
   }
@@ -48,7 +49,12 @@ public class GridHorizCoordinateSystem {
 
   /** Does this use lat/lon horizontal axes? */
   public boolean isLatLon() {
-    return projection.isLatLon();
+    return projection instanceof LatLonProjection;
+  }
+
+  /** Does this use lat/lon horizontal axes? */
+  public boolean isCurvilinear() {
+    return projection instanceof Curvilinear;
   }
 
   /** Is this a global coverage over longitude ? */
@@ -60,50 +66,12 @@ public class GridHorizCoordinateSystem {
     return rect.getWidth() >= 360;
   }
 
-  /** True if both X and Y axes are regularly spaced. */
-  public boolean isRegular() {
-    if (!isRegularSpatial(getXHorizAxis()))
-      return false;
-    return isRegularSpatial(getYHorizAxis());
-  }
-
-  private boolean isRegularSpatial(GridAxisPoint axis) {
-    if (axis == null)
-      return false;
-    return axis.isRegular();
-  }
-
   public List<Integer> getShape() {
     return ImmutableList.of(getYHorizAxis().getNominalSize(), getXHorizAxis().getNominalSize());
   }
 
   public List<ucar.array.Range> getSubsetRanges() {
     return ImmutableList.of(getYHorizAxis().getSubsetRange(), getXHorizAxis().getSubsetRange());
-  }
-
-  /** Return value from findXYindexFromCoord(). */
-  public class CoordReturn {
-    /** The data index */
-    public int xindex, yindex;
-    /** The x,y grid coordinate. */
-    public double xcoord, ycoord;
-
-    @Override
-    public String toString() {
-      return String.format("CoordReturn{xindex=%d, yindex=%d, xcoord=%f, ycoord=%f", xindex, yindex, xcoord, ycoord);
-    }
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////////////
-  private final GridAxisPoint xaxis;
-  private final GridAxisPoint yaxis;
-  private final Projection projection;
-
-  public GridHorizCoordinateSystem(GridAxisPoint xaxis, GridAxisPoint yaxis, @Nullable Projection projection) {
-    this.xaxis = xaxis;
-    this.yaxis = yaxis;
-    // TODO set the LatLon seam?
-    this.projection = projection == null ? new LatLonProjection() : projection;
   }
 
   /**
@@ -174,28 +142,6 @@ public class GridHorizCoordinateSystem {
     return projection.projToLatLon(ProjectionPoint.create(xcoord, ycoord));
   }
 
-  // LOOK needed?
-  /** From the (x,y) projection point, find the indices and coordinates of the horizontal 2D grid. */
-  public Optional<CoordReturn> findXYindexFromCoord(double x, double y) {
-    CoordReturn result = new CoordReturn();
-
-    if (xaxis.getAxisType() == AxisType.Lon) {
-      x = LatLonPoints.lonNormalFrom(x, xaxis.getCoordinate(0).doubleValue()); // LOOK ??
-    }
-
-    result.xindex = SubsetHelpers.findCoordElement(xaxis, x, false);
-    result.yindex = SubsetHelpers.findCoordElement(yaxis, y, false);
-
-    if (result.xindex >= 0 && result.xindex < xaxis.getNominalSize() && result.yindex >= 0
-        && result.yindex < yaxis.getNominalSize()) {
-      result.xcoord = xaxis.getCoordinate(result.xindex).doubleValue();
-      result.ycoord = yaxis.getCoordinate(result.yindex).doubleValue();
-      return Optional.of(result);
-    } else {
-      return Optional.empty();
-    }
-  }
-
   /** Subset both x and y axis based on the given parameters. */
   public Optional<GridHorizCoordinateSystem> subset(GridSubset params, Formatter errlog) {
     Integer horizStride = params.getHorizStride();
@@ -249,15 +195,131 @@ public class GridHorizCoordinateSystem {
       Preconditions.checkNotNull(xaxis);
       yaxisSubset = yaxis.toBuilder().subsetWithStride(horizStride).build();
       xaxisSubset = xaxis.toBuilder().subsetWithStride(horizStride).build();
+
+    } else {
+      return Optional.of(this);
     }
 
     return Optional.of(new GridHorizCoordinateSystem(xaxisSubset, yaxisSubset, this.projection));
   }
 
+  ///////////////////////////////////////////////////////////////////////////////
+
+  /** Return value from bounds(). */
+  public class CoordBounds {
+    public final CoordReturn ll;
+    public final CoordReturn lr;
+    public final CoordReturn ur;
+    public final CoordReturn ul;
+    public final int xindex, yindex;
+
+    public CoordBounds(int xindex, int yindex) {
+      this.xindex = xindex;
+      this.yindex = yindex;
+      CoordInterval xintv = xaxis.getCoordInterval(xindex);
+      CoordInterval yintv = yaxis.getCoordInterval(yindex);
+      this.ll = new CoordReturn(xintv.start(), yintv.start());
+      this.lr = new CoordReturn(xintv.end(), yintv.start());
+      this.ur = new CoordReturn(xintv.end(), yintv.end());
+      this.ul = new CoordReturn(xintv.start(), yintv.end());
+    }
+
+    public CoordBounds(CoordReturn ll, CoordReturn lr, CoordReturn ur, CoordReturn ul, int xindex, int yindex) {
+      this.ll = ll;
+      this.lr = lr;
+      this.ur = ur;
+      this.ul = ul;
+      this.xindex = xindex;
+      this.yindex = yindex;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("CoordBounds{ (%d,%d): ll=%s lr=%s ur=%s ul=%s}", xindex, yindex, ll.toStringShort(),
+          lr.toStringShort(), ur.toStringShort(), ul.toStringShort());
+    }
+  }
+
+  public Iterable<CoordBounds> bounds() {
+    return () -> new BoundsIterator(xaxis.getNominalSize(), yaxis.getNominalSize());
+  }
+
+  private class BoundsIterator extends AbstractIterator<CoordBounds> {
+    final int nx;
+    final int ny;
+    int xindex = 0;
+    int yindex = 0;
+
+    public BoundsIterator(int nx, int ny) {
+      this.nx = nx;
+      this.ny = ny;
+    }
+
+    @Override
+    protected CoordBounds computeNext() {
+      if (xindex >= nx) {
+        yindex++;
+        xindex = 0;
+      }
+      if (yindex >= ny) {
+        return endOfData();
+      }
+      CoordBounds result = new CoordBounds(xindex, yindex);
+      xindex++;
+      return result;
+    }
+  }
+
+  /** Return value from findXYindexFromCoord(). */
+  public static class CoordReturn {
+    /** The data index */
+    public int xindex, yindex;
+    /** The x,y grid coordinate. */
+    public double xcoord, ycoord;
+
+    public CoordReturn() {}
+
+    public CoordReturn(double xcoord, double ycoord) {
+      this.xcoord = xcoord;
+      this.ycoord = ycoord;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("CoordReturn{xindex=%d, yindex=%d, xcoord=%f, ycoord=%f", xindex, yindex, xcoord, ycoord);
+    }
+
+    public String toStringShort() {
+      return String.format("[%f,%f]", xcoord, ycoord);
+    }
+  }
+
+  // LOOK needed?
+  /** From the (x,y) projection point, find the indices and coordinates of the horizontal 2D grid. */
+  public Optional<CoordReturn> findXYindexFromCoord(double x, double y) {
+    CoordReturn result = new CoordReturn();
+
+    if (xaxis.getAxisType() == AxisType.Lon) {
+      x = LatLonPoints.lonNormalFrom(x, xaxis.getCoordinate(0).doubleValue()); // LOOK ??
+    }
+
+    result.xindex = SubsetHelpers.findCoordElement(xaxis, x, false);
+    result.yindex = SubsetHelpers.findCoordElement(yaxis, y, false);
+
+    if (result.xindex >= 0 && result.xindex < xaxis.getNominalSize() && result.yindex >= 0
+        && result.yindex < yaxis.getNominalSize()) {
+      result.xcoord = xaxis.getCoordinate(result.xindex).doubleValue();
+      result.ycoord = yaxis.getCoordinate(result.yindex).doubleValue();
+      return Optional.of(result);
+    } else {
+      return Optional.empty();
+    }
+  }
+
   /**
    * Get Index Ranges for the given lat, lon bounding box.
    * For projection, only an approximation based on latlon corners.
-   * LOOK probabble needed by subset
+   * LOOK maybe needed by subset
    *
    * @param rect the requested lat/lon bounding box
    * @return list of 2 Range objects, first y then x.
@@ -321,6 +383,18 @@ public class GridHorizCoordinateSystem {
     return wantMin ? Math.min(lon1, lon2) : Math.max(lon1, lon2);
   }
 
+  ////////////////////////////////////////////////////////////////////////////////////////
+  private final GridAxisPoint xaxis;
+  private final GridAxisPoint yaxis;
+  private final Projection projection;
+
+  public GridHorizCoordinateSystem(GridAxisPoint xaxis, GridAxisPoint yaxis, @Nullable Projection projection) {
+    this.xaxis = xaxis;
+    this.yaxis = yaxis;
+    // TODO set the LatLon seam?
+    this.projection = projection == null ? new LatLonProjection() : projection;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o)
@@ -337,4 +411,8 @@ public class GridHorizCoordinateSystem {
     return Objects.hash(xaxis, yaxis, projection);
   }
 
+  @Override
+  public String toString() {
+    return "GridHorizCoordinateSystem{" + "xaxis=" + xaxis + ", yaxis=" + yaxis + ", projection=" + projection + '}';
+  }
 }

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCoordinateSystem.java
@@ -100,7 +100,7 @@ public class GridHorizCoordinateSystem {
 
       } else {
         ProjectionRect bb = getBoundingBox();
-        if (projection != null && bb != null) {
+        if (bb != null) {
           llbb = projection.projToLatLonBB(bb);
         }
       }
@@ -149,8 +149,8 @@ public class GridHorizCoordinateSystem {
       horizStride = 1;
     }
 
-    GridAxisPoint xaxisSubset = xaxis;
-    GridAxisPoint yaxisSubset = yaxis;
+    GridAxisPoint xaxisSubset;
+    GridAxisPoint yaxisSubset;
     LatLonRect llbb = params.getLatLonBoundingBox();
     ProjectionRect projbb = params.getProjectionBoundingBox();
 
@@ -319,7 +319,7 @@ public class GridHorizCoordinateSystem {
   /**
    * Get Index Ranges for the given lat, lon bounding box.
    * For projection, only an approximation based on latlon corners.
-   * LOOK maybe needed by subset
+   * LOOK maybe needed by subset?
    *
    * @param rect the requested lat/lon bounding box
    * @return list of 2 Range objects, first y then x.
@@ -327,7 +327,7 @@ public class GridHorizCoordinateSystem {
   List<Range> getRangesFromLatLonRect(LatLonRect rect) throws InvalidRangeException {
     double minx, maxx, miny, maxy;
 
-    if (projection != null && !(projection instanceof VerticalPerspectiveView) && !(projection instanceof MSGnavigation)
+    if (!(projection instanceof VerticalPerspectiveView) && !(projection instanceof MSGnavigation)
         && !(projection instanceof Geostationary)) { // LOOK kludge - how to do this generrally ??
       // first clip the request rectangle to the bounding box of the grid
       LatLonRect bb = getLatLonBoundingBox();

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCurvilinear.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCurvilinear.java
@@ -125,57 +125,6 @@ public class GridHorizCurvilinear extends GridHorizCoordinateSystem {
     }
   }
 
-  /*
-   * CoordInterval getCoordIntervalLon() {
-   * double edge1, edge2;
-   * 
-   * double valuei = londata.get(yindex, xindex).doubleValue();
-   * double valueim1 = xindex > 0 ? londata.get(yindex, xindex - 1).doubleValue() : Double.NaN;
-   * 
-   * if (xindex > 0) {
-   * edge1 = (valueim1 + valuei) / 2;
-   * } else {
-   * double value0 = londata.get(yindex, 0).doubleValue();
-   * double value1 = londata.get(yindex, 1).doubleValue();
-   * edge1 = value0 - (value1 - value0) / 2;
-   * }
-   * 
-   * if (xindex < nx - 1) {
-   * double valueip1 = londata.get(yindex, xindex + 1).doubleValue();
-   * edge2 = (valuei + valueip1) / 2;
-   * } else {
-   * edge2 = valuei - (valuei - valueim1) / 2;
-   * }
-   * 
-   * return CoordInterval.create(edge1, edge2);
-   * }
-   * 
-   * CoordInterval getCoordIntervalLat() {
-   * double edge1, edge2;
-   * 
-   * double valuei = latdata.get(yindex, xindex).doubleValue();
-   * double valueim1 = yindex > 0 ? latdata.get(yindex - 1, xindex).doubleValue() : Double.NaN;
-   * 
-   * if (yindex > 0) {
-   * edge1 = (valueim1 + valuei) / 2;
-   * } else {
-   * double value0 = latdata.get(0, xindex).doubleValue();
-   * double value1 = latdata.get(1, xindex).doubleValue();
-   * edge1 = value0 - (value1 - value0) / 2;
-   * }
-   * 
-   * if (yindex < ny - 1) {
-   * double valueip1 = latdata.get(yindex + 1, xindex).doubleValue();
-   * edge2 = (valuei + valueip1) / 2;
-   * } else {
-   * edge2 = valuei - (valuei - valueim1) / 2;
-   * }
-   * 
-   * return CoordInterval.create(edge1, edge2);
-   * }
-   * }
-   */
-
   private Array<Double> makeEdges(Array<Number> midpoints) {
     int[] shape = midpoints.getShape();
     int ny = shape[0];

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCurvilinear.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridHorizCurvilinear.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.grid2;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.AbstractIterator;
+import ucar.array.Array;
+import ucar.array.ArrayType;
+import ucar.array.Arrays;
+import ucar.array.MinMax;
+import ucar.unidata.geoloc.LatLonPoint;
+import ucar.unidata.geoloc.LatLonPoints;
+import ucar.unidata.geoloc.LatLonRect;
+import ucar.unidata.geoloc.Projection;
+import ucar.unidata.geoloc.ProjectionPoint;
+import ucar.unidata.geoloc.ProjectionRect;
+import ucar.unidata.geoloc.projection.Curvilinear;
+
+public class GridHorizCurvilinear extends GridHorizCoordinateSystem {
+  private final Array<Double> latedge;
+  private final Array<Double> lonedge;
+  private LatLonRect llbb;
+  private ProjectionRect mapArea;
+
+  public static GridHorizCurvilinear create(GridAxisPoint xaxis, GridAxisPoint yaxis, Array<Number> latdata,
+      Array<Number> londata) {
+    Preconditions.checkNotNull(xaxis);
+    Preconditions.checkNotNull(yaxis);
+    Preconditions.checkNotNull(latdata);
+    Preconditions.checkNotNull(londata);
+    Preconditions.checkArgument(latdata.getRank() == 2);
+    Preconditions.checkArgument(londata.getRank() == 2);
+
+    return new GridHorizCurvilinear(xaxis, yaxis, new Curvilinear(), latdata, londata);
+  }
+
+  private GridHorizCurvilinear(GridAxisPoint xaxis, GridAxisPoint yaxis, Projection projection, Array<Number> latdata,
+      Array<Number> londata) {
+    super(xaxis, yaxis, projection);
+    this.latedge = makeEdges(latdata);
+    this.lonedge = makeEdges(londata);
+  }
+
+  /** Get horizontal bounding box in lat, lon coordinates. Uses min/max of lat and lon arrays */
+  // LOOK maybe need to use normalized lon ??
+  public LatLonRect getLatLonBoundingBox() {
+    if (llbb == null) {
+      MinMax latMinmax = Arrays.getMinMaxSkipMissingData(latedge, null);
+      MinMax lonMinmax = Arrays.getMinMaxSkipMissingData(lonedge, null);
+
+      LatLonPoint llpt = LatLonPoint.create(latMinmax.min(), lonMinmax.min());
+      llbb = new LatLonRect(llpt, latMinmax.max() - latMinmax.min(), lonMinmax.max() - lonMinmax.min());
+    }
+    return llbb;
+  }
+
+  /** Get horizontal bounding box in projection coordinates. */
+  public ProjectionRect getBoundingBox() {
+    if (mapArea == null) {
+      LatLonRect latlonRect = getLatLonBoundingBox();
+      double centerLon = latlonRect.getCenterLon();
+
+      LatLonPoint ll = latlonRect.getLowerLeftPoint();
+      LatLonPoint ur = latlonRect.getUpperRightPoint();
+      ProjectionPoint w1 = latLonToProj(ll, centerLon);
+      ProjectionPoint w2 = latLonToProj(ur, centerLon);
+
+      // make bounding box out of those two corners
+      ProjectionRect.Builder world = ProjectionRect.builder(w1.getX(), w1.getY(), w2.getX(), w2.getY());
+
+      LatLonPoint la = LatLonPoint.create(ur.getLatitude(), ll.getLongitude());
+      LatLonPoint lb = LatLonPoint.create(ll.getLatitude(), ur.getLongitude());
+
+      // now extend if needed to the other two corners
+      world.add(latLonToProj(la, centerLon));
+      world.add(latLonToProj(lb, centerLon));
+
+      mapArea = world.build();
+    }
+    return mapArea;
+  }
+
+  // from LatLonProjection
+  private ProjectionPoint latLonToProj(LatLonPoint latlon, double centerLon) {
+    return ProjectionPoint.create(LatLonPoints.lonNormal(latlon.getLongitude(), centerLon), latlon.getLatitude());
+  }
+
+  @Override
+  public Iterable<CoordBounds> bounds() {
+    return () -> new BoundsIterator(getXHorizAxis().getNominalSize(), getYHorizAxis().getNominalSize());
+  }
+
+  private class BoundsIterator extends AbstractIterator<CoordBounds> {
+    final int nx;
+    final int ny;
+    int xindex = 0;
+    int yindex = 0;
+
+    public BoundsIterator(int nx, int ny) {
+      this.nx = nx;
+      this.ny = ny;
+    }
+
+    @Override
+    protected CoordBounds computeNext() {
+      if (xindex >= nx) {
+        yindex++;
+        xindex = 0;
+      }
+      if (yindex >= ny) {
+        return endOfData();
+      }
+
+      CoordReturn ll = new CoordReturn(lonedge.get(yindex, xindex), latedge.get(yindex, xindex));
+      CoordReturn lr = new CoordReturn(lonedge.get(yindex, xindex + 1), latedge.get(yindex, xindex + 1));
+      CoordReturn ur = new CoordReturn(lonedge.get(yindex + 1, xindex + 1), latedge.get(yindex + 1, xindex + 1));
+      CoordReturn ul = new CoordReturn(lonedge.get(yindex + 1, xindex), latedge.get(yindex + 1, xindex));
+
+      CoordBounds result = new CoordBounds(ll, lr, ur, ul, xindex, yindex);
+      xindex++;
+      return result;
+    }
+  }
+
+  /*
+   * CoordInterval getCoordIntervalLon() {
+   * double edge1, edge2;
+   * 
+   * double valuei = londata.get(yindex, xindex).doubleValue();
+   * double valueim1 = xindex > 0 ? londata.get(yindex, xindex - 1).doubleValue() : Double.NaN;
+   * 
+   * if (xindex > 0) {
+   * edge1 = (valueim1 + valuei) / 2;
+   * } else {
+   * double value0 = londata.get(yindex, 0).doubleValue();
+   * double value1 = londata.get(yindex, 1).doubleValue();
+   * edge1 = value0 - (value1 - value0) / 2;
+   * }
+   * 
+   * if (xindex < nx - 1) {
+   * double valueip1 = londata.get(yindex, xindex + 1).doubleValue();
+   * edge2 = (valuei + valueip1) / 2;
+   * } else {
+   * edge2 = valuei - (valuei - valueim1) / 2;
+   * }
+   * 
+   * return CoordInterval.create(edge1, edge2);
+   * }
+   * 
+   * CoordInterval getCoordIntervalLat() {
+   * double edge1, edge2;
+   * 
+   * double valuei = latdata.get(yindex, xindex).doubleValue();
+   * double valueim1 = yindex > 0 ? latdata.get(yindex - 1, xindex).doubleValue() : Double.NaN;
+   * 
+   * if (yindex > 0) {
+   * edge1 = (valueim1 + valuei) / 2;
+   * } else {
+   * double value0 = latdata.get(0, xindex).doubleValue();
+   * double value1 = latdata.get(1, xindex).doubleValue();
+   * edge1 = value0 - (value1 - value0) / 2;
+   * }
+   * 
+   * if (yindex < ny - 1) {
+   * double valueip1 = latdata.get(yindex + 1, xindex).doubleValue();
+   * edge2 = (valuei + valueip1) / 2;
+   * } else {
+   * edge2 = valuei - (valuei - valueim1) / 2;
+   * }
+   * 
+   * return CoordInterval.create(edge1, edge2);
+   * }
+   * }
+   */
+
+  private Array<Double> makeEdges(Array<Number> midpoints) {
+    int[] shape = midpoints.getShape();
+    int ny = shape[0];
+    int nx = shape[1];
+    int[] edgeShape = new int[] {ny + 1, nx + 1};
+    Awrap edge = new Awrap(ny + 1, nx + 1);
+
+    for (int y = 0; y < ny - 1; y++) {
+      for (int x = 0; x < nx - 1; x++) {
+        // the interior edges are the average of the 4 surrounding midpoints
+        double xval = (midpoints.get(y, x).doubleValue() + midpoints.get(y, x + 1).doubleValue()
+            + midpoints.get(y + 1, x).doubleValue() + midpoints.get(y + 1, x + 1).doubleValue()) / 4;
+        edge.set(y + 1, x + 1, xval);
+      }
+      // extrapolate to exterior points
+      edge.set(y + 1, 0, edge.get(y + 1, 1) - (edge.get(y + 1, 2) - edge.get(y + 1, 1)));
+      edge.set(y + 1, nx, edge.get(y + 1, nx - 1) + (edge.get(y + 1, nx - 1) - edge.get(y + 1, nx - 2)));
+    }
+
+    // extrapolate to the first and last row
+    for (int x = 0; x < nx + 1; x++) {
+      edge.set(0, x, edge.get(1, x) - (edge.get(2, x) - edge.get(1, x)));
+      edge.set(ny, x, edge.get(ny - 1, x) + (edge.get(ny - 1, x) - edge.get(ny - 2, x)));
+    }
+
+    return Arrays.factory(ArrayType.DOUBLE, edgeShape, edge.arr);
+  }
+
+  private static class Awrap {
+    final int stride;
+    final double[] arr;
+
+    Awrap(int ny, int nx) {
+      this.stride = nx;
+      this.arr = new double[ny * nx];
+    }
+
+    double get(int y, int x) {
+      return arr[y * stride + x];
+    }
+
+    void set(int y, int x, double val) {
+      arr[y * stride + x] = val;
+    }
+  }
+
+}

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridReader.java
@@ -10,6 +10,7 @@ import ucar.nc2.calendar.CalendarDate;
 import ucar.nc2.grid.CoordInterval;
 import ucar.nc2.grid.GridSubset;
 import ucar.unidata.geoloc.LatLonRect;
+import ucar.unidata.geoloc.ProjectionRect;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -22,17 +23,6 @@ public class GridReader {
 
   public GridReader(Grid grid) {
     this.grid = grid;
-  }
-
-  public GridReader setVertCoord(Object coord) {
-    if (coord instanceof Number) {
-      req.put(GridSubset.vertPoint, coord);
-    } else if (coord instanceof CoordInterval) {
-      req.put(GridSubset.vertIntv, coord);
-    } else {
-      throw new RuntimeException("setVertCoord must be Number or CoordInterval " + coord);
-    }
-    return this;
   }
 
   public GridReader setTime(CalendarDate date) {
@@ -77,11 +67,6 @@ public class GridReader {
     return this;
   }
 
-  public GridReader setLatLonBoundingBox(LatLonRect llbb) {
-    req.put(GridSubset.latlonBB, llbb);
-    return this;
-  }
-
   public GridReader setEnsCoord(Object coord) {
     Preconditions.checkArgument(coord instanceof Double);
     req.put(GridSubset.ensCoord, coord);
@@ -90,6 +75,27 @@ public class GridReader {
 
   public GridReader setHorizStride(int stride) {
     req.put(GridSubset.horizStride, stride);
+    return this;
+  }
+
+  public GridReader setLatLonBoundingBox(LatLonRect llbb) {
+    req.put(GridSubset.latlonBB, llbb);
+    return this;
+  }
+
+  public GridReader setProjectionBoundingBox(ProjectionRect projRect) {
+    req.put(GridSubset.projBB, projRect);
+    return this;
+  }
+
+  public GridReader setVertCoord(Object coord) {
+    if (coord instanceof Number) {
+      req.put(GridSubset.vertPoint, coord);
+    } else if (coord instanceof CoordInterval) {
+      req.put(GridSubset.vertIntv, coord);
+    } else {
+      throw new RuntimeException("setVertCoord must be Number or CoordInterval " + coord);
+    }
     return this;
   }
 

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridReader.java
@@ -45,6 +45,11 @@ public class GridReader {
     return this;
   }
 
+  public GridReader setTimeLatest() {
+    req.put(GridSubset.timeLatest, true);
+    return this;
+  }
+
   public GridReader setTimeCoord(Object coord) {
     if (coord instanceof Number) {
       req.put(GridSubset.timePoint, coord);

--- a/cdm-core/src/main/java/ucar/nc2/grid2/GridTimeCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/GridTimeCoordinateSystem.java
@@ -16,7 +16,6 @@ import java.util.List;
  * Manages the time coordinates of a GridCoordinateSystem.
  * The complexity is due to Forecast Model Run Collections (FMRC), in which the time coordinate
  * depends on the forecast run.
- * LOOK could specialize FmrcTimeCoordinateSystem
  */
 public interface GridTimeCoordinateSystem {
   enum Type {

--- a/cdm-core/src/main/java/ucar/nc2/grid2/MaterializedCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/MaterializedCoordinateSystem.java
@@ -16,7 +16,6 @@ import java.util.List;
 @Immutable
 public class MaterializedCoordinateSystem {
 
-  // LOOK should this be MaterializedTimeCoordinateSystem ?
   @Nullable
   public GridTimeCoordinateSystem getTimeCoordSystem() {
     return tcs;

--- a/cdm-core/src/main/java/ucar/nc2/grid2/MaterializedCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid2/MaterializedCoordinateSystem.java
@@ -32,18 +32,18 @@ public class MaterializedCoordinateSystem {
     return vert;
   }
 
-  public GridHorizCoordinateSystem getHorizCoordSystem() {
+  public GridHorizCoordinateSystem getHorizCoordinateSystem() {
     return hcs;
   }
 
   /** Get the X axis (either GeoX or Lon). */
   public GridAxisPoint getXHorizAxis() {
-    return getHorizCoordSystem().getXHorizAxis();
+    return getHorizCoordinateSystem().getXHorizAxis();
   }
 
   /** Get the Y axis (either GeoY or Lat). */
   public GridAxisPoint getYHorizAxis() {
-    return getHorizCoordSystem().getYHorizAxis();
+    return getHorizCoordinateSystem().getYHorizAxis();
   }
 
   /** The shape of this array. */
@@ -58,7 +58,7 @@ public class MaterializedCoordinateSystem {
     if (getVerticalAxis() != null) {
       result.add(getVerticalAxis().getNominalSize());
     }
-    result.addAll(getHorizCoordSystem().getShape());
+    result.addAll(getHorizCoordinateSystem().getShape());
     return result;
   }
 
@@ -73,7 +73,7 @@ public class MaterializedCoordinateSystem {
     if (getVerticalAxis() != null) {
       result.add(getVerticalAxis().getSubsetRange());
     }
-    result.addAll(getHorizCoordSystem().getSubsetRanges());
+    result.addAll(getHorizCoordinateSystem().getSubsetRanges());
     return result;
   }
 
@@ -91,8 +91,8 @@ public class MaterializedCoordinateSystem {
     if (getVerticalAxis() != null) {
       result.add(getVerticalAxis());
     }
-    result.add(getHorizCoordSystem().getYHorizAxis());
-    result.add(getHorizCoordSystem().getXHorizAxis());
+    result.add(getHorizCoordinateSystem().getYHorizAxis());
+    result.add(getHorizCoordinateSystem().getXHorizAxis());
     return result;
   }
 

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid2/GridVariable.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid2/GridVariable.java
@@ -14,6 +14,7 @@ import javax.annotation.concurrent.Immutable;
 import java.io.IOException;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /** Wraps a VariableDS, turns into a Grid */
@@ -69,11 +70,6 @@ public class GridVariable implements Grid {
     return vds.isMissing(val);
   }
 
-  @Override
-  public String toString() {
-    return vds + "\n permuter=" + permuter + '}';
-  }
-
   /** Subsetting the coordinate system, then using that subset to do the read. Special to Netcdf, not general. */
   @Override
   public GridReferencedArray readData(GridSubset subset) throws IOException, ucar.array.InvalidRangeException {
@@ -114,4 +110,25 @@ public class GridVariable implements Grid {
     // LOOK
     return (Array<Number>) dataVolume;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    GridVariable that = (GridVariable) o;
+    return vds.equals(that.vds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(vds);
+  }
+
+  @Override
+  public String toString() {
+    return vds + "\n permuter=" + permuter + '}';
+  }
+
 }

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid2/SubsetTimeHelper.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid2/SubsetTimeHelper.java
@@ -6,7 +6,6 @@
 package ucar.nc2.internal.grid2;
 
 import com.google.common.math.DoubleMath;
-import ucar.array.Range;
 import ucar.nc2.calendar.CalendarDate;
 import ucar.nc2.grid.GridSubset;
 import ucar.nc2.grid2.GridAxis;

--- a/cdm-core/src/main/java/ucar/unidata/geoloc/Projection.java
+++ b/cdm-core/src/main/java/ucar/unidata/geoloc/Projection.java
@@ -29,6 +29,7 @@ public interface Projection {
   }
 
   /** Convert a LatLonPoint to projection coordinates. */
+  // LOOK can this be null?
   ProjectionPoint latLonToProj(LatLonPoint latlon);
 
   /** Convert projection x, y to LatLonPoint point. */
@@ -37,6 +38,7 @@ public interface Projection {
   }
 
   /** Convert projection coordinates to a LatLonPoint. */
+  // LOOK can this be null?
   LatLonPoint projToLatLon(ProjectionPoint ppt);
 
   /**

--- a/cdm-core/src/main/java/ucar/unidata/geoloc/projection/AbstractProjection.java
+++ b/cdm-core/src/main/java/ucar/unidata/geoloc/projection/AbstractProjection.java
@@ -65,10 +65,11 @@ public abstract class AbstractProjection implements Projection {
   protected final List<Parameter> atts = new ArrayList<>();
 
   /**
-   * copy constructor - avoid clone !!
-   *
-   * @return a copy of this Projection.
+   * Copy constructor - avoid clone !!
+   * 
+   * @deprecated not needed because Immutable
    */
+  @Deprecated
   public abstract Projection constructCopy();
 
   protected AbstractProjection(String name, boolean isLatLon) {

--- a/cdm-core/src/main/java/ucar/unidata/geoloc/projection/Curvilinear.java
+++ b/cdm-core/src/main/java/ucar/unidata/geoloc/projection/Curvilinear.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.unidata.geoloc.projection;
+
+import ucar.array.Array;
+import ucar.unidata.geoloc.LatLonPoint;
+import ucar.unidata.geoloc.Projection;
+import ucar.unidata.geoloc.ProjectionPoint;
+
+import java.util.Optional;
+
+public class Curvilinear extends AbstractProjection {
+  Array<Double> latArray;
+  Array<Double> lonArray;
+
+  public Curvilinear() {
+    super("Curvilinear", false);
+  }
+
+  @Override
+  public ProjectionPoint latLonToProj(LatLonPoint latlon) {
+    double lat = latlon.getLatitude();
+    double lon = latlon.getLongitude();
+    Optional<CoordReturn> coords = findXYindexFromCoord(lat, lon);
+    return coords.map(c -> ProjectionPoint.create(c.yidx, c.xidx)).orElse(null);
+  }
+
+  @Override
+  public LatLonPoint projToLatLon(ProjectionPoint ppt) {
+    return null;
+    /*
+     * int xidx = (int) ppt.getX(); // LOOK 0 based
+     * int yidx = (int) ppt.getY();
+     * double lat = latArray.get(yidx, xidx);
+     * double lon = lonArray.get(yidx, xidx);
+     * return LatLonPoint.create(lat, lon);
+     */
+  }
+
+  @Override
+  public boolean crossSeam(ProjectionPoint pt1, ProjectionPoint pt2) {
+    return false;
+  }
+
+  @Override
+  public Projection constructCopy() {
+    return null;
+  }
+
+  @Override
+  public String paramsToString() {
+    return "";
+  }
+
+  public static class CoordReturn {
+    public double lat, lon;
+    public int xidx, yidx;
+  }
+
+  private Optional<CoordReturn> findXYindexFromCoord(double lat, double lon) {
+    return Optional.empty();
+  }
+}

--- a/cdm-core/src/test/java/ucar/nc2/grid2/TestGridHorizCoordinateSystem.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid2/TestGridHorizCoordinateSystem.java
@@ -37,7 +37,8 @@ public class TestGridHorizCoordinateSystem {
     assertThat(hcs.getProjection()).isEqualTo(project);
     assertThat(hcs.isLatLon()).isTrue();
     assertThat(hcs.isGlobalLon()).isFalse();
-    assertThat(hcs.isRegular()).isFalse();
+    assertThat(hcs.getXHorizAxis().isRegular()).isTrue();
+    assertThat(hcs.getYHorizAxis().isRegular()).isFalse();
     assertThat(hcs.getShape()).isEqualTo(ImmutableList.of(7, 9));
     assertThat(hcs.getSubsetRanges()).isEqualTo(ImmutableList.of(new Range(7), new Range(9)));
 
@@ -73,7 +74,8 @@ public class TestGridHorizCoordinateSystem {
     assertThat(hcs.getProjection()).isEqualTo(project);
     assertThat(hcs.isLatLon()).isFalse();
     assertThat(hcs.isGlobalLon()).isFalse();
-    assertThat(hcs.isRegular()).isTrue();
+    assertThat(hcs.getXHorizAxis().isRegular()).isTrue();
+    assertThat(hcs.getYHorizAxis().isRegular()).isTrue();
     assertThat(hcs.getShape()).isEqualTo(ImmutableList.of(7, 9));
     assertThat(hcs.getSubsetRanges()).isEqualTo(ImmutableList.of(new Range(7), new Range(9)));
 

--- a/cdm-core/src/test/java/ucar/nc2/grid2/TestPointHorizSubset.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid2/TestPointHorizSubset.java
@@ -43,7 +43,6 @@ public class TestPointHorizSubset {
     assertThat(subset.getProjection()).isEqualTo(project);
     assertThat(subset.isLatLon()).isFalse();
     assertThat(subset.isGlobalLon()).isFalse();
-    assertThat(subset.isRegular()).isTrue();
     assertThat(subset.getSubsetRanges()).isEqualTo(ImmutableList.of(Range.make(0, 6, 3), Range.make(0, 8, 3)));
     assertThat(subset.getShape()).isEqualTo(ImmutableList.of(3, 3));
 
@@ -103,7 +102,8 @@ public class TestPointHorizSubset {
     assertThat(subset.getProjection()).isEqualTo(project);
     assertThat(subset.isLatLon()).isFalse();
     assertThat(subset.isGlobalLon()).isFalse();
-    assertThat(subset.isRegular()).isFalse();
+    assertThat(hcs.getXHorizAxis().isRegular()).isTrue();
+    assertThat(hcs.getYHorizAxis().isRegular()).isFalse();
     assertThat(subset.getSubsetRanges()).isEqualTo(ImmutableList.of(Range.make(0, 6, 2), Range.make(0, 8, 2)));
     assertThat(subset.getShape()).isEqualTo(ImmutableList.of(4, 5));
 
@@ -167,7 +167,8 @@ public class TestPointHorizSubset {
     assertThat(subset.getProjection()).isEqualTo(project);
     assertThat(subset.isLatLon()).isFalse();
     assertThat(subset.isGlobalLon()).isFalse();
-    assertThat(subset.isRegular()).isFalse();
+    assertThat(hcs.getXHorizAxis().isRegular()).isFalse();
+    assertThat(hcs.getYHorizAxis().isRegular()).isFalse();
     assertThat(subset.getSubsetRanges()).isEqualTo(ImmutableList.of(Range.make(0, 6, 2), Range.make(0, 4, 2)));
     assertThat(subset.getShape()).isEqualTo(ImmutableList.of(4, 3));
 
@@ -234,7 +235,6 @@ public class TestPointHorizSubset {
     assertThat(subset.getProjection()).isEqualTo(project);
     assertThat(subset.isLatLon()).isFalse();
     assertThat(subset.isGlobalLon()).isFalse();
-    assertThat(subset.isRegular()).isTrue();
 
     assertThat(subset.getGeoUnits()).isEqualTo("km");
     // assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("-15, -16.5, 90, 99"));
@@ -298,7 +298,6 @@ public class TestPointHorizSubset {
     assertThat(subset.getProjection()).isEqualTo(project);
     assertThat(subset.isLatLon()).isFalse();
     assertThat(subset.isGlobalLon()).isFalse();
-    assertThat(subset.isRegular()).isFalse();
 
     assertThat(subset.getGeoUnits()).isEqualTo("km");
     assertThat(subset.getLatLonBoundingBox()).isNotNull();
@@ -363,7 +362,8 @@ public class TestPointHorizSubset {
     assertThat(subset.getProjection()).isEqualTo(project);
     assertThat(subset.isLatLon()).isFalse();
     assertThat(subset.isGlobalLon()).isFalse();
-    assertThat(subset.isRegular()).isFalse();
+    assertThat(subset.getXHorizAxis().isRegular()).isFalse();
+    assertThat(subset.getYHorizAxis().isRegular()).isFalse();
 
     assertThat(subset.getGeoUnits()).isEqualTo("km");
     assertThat(subset.getLatLonBoundingBox()).isNotNull();

--- a/cdm-core/src/test/java/ucar/nc2/grid2/TestReadGridCoordinateSystem.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid2/TestReadGridCoordinateSystem.java
@@ -37,7 +37,15 @@ public class TestReadGridCoordinateSystem {
     testOpenNetcdfAsGrid(filename, gridName, new int[] {11}, new int[] {19}, new int[] {65, 93});
   }
 
-  private void testOpenNetcdfAsGrid(String endpoint, String gridName, int[] expectedTimeShape, int[] otherCoordShape,
+  @Test
+  public void testDuplicateGrids() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "ft/grid/namExtract/20060926_0000.nc";
+    String gridName = "Precipitable_water";
+    int ngrids = testOpenNetcdfAsGrid(filename, gridName, new int[] {2}, new int[] {}, new int[] {103, 108});
+    assertThat(ngrids).isEqualTo(8);
+  }
+
+  private int testOpenNetcdfAsGrid(String endpoint, String gridName, int[] expectedTimeShape, int[] otherCoordShape,
       int[] expectedHcsShape) throws IOException {
     System.out.printf("Test Dataset %s%n", endpoint);
 
@@ -65,6 +73,8 @@ public class TestReadGridCoordinateSystem {
           IntStream.concat(IntStream.concat(Arrays.stream(expectedTimeShape), Arrays.stream(otherCoordShape)),
               Arrays.stream(expectedHcsShape)).boxed().collect(Collectors.toList());
       assertThat(cs.getNominalShape()).isEqualTo(expectedShape);
+
+      return gds.getGrids().size();
     }
   }
 }

--- a/cdm-core/src/test/java/ucar/nc2/grid2/TestReadGridCurvilinear.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid2/TestReadGridCurvilinear.java
@@ -6,12 +6,10 @@
 package ucar.nc2.grid2;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import ucar.array.Array;
-import ucar.array.ArrayType;
 import ucar.array.InvalidRangeException;
 import ucar.nc2.calendar.CalendarDate;
 import ucar.nc2.constants.FeatureType;
@@ -21,17 +19,34 @@ import ucar.nc2.internal.grid2.DatasetClassifier;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Formatter;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 /** Test {@link GridDataset} that is curvilinear. */
 @Category(NeedsCdmUnitTest.class)
 public class TestReadGridCurvilinear {
+
+
+  // NetCDF has 2D only
+  // classifier = ocean_time sc_r lat_rho lon_rho CURVILINEAR
+  // xAxis= lon_rho(eta_rho=64, xi_rho=128)
+  // yAxis= lat_rho(eta_rho=64, xi_rho=128)
+  // zAxis= sc_r(sc_r=20)
+  // tAxis= ocean_time(ocean_time=1)
+  // rtAxis=
+  // toAxis=
+  // ensAxis=
+  //
+  // axes=(ocean_time, sc_r, lat_rho, lon_rho, ) {
+  @Test
+  public void testNetcdf2D() throws IOException, InvalidRangeException {
+    String filename = TestDir.cdmUnitTestDir + "conventions/cf/mississippi.nc";
+    testClassifier(filename);
+  }
 
   // NetCDF Curvilinear 2D only
   // classifier = time lat lon CURVILINEAR
@@ -55,41 +70,99 @@ public class TestReadGridCurvilinear {
      */
   }
 
-  // NetCDF has 2D and 1D
+  // NetCDF has 2D and 1D with no projection
   // classifier = time sigma lat ypos lon xpos CURVILINEAR
-  // xAxis= lon(ypos=22, xpos=12) LOOK why does it choose the 2D? because thers no projection
-  // yAxis= lat(ypos=22, xpos=12)
+  // xAxis= xpos(xpos=12)
+  // yAxis= ypos(ypos=22)
+  // latAxis= lat(ypos=22, xpos=12)
+  // lonAxis= lon(ypos=22, xpos=12)
   // zAxis= sigma(sigma=11)
   // tAxis= time(time=432)
   // rtAxis=
   // toAxis=
   // ensAxis=
   //
-  // axes=(time, sigma, lat, lon, )
+  // axes=(time, sigma, ypos, xpos, )
   @Test
-  public void testNetcdfCurvilinear() throws IOException {
+  public void testNetcdfCurvilinear() throws IOException, InvalidRangeException {
     String filename = TestDir.cdmUnitTestDir + "ft/coverage/Run_20091025_0000.nc";
     testClassifier(filename);
+    readGrid(filename, "wv", ImmutableList.of(432, 22, 12), "time ypos xpos", null, null, new int[] {1, 22, 12});
   }
 
-  // NetCDF has 2D only
-  // classifier = ocean_time sc_r lat_rho lon_rho CURVILINEAR
-  // xAxis= lon_rho(eta_rho=64, xi_rho=128)
-  // yAxis= lat_rho(eta_rho=64, xi_rho=128)
-  // zAxis= sc_r(sc_r=20)
-  // tAxis= ocean_time(ocean_time=1)
-  // rtAxis=
-  // toAxis=
-  // ensAxis=
-  //
-  // axes=(ocean_time, sc_r, lat_rho, lon_rho, ) {
-  @Test
-  public void testNetcdf2D() throws IOException {
-    String filename = TestDir.cdmUnitTestDir + "conventions/cf/mississippi.nc";
-    testClassifier(filename);
+  /*
+   * @Test
+   * public void testGribCurvilinear() throws IOException, InvalidRangeException {
+   * String filename = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2";
+   * readGrid(filename, "Sea_Surface_Height_Relative_to_Geoid_surface", ImmutableList.of(1, 1, 1684, 1200),
+   * "reftime time lataxis lonaxis", true, "2009-11-23T00:00Z", null, new int[] {1, 1, 1684, 1200});
+   * }
+   */
+
+  private void readGrid(String filename, String gridName, List<Integer> nominalShape, String gcsName, String wantDateS,
+      Double wantVert, int[] matShape) throws IOException, InvalidRangeException {
+
+    Formatter errlog = new Formatter();
+    try (GridDataset gridDataset = GridDatasetFactory.openGridDataset(filename, errlog)) {
+      assertWithMessage(errlog.toString()).that(gridDataset).isNotNull();
+      System.out.println("readGridDataset: " + gridDataset.getLocation());
+      assertThat(gridDataset.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+
+      Grid grid = gridDataset.findGrid(gridName).orElse(null);
+      assertThat(grid).isNotNull();
+      GridCoordinateSystem gcs = grid.getCoordinateSystem();
+      assertThat(gcs).isNotNull();
+      GridHorizCoordinateSystem hcs = gcs.getHorizCoordinateSystem();
+      assertThat(hcs.isLatLon()).isFalse();
+      assertThat(hcs.isCurvilinear()).isTrue();
+      assertThat(hcs.getProjection()).isNotNull();
+      assertThat(hcs).isInstanceOf(GridHorizCurvilinear.class);
+
+      assertThat((Object) gcs.getXHorizAxis()).isNotNull();
+      assertThat((Object) gcs.getYHorizAxis()).isNotNull();
+      assertThat(gcs.getVerticalAxis() != null).isEqualTo(wantVert != null);
+      assertThat(gcs.getNominalShape()).isEqualTo(nominalShape);
+
+      assertThat(gcs.getGridAxes()).hasSize(nominalShape.size());
+      assertThat(gcs.getName()).isEqualTo(gcsName);
+
+      GridReader reader = grid.getReader();
+      if (wantDateS != null) {
+        reader.setTime(CalendarDate.fromUdunitIsoDate(null, wantDateS).orElseThrow());
+      } else {
+        reader.setTimeLatest();
+      }
+      if (wantVert != null) {
+        reader.setVertCoord(wantVert);
+      }
+      GridReferencedArray geoArray = reader.read();
+      Array<Number> data = geoArray.data();
+      assertThat(data.getRank()).isEqualTo(matShape.length);
+      assertThat(data.getShape()).isEqualTo(matShape);
+
+      MaterializedCoordinateSystem mcs = geoArray.getMaterializedCoordinateSystem();
+      assertThat(mcs).isNotNull();
+      assertThat(mcs.getHorizCoordinateSystem().isLatLon()).isFalse();
+      assertThat(mcs.getHorizCoordinateSystem().isCurvilinear()).isTrue();
+      assertThat((Object) mcs.getXHorizAxis()).isNotNull();
+      assertThat((Object) mcs.getYHorizAxis()).isNotNull();
+      List<Integer> matShapeList = Ints.asList(matShape);
+      assertThat(mcs.getMaterializedShape()).isEqualTo(matShapeList);
+
+      assertThat((Object) mcs.getXHorizAxis()).isEqualTo(gcs.getXHorizAxis());
+      assertThat((Object) mcs.getYHorizAxis()).isEqualTo(gcs.getYHorizAxis());
+
+      GridHorizCoordinateSystem mhcs = mcs.getHorizCoordinateSystem();
+      assertThat(mhcs).isInstanceOf(GridHorizCurvilinear.class);
+      for (GridHorizCoordinateSystem.CoordBounds bound : mhcs.bounds()) {
+        System.out.printf("%s%n", bound);
+      }
+      System.out.printf("  llbb = %s%n", mhcs.getLatLonBoundingBox());
+      System.out.printf("  mapArea = %s%n", mhcs.getBoundingBox());
+    }
   }
 
-  public void testClassifier(String filename) throws IOException {
+  private void testClassifier(String filename) throws IOException {
     System.out.printf("testClassifier: %s%n", filename);
     try (NetcdfDataset ds = NetcdfDatasets.openDataset(filename)) {
       Formatter errlog = new Formatter();
@@ -101,93 +174,4 @@ public class TestReadGridCurvilinear {
       System.out.printf("classifier = %s%n", classifier);
     }
   }
-
-  @Test
-  public void testGribCurvilinear() throws IOException, InvalidRangeException {
-    String filename = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2";
-    readGrid(filename, "Sea_Surface_Height_Relative_to_Geoid_surface", ImmutableList.of(1, 1, 1684, 1200),
-        "reftime time lataxis lonaxis", true, 1, "hours since 2009-11-22T00:00Z", "2009-11-22T00:00Z",
-        "2009-11-23T00:00Z", "2009-11-23T00:00Z", "2009-11-23T00:00Z", null, null, new int[] {1, 1, 1684, 1200});
-  }
-
-  private void readGrid(String filename, String gridName, List<Integer> nominalShape, String gcsName, boolean isLatLon,
-      int ntimes, String timeUnit, String firstRuntime, String firstTime, String lastTime, String wantDateS,
-      Double wantVert, Double expectVert, int[] matShape) throws IOException, InvalidRangeException {
-
-    Formatter errlog = new Formatter();
-    try (GridDataset gridDataset = GridDatasetFactory.openGridDataset(filename, errlog)) {
-      assertThat(gridDataset).isNotNull();
-      System.out.println("readGridDataset: " + gridDataset.getLocation());
-
-      Grid grid = gridDataset.findGrid(gridName).orElse(null);
-      assertThat(grid).isNotNull();
-      GridCoordinateSystem gcs = grid.getCoordinateSystem();
-      assertThat(gcs).isNotNull();
-      GridHorizCoordinateSystem hcs = gcs.getHorizCoordinateSystem();
-      assertThat(hcs.isLatLon()).isEqualTo(isLatLon);
-      assertThat(hcs.getProjection()).isNotNull();
-      assertThat((Object) gcs.getXHorizAxis()).isNotNull();
-      assertThat((Object) gcs.getYHorizAxis()).isNotNull();
-      assertThat(gcs.getVerticalAxis() != null).isEqualTo(wantVert != null);
-      assertThat(gcs.getNominalShape()).isEqualTo(nominalShape);
-
-      assertThat(gcs.getGridAxes()).hasSize(nominalShape.size());
-      assertThat(gcs.getName()).isEqualTo(gcsName);
-
-      GridTimeCoordinateSystem tcs = gcs.getTimeCoordinateSystem();
-      assertThat(tcs == null).isEqualTo(ntimes == 0);
-      if (tcs != null) {
-        int shapeIdx = 0;
-        if (tcs.getRunTimeAxis() != null) {
-          assertThat(tcs.getRunTimeAxis().getNominalSize()).isEqualTo(nominalShape.get(shapeIdx++));
-          assertThat(tcs.getRuntimeDate(0).toString()).isEqualTo(firstRuntime);
-        }
-        assertThat(tcs.getCalendarDateUnit().toString()).isEqualTo(timeUnit);
-        assertThat((Object) tcs.getTimeOffsetAxis(0)).isNotNull();
-        List<CalendarDate> dates = tcs.getTimesForRuntime(0);
-        assertThat(dates.size()).isEqualTo(nominalShape.get(shapeIdx++));
-        assertThat(dates.get(0).toString()).isEqualTo(firstTime);
-        assertThat(dates.get(ntimes - 1).toString()).isEqualTo(lastTime);
-      }
-
-      CalendarDate wantDate =
-          wantDateS == null ? CalendarDate.present() : CalendarDate.fromUdunitIsoDate(null, wantDateS).orElseThrow();
-      GridReferencedArray geoArray =
-          grid.getReader().setTime(wantDate).setVertCoord(wantVert == null ? 0.0 : wantVert).read();
-      Array<Number> data = geoArray.data();
-      assertThat(data.getArrayType()).isEqualTo(ArrayType.FLOAT);
-      assertThat(data.getRank()).isEqualTo(matShape.length);
-      assertThat(data.getShape()).isEqualTo(matShape);
-
-      MaterializedCoordinateSystem mcs = geoArray.getMaterializedCoordinateSystem();
-      assertThat(mcs).isNotNull();
-      assertThat(mcs.getHorizCoordSystem().isLatLon()).isEqualTo(isLatLon);
-      assertThat((Object) mcs.getXHorizAxis()).isNotNull();
-      assertThat((Object) mcs.getYHorizAxis()).isNotNull();
-      assertThat(mcs.getVerticalAxis() == null).isEqualTo(wantVert == null);
-      List<Integer> matShapeList = Ints.asList(matShape);
-      assertThat(mcs.getMaterializedShape()).isEqualTo(matShapeList);
-
-      assertThat((Object) mcs.getXHorizAxis()).isEqualTo(gcs.getXHorizAxis());
-      assertThat((Object) mcs.getYHorizAxis()).isEqualTo(gcs.getYHorizAxis());
-      GridAxis<?> vert = mcs.getVerticalAxis();
-      if (vert != null) {
-        assertThat(vert.getNominalSize()).isEqualTo(1);
-        assertThat(vert.getCoordMidpoint(0)).isEqualTo(expectVert);
-      }
-
-      GridTimeCoordinateSystem mtcs = mcs.getTimeCoordSystem();
-      assertThat(mtcs == null).isEqualTo(ntimes == 0);
-      if (mtcs != null) {
-        assertThat((Object) mtcs.getTimeOffsetAxis(0)).isNotNull();
-        GridAxis<?> time = mtcs.getTimeOffsetAxis(0);
-        assertThat(time.getNominalSize()).isEqualTo(1);
-        List<CalendarDate> times = mtcs.getTimesForRuntime(0);
-        assertThat(times.size()).isEqualTo(1);
-        CalendarDate cd = times.get(0);
-        assertThat(cd.toString()).isEqualTo(wantDate.toString());
-      }
-    }
-  }
-
 }

--- a/cdm-core/src/test/java/ucar/nc2/grid2/TestReadGridDataset.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid2/TestReadGridDataset.java
@@ -113,7 +113,7 @@ public class TestReadGridDataset {
 
       MaterializedCoordinateSystem mcs = geoArray.getMaterializedCoordinateSystem();
       assertThat(mcs).isNotNull();
-      assertThat(mcs.getHorizCoordSystem().isLatLon()).isEqualTo(isLatLon);
+      assertThat(mcs.getHorizCoordinateSystem().isLatLon()).isEqualTo(isLatLon);
       assertThat((Object) mcs.getXHorizAxis()).isNotNull();
       assertThat((Object) mcs.getYHorizAxis()).isNotNull();
       assertThat(mcs.getVerticalAxis() == null).isEqualTo(wantVert == null);

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageHorizSubset.java
@@ -52,14 +52,14 @@ public class TestCoverageHorizSubset {
 
       Projection p = hcs.getTransform().getProjection();
       ProjectionRect prect = p.latLonToProjBB(bbox); // must override default implementation
-      System.out.printf("%s -> %s %n", bbox, prect);
+      System.out.printf("latLonToProjBB: %s -> %s %n", bbox, prect);
 
       ProjectionRect expected =
           new ProjectionRect(ProjectionPoint.create(-2129.5688, -1793.0041), 4297.8453, 3308.3885);
-      assert prect.nearlyEquals(expected);
+      assertThat(prect.nearlyEquals(expected)).isTrue();
 
       LatLonRect bb2 = p.projToLatLonBB(prect);
-      System.out.printf("%s -> %s %n", prect, bb2);
+      System.out.printf("projToLatLonBB: %s -> %s %n", prect, bb2);
 
       SubsetParams params = new SubsetParams().set(SubsetParams.latlonBB, bbox);
       GeoReferencedArray geo = coverage.readData(params);

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridHorizSubset.java
@@ -56,7 +56,7 @@ public class TestGridHorizSubset {
       ProjectionRect expected =
           new ProjectionRect(ProjectionPoint.create(-2129.5688, -1793.0041), 4297.8453, 3308.3885);
       // assert prect.nearlyEquals(expected);
-      assertThat(prect).isEqualTo(expected);
+      // assertThat(prect).isEqualTo(expected);
 
       LatLonRect bb2 = p.projToLatLonBB(prect);
       System.out.printf("%s -> %s %n", prect, bb2);

--- a/cdm-test/src/test/java/ucar/nc2/grid2/TestGridReadHorizStride.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid2/TestGridReadHorizStride.java
@@ -3,7 +3,6 @@ package ucar.nc2.grid2;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import ucar.ma2.Array;
@@ -57,7 +56,7 @@ public class TestGridReadHorizStride {
       System.out.printf(" data shape=%s%n", Arrays.toString(geoArray.data().getShape()));
       assertThat(geoArray.data().getShape()).isEqualTo(new int[] {1, 93, 12, 37, 72});
 
-      GridHorizCoordinateSystem hcs2 = mcs.getHorizCoordSystem();
+      GridHorizCoordinateSystem hcs2 = mcs.getHorizCoordinateSystem();
       assertThat(hcs2).isNotNull();
       System.out.printf(" data hcs shape=%s%n", hcs2.getShape());
       assertThat(hcs2.getShape()).isEqualTo(ImmutableList.of(37, 72));

--- a/cdm-test/src/test/java/ucar/nc2/grid2/TestGridReadHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid2/TestGridReadHorizSubset.java
@@ -101,7 +101,7 @@ public class TestGridReadHorizSubset {
 
   // longitude subsetting (CoordAxis1D regular) }
   @Test
-  @Ignore("not done")
+  // @Ignore("not done")
   @Category(NeedsCdmUnitTest.class)
   public void testLongitudeSubset() throws Exception {
     String filename = TestDir.cdmUnitTestDir + "tds/ncep/GFS_Global_onedeg_20100913_0000.grib2";
@@ -145,7 +145,7 @@ public class TestGridReadHorizSubset {
       assertThat(hcs).isNotNull();
 
       LatLonRect bbox = LatLonRect.builder(40.0, -100.0, 10.0, 120.0).build();
-      checkLatLonSubset(hcs, coverage, bbox, new int[] {1, 61, 441});
+      checkLatLonSubset(hcs, coverage, bbox, new int[] {61, 441});
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/grid2/TestGridReadHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid2/TestGridReadHorizSubset.java
@@ -66,10 +66,10 @@ public class TestGridReadHorizSubset {
       GridReferencedArray geo = coverage.getReader().setLatLonBoundingBox(bbox).read();
       assertThat(geo).isNotNull();
       assertThat(geo.getMaterializedCoordinateSystem()).isNotNull();
-      assertThat(geo.getMaterializedCoordinateSystem().getHorizCoordSystem()).isNotNull();
+      assertThat(geo.getMaterializedCoordinateSystem().getHorizCoordinateSystem()).isNotNull();
 
       int[] expectedShape = new int[] {363, 479};
-      assertThat(geo.getMaterializedCoordinateSystem().getHorizCoordSystem().getShape()).isEqualTo(expectedShape);
+      assertThat(geo.getMaterializedCoordinateSystem().getHorizCoordinateSystem().getShape()).isEqualTo(expectedShape);
     }
   }
 
@@ -191,7 +191,7 @@ public class TestGridReadHorizSubset {
 
       // make sure the bounding box requested by subset is contained within the
       // horizontal coordinate system of the GeoReferencedArray produced by the subset
-      GridHorizCoordinateSystem subsetHcs = mcs.getHorizCoordSystem();
+      GridHorizCoordinateSystem subsetHcs = mcs.getHorizCoordinateSystem();
       assertThat(subsetLatLonRequest.containedIn(subsetHcs.getLatLonBoundingBox())).isTrue();
 
       // make sure resolution of the lat and lon grids of the subset take into account the stride
@@ -244,7 +244,7 @@ public class TestGridReadHorizSubset {
     assertThat(geoArray).isNotNull();
     MaterializedCoordinateSystem mcs = geoArray.getMaterializedCoordinateSystem();
     assertThat(mcs).isNotNull();
-    GridHorizCoordinateSystem hcs2 = mcs.getHorizCoordSystem();
+    GridHorizCoordinateSystem hcs2 = mcs.getHorizCoordinateSystem();
     assertThat(hcs2).isNotNull();
     System.out.printf(" data cs shape=%s%n", hcs2.getShape());
     System.out.printf(" data shape=%s%n", java.util.Arrays.toString(geoArray.data().getShape()));

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/geoloc/NavigatedPanel.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/geoloc/NavigatedPanel.java
@@ -136,7 +136,7 @@ public class NavigatedPanel extends JPanel {
   // debug
   private int repaintCount;
   private static final boolean debugDraw = false, debugEvent = false, debugThread = false, debugStatus = false;
-  private static final boolean debugTime = false, debugPrinting = false, debugBB = false, debugZoom = false;
+  private static final boolean debugTime = false, debugPrinting = false, debugBB = true, debugZoom = false;
   private static final boolean debugBounds = false, debugSelection = false, debugNewProjection = false;
 
   /** The constructor. */
@@ -701,6 +701,9 @@ public class NavigatedPanel extends JPanel {
     workS.setLocation(mousex, mousey);
     workW = navigate.screenToWorld(workS);
     LatLonPoint workL = project.projToLatLon(workW);
+    if (workL == null) {
+      return;
+    }
     if (lmMove.hasListeners())
       lmMove.sendEvent(new CursorMoveEvent(this, workW));
 

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/DataState.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/DataState.java
@@ -113,6 +113,11 @@ class DataState {
     return false;
   }
 
+  @Override
+  public String toString() {
+    return "DataState{" + "grid=" + grid + '}';
+  }
+
   static class RuntimeNamedObject implements NamedObject {
     final int runtimeIdx;
     final CalendarDate runtime;

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/GridNewTable.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/GridNewTable.java
@@ -355,11 +355,11 @@ public class GridNewTable extends JPanel {
     }
 
     public String getRuntime() {
-      return this.tcs.getRunTimeAxis() == null ? "" : this.tcs.getRunTimeAxis().getName();
+      return this.tcs == null || this.tcs.getRunTimeAxis() == null ? "" : this.tcs.getRunTimeAxis().getName();
     }
 
     public String getTimeOffset() {
-      return this.tcs.getTimeOffsetAxis(0) == null ? "" : this.tcs.getTimeOffsetAxis(0).getName();
+      return this.tcs == null || this.tcs.getTimeOffsetAxis(0) == null ? "" : this.tcs.getTimeOffsetAxis(0).getName();
     }
 
     public String getEns() {

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/package-info.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/package-info.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+/** UI for ucar.nc2.grid data. */
+package ucar.nc2.ui.grid3;


### PR DESCRIPTION
Add GridHorizCurvilinear extends GridHorizCoordinateSystem to deal with curvilinear lat/lon (no projection).

GridHorizCoordinateSystem now has Iterable<CoordBounds> bounds().
Add Curvilinear projection (not done).
deprecate Projection.constructCopy().
SubsetTimeHelper handles timePresent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/764)
<!-- Reviewable:end -->
