### PR TITLE
[5.x]: Enable the use of a persisted FMRC cache

### DIFF
--- a/cdm/core/src/main/java/thredds/inventory/MControllerProvider.java
+++ b/cdm/core/src/main/java/thredds/inventory/MControllerProvider.java
@@ -22,7 +22,7 @@ public interface MControllerProvider {
   /**
    * Creates an instance of
    * 
-   * @return An {@link MController} that scans locations to filter and provide a set of {@linik MFile}s defining to
+   * @return An {@link MController} that scans locations to filter and provide a set of {@link MFile}s defining to
    *         be used to define a collection.
    */
   MController create();

--- a/cdm/core/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
@@ -65,16 +65,6 @@ public class GridDatasetInv {
     }
   }
 
-  /**
-   * Check if a given version of the GribDatasetInv xml format can be read by this code.
-   *
-   * @param version GridDatasetInv xml format version
-   * @return true if version can be read, otherwise false.
-   */
-  public static boolean isXmlVersionCompatible(int version) {
-    return version >= REQ_VERSION;
-  }
-
   private static class GenerateInv implements Callable<GridDatasetInv> {
     private final MCollection cm;
     private final MFile mfile;
@@ -203,30 +193,21 @@ public class GridDatasetInv {
     return location;
   }
 
+  /**
+   * Check if the GribDatasetInv xml format can be fully understood by this code.
+   *
+   * @return true if version can be fully understood, otherwise false.
+   */
+  public boolean isXmlVersionCompatible() {
+    return this.version >= REQ_VERSION;
+  }
+
   public String getLocation() {
     return location;
   }
 
   public long getLastModified() {
     return lastModified.getTime();
-  }
-
-  /**
-   * Version of the grid inventory format used by this inventory object
-   *
-   * @return grid inventory version
-   */
-  public int getVersion() {
-    return version;
-  }
-
-  /**
-   * Minimum support version of the GridDatasetInv inventory format that can be read.
-   *
-   * @return minimum supported version
-   */
-  public static int getMinimumSupportedVersion() {
-    return REQ_VERSION;
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/ft/fmrc/InventoryCacheProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/ft/fmrc/InventoryCacheProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.internal.dataset.ft.fmrc;
+
+import thredds.inventory.MFile;
+import ucar.nc2.ft.fmrc.GridDatasetInv;
+
+import javax.annotation.Nullable;
+import java.io.*;
+
+/**
+ * Service Provider Interface for providing a persisted cache for {@link GridDatasetInv}.
+ *
+ * For use by the THREDDS Data Server and not intended to be used publicly.
+ *
+ */
+public interface InventoryCacheProvider {
+
+  /**
+   * Get the grid inventory associated with an MFile from the cache.
+   *
+   * @param mfile the mfile containing gridded data
+   * @return grid inventory of the of mfile, null if not found
+   * @throws IOException
+   */
+  @Nullable
+  public GridDatasetInv get(MFile mfile) throws IOException;
+
+  /**
+   * Add the grid inventory associated with an MFile to the cache.
+   *
+   * @param mfile the mfile containing gridded data
+   * @param inventory the grid inventory of the of mfile
+   * @throws IOException
+   */
+  public void put(MFile mfile, GridDatasetInv inventory) throws IOException;
+
+}

--- a/cdm/core/src/main/java/ucar/unidata/io/RandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/RandomAccessFile.java
@@ -1456,7 +1456,7 @@ public class RandomAccessFile implements DataInput, DataOutput, FileCacheable, C
    * The charset parameter is an extension not implemented in java.io.RandomAccessFile.
    *
    * @param charset - character encoding to use
-   * @return
+   * @return the next line of text
    * @throws IOException
    */
   public String readLine(Charset charset) throws IOException {


### PR DESCRIPTION
## Description of Changes

In this PR, I've added hooks to allow for the runtime loading of a persisted FMRC cache (specifically, the `GridDatasetInv` objects). This is very much needed by the TDS. This does not need to be ported forward at this point. Unrelated, I also fixed two minor javadoc warnings. Closes Unidata/netcdf-java#771.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [X] Link to any issues that the PR addresses
- [X] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/772)
<!-- Reviewable:end -->
