### PR TITLE
[5.x]: DtCoverageDataset bug and failing Jenkins tests

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestRemoteCoverage.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestRemoteCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.ft.coverage;
@@ -58,7 +58,7 @@ public class TestRemoteCoverage {
 
       int[] shape = geoCoordsys.getShape();
       logger.debug("grid_section.getShape = {}", new Section(shape));
-      int[] expectShape = new int[] {1, 31, 241, 480};
+      int[] expectShape = new int[] {1, 41, 241, 480};
       Assert.assertArrayEquals("subset shape", expectShape, shape);
     }
   }

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
@@ -90,12 +90,13 @@ public class TestGribCollectionCoordinates {
     config.gribConfig.setExcludeZero(true); // no longer the default
 
     boolean changed = GribCdmIndex.updateGribCollection(config, CollectionUpdateType.always, logger);
+    String topLevelIndex = GribCdmIndex.getTopIndexFileFromConfig(config).getAbsolutePath();
+
     System.out.printf("changed = %s%n", changed);
 
     boolean ok = true;
 
-    try (NetcdfDataset ds =
-        NetcdfDatasets.openDataset(TestDir.cdmUnitTestDir + "gribCollections/namAlaska22/namAlaska22.ncx4")) {
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(topLevelIndex)) {
       for (Variable vds : ds.getVariables()) {
         String stdname = vds.findAttributeString("standard_name", "no");
         if (!stdname.equalsIgnoreCase("time"))
@@ -147,11 +148,10 @@ public class TestGribCollectionCoordinates {
 
     boolean changed = GribCdmIndex.updateGribCollection(config, updateMode, logger);
     System.out.printf("changed = %s%n", changed);
-
+    String topLevelIndex = GribCdmIndex.getTopIndexFileFromConfig(config).getAbsolutePath();
     boolean ok = true;
 
-    try (NetcdfDataset ds =
-        NetcdfDatasets.openDataset(TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4")) {
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(topLevelIndex)) {
       for (Variable vds : ds.getVariables()) {
         String stdname = vds.findAttributeString("standard_name", "no");
         if (!stdname.equalsIgnoreCase("forecast_reference_time"))

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageDataset.java
@@ -118,7 +118,7 @@ public class DtCoverageDataset implements Closeable {
     Set<NetcdfDataset.Enhance> enhance = ncd.getEnhanceMode();
     if (enhance == null || enhance.isEmpty())
       enhance = NetcdfDataset.getDefaultEnhanceMode();
-    NetcdfDatasets.enhance(ncd, enhance, null);
+    ncd = NetcdfDatasets.enhance(ncd, enhance, null);
 
     DtCoverageCSBuilder facc = DtCoverageCSBuilder.classify(ncd, parseInfo);
     if (facc != null)


### PR DESCRIPTION
## Description of Changes

This PR fixes a bug in the `DtCoverageDataset`, as well as addresses the remaining failing Jenkins tests on the `5.x` branch.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/775)
<!-- Reviewable:end -->
