### PR TITLE
[5.x]: Fix root publishing script

### DIFF
--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -30,7 +30,6 @@ configurations {
   ncIdv
   netcdfAll
   toolsUI
-  dap4lib
 }
 
 dependencies {
@@ -62,11 +61,6 @@ dependencies {
   toolsUI enforcedPlatform(project(':netcdf-java-platform'))
   toolsUI project(':uicdm')
   toolsUI 'ch.qos.logback:logback-classic'
-
-  dap4lib enforcedPlatform(project(':netcdf-java-platform'))
-  dap4lib project(':dap4:d4core')
-  dap4lib project(':dap4:d4lib')
-  dap4lib 'ch.qos.logback:logback-classic'
 }
 
 def fatJarTasks = []
@@ -110,17 +104,6 @@ fatJarTasks << tasks.create(name: 'buildToolsUI', type: ShadowJar) {
   }
 }
 
-fatJarTasks << tasks.create(name: 'buildDap4Lib', type: ShadowJar) {
-  archiveBaseName = 'dap4lib'
-  baseName = 'dap4lib'
-  setArchiveBaseName('dap4lib')
-  configurations = [project.configurations.dap4lib]
-
-  doFirst {
-    manifest.attributes project(':dap4:d4lib').tasks.jar.manifest.attributes
-  }
-}
-
 // Common configuration.
 configure(fatJarTasks) {
   dependsOn configurations*.buildDependencies
@@ -154,5 +137,4 @@ artifacts {
   archives buildNcIdv
   archives buildNetcdfAll
   archives buildToolsUI
-  archives buildDap4Lib
 }

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -82,7 +82,7 @@ def createChecksumsTask = tasks.register('createChecksums') {
       }
     }
   }
-  dependsOn buildDap4Lib, buildNcIdv, buildNetcdfAll, buildToolsUI
+  dependsOn buildNcIdv, buildNetcdfAll, buildToolsUI
 }
 
 def publishFatJarsTask = tasks.register('publishFatJars', PublishToRawRepoTask) {

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -105,3 +105,21 @@ def publishFatJarsTask = tasks.register('publishFatJars', PublishToRawRepoTask) 
 }
 
 publish.dependsOn publishFatJarsTask
+
+// The "publish" tasks for all subprojects require credentials for our Nexus server, which they look for in Gradle
+// properties. If those properties (i.e. NEXUS_USERNAME_KEY and NEXUS_PASSWORD_KEY) haven't been provided, the build
+// will fail. Therefore, we only want to configure credentials when a "publish" task is part of the execution plan.
+// Otherwise, unavailable credentials could cause a build to fail even if we aren't doing any publishing. The
+// TaskExecutionGraph allows us to do that.
+gradle.taskGraph.whenReady {TaskExecutionGraph taskGraph ->
+  // This won't find any publishToMavenLocal tasks. Those are of type PublishToMavenLocal
+  Collection<Task> mavenPublishTasks = taskGraph.allTasks.findAll {
+    it instanceof PublishToMavenRepository
+  }
+  mavenPublishTasks.each {
+    it.repository.credentials.with {
+      username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+      password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
+    }
+  }
+ }


### PR DESCRIPTION
## Description of Changes

When making changes to publishing of the `fatJar` artifacts to the download raw repo instead of the maven repo (Unidata/netcdf-java#777), I removed some code that was necessary for passing credentials to the code that handles publishing to the maven repo. This PR restores that code and now things work again. Also, dap4lib.jar does not appear to be documented or used anywhere, so I've removed it from the `fatJar` generation process.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/778)
<!-- Reviewable:end -->
