### PR TITLE
[6.x]: Finish port of Unidata/netcdf-java#718

### DIFF
--- a/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
+++ b/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -7,8 +7,6 @@ package ucar.nc2.ffi.netcdf;
 
 import com.google.common.base.Strings;
 import com.sun.jna.Native;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 import ucar.nc2.jni.netcdf.Nc4prototypes;
 
@@ -119,15 +117,6 @@ public class NetcdfClibrary {
   private static Nc4prototypes load() {
     if (nc4 == null) {
       if (jnaPath == null) {
-        // netCDF-C will return strings encoded as UTF-8 (not default C behavior).
-        // JNA assumes c code is returning using the system encoding by default
-        // So, if the system encoding isn't UTF_8 (hello, windows!), set the jna
-        // encoding to utf_8. LOOK: This might hose other application use JNA and
-        // not expect their c code to return UTF-8
-        if (!Charset.defaultCharset().equals(StandardCharsets.UTF_8)) {
-          log.info("Setting System Property jna.encoding to UTF8");
-          // System.setProperty("jna.encoding", StandardCharsets.UTF_8.name());
-        }
         setLibraryNameAndPath(null, null);
       }
       try {


### PR DESCRIPTION
## Description of Changes

Finish port of Unidata/netcdf-java#718 to `6.x` branch

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/782)
<!-- Reviewable:end -->
