### PR TITLE
[7.x]: Port farJar publishing changes from maint-5.x branch

### DIFF
--- a/gradle/any/javadoc.gradle
+++ b/gradle/any/javadoc.gradle
@@ -7,7 +7,7 @@ tasks.withType(Javadoc).all {  // Common Javadoc config.
 
   // When instances of JDK classes appear in our Javadoc (e.g. "java.lang.String"), create links out of them to
   // Oracle's JavaSE 8 Javadoc.
-  options.links('https://docs.oracle.com/javase/8/docs/api/')
+  options.links('https://docs.oracle.com/en/java/javase/11/docs/api/')
 
   if (JavaVersion.current().isJava8Compatible()) {
     // doclint="all" (the default) will identify 100s of errors in our docs and cause no Javadoc to be generated.

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -31,7 +31,9 @@ configurations {
 }
 
 dependencies {
+  toolsUI enforcedPlatform(project(':netcdf-java-platform'))
   toolsUI project(':toolsui:uicdm')
+  toolsUI 'ch.qos.logback:logback-classic'
 }
 
 def fatJarTasks = []

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -43,42 +43,44 @@ import java.security.MessageDigest
 def createChecksumsTask = tasks.register('createChecksums') {
   group = 'publishing'
   description = 'Create .sha1, .sha256, and .md5 checksum files for the fatJars.'
-  String sourceDir = "${rootProject.getBuildDir()}/libs"
-  def files = fileTree(dir: "${sourceDir}", include: '**/*.jar')
-  def algorithms = ["MD5", "SHA-1", "SHA-256"]
-  algorithms.each {algorithm ->
-    MessageDigest md = MessageDigest.getInstance(algorithm)
-    files.each { File jarFile ->
-      InputStream is = null
-      DigestInputStream dis = null
-      byte[] buffer = new byte[2048]
-      try {
-        is = Files.newInputStream(Paths.get(jarFile.absolutePath))
-        dis = new DigestInputStream(is, md)
-        while (dis.read(buffer) != -1) {
-          // just need to read through the file
-        }
-        dis.close()
-        is.close()
-      } finally {
-        if (dis != null) {
+  doLast {
+    String sourceDir = "${rootProject.getBuildDir()}/libs"
+    def files = fileTree(dir: "${sourceDir}", include: '**/*.jar')
+    def algorithms = ["MD5", "SHA-1", "SHA-256"]
+      algorithms.each { algorithm ->
+      MessageDigest md = MessageDigest.getInstance(algorithm)
+      files.each { File jarFile ->
+        InputStream is = null
+        DigestInputStream dis = null
+        byte[] buffer = new byte[2048]
+        try {
+          is = Files.newInputStream(Paths.get(jarFile.absolutePath))
+          dis = new DigestInputStream(is, md)
+          while (dis.read(buffer) != -1) {
+            // just need to read through the file
+          }
           dis.close()
-        }
-        if (is != null) {
           is.close()
+        } finally {
+          if (dis != null) {
+            dis.close()
+          }
+          if (is != null) {
+            is.close()
+          }
         }
-      }
 
-      byte[] digest = md.digest()
-      StringBuilder sb = new StringBuilder()
-      for (int b=0; b < digest.length; b++) {
-        sb.append(Integer.toString((digest[b] & 0xff) + 0x100, 16).substring(1))
-      }
-      String checksum = sb.toString()
-      def ext = algorithm.toLowerCase().replace("-","")
-      String outputFilename = "${buildDir}/libs/${jarFile.getName()}.${ext}"
-      new File(outputFilename).withWriter { writer ->
-        writer.write checksum
+        byte[] digest = md.digest()
+        StringBuilder sb = new StringBuilder()
+        for (int b = 0; b < digest.length; b++) {
+          sb.append(Integer.toString((digest[b] & 0xff) + 0x100, 16).substring(1))
+        }
+        String checksum = sb.toString()
+        def ext = algorithm.toLowerCase().replace("-", "")
+        String outputFilename = "${buildDir}/libs/${jarFile.getName()}.${ext}"
+        new File(outputFilename).withWriter { writer ->
+          writer.write checksum
+        }
       }
     }
   }

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -82,7 +82,7 @@ def createChecksumsTask = tasks.register('createChecksums') {
       }
     }
   }
-  dependsOn buildDap4Lib, buildNcIdv, buildNetcdfAll, buildToolsUI
+  dependsOn buildToolsUI
 }
 
 def publishFatJarsTask = tasks.register('publishFatJars', PublishToRawRepoTask) {
@@ -105,3 +105,21 @@ def publishFatJarsTask = tasks.register('publishFatJars', PublishToRawRepoTask) 
 }
 
 publish.dependsOn publishFatJarsTask
+
+// The "publish" tasks for all subprojects require credentials for our Nexus server, which they look for in Gradle
+// properties. If those properties (i.e. NEXUS_USERNAME_KEY and NEXUS_PASSWORD_KEY) haven't been provided, the build
+// will fail. Therefore, we only want to configure credentials when a "publish" task is part of the execution plan.
+// Otherwise, unavailable credentials could cause a build to fail even if we aren't doing any publishing. The
+// TaskExecutionGraph allows us to do that.
+gradle.taskGraph.whenReady {TaskExecutionGraph taskGraph ->
+  // This won't find any publishToMavenLocal tasks. Those are of type PublishToMavenLocal
+  Collection<Task> mavenPublishTasks = taskGraph.allTasks.findAll {
+    it instanceof PublishToMavenRepository
+  }
+  mavenPublishTasks.each {
+    it.repository.credentials.with {
+      username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+      password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
+    }
+  }
+ }

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -1,47 +1,107 @@
+buildscript {
+  // Add the "buildPlugins" ExtraProperty. It should be usable from the rest of this script as well.
+  // See http://goo.gl/9bixNV
+  apply from: "$rootDir/gradle/any/shared-mvn-coords.gradle"
+
+  // The buildscript {} block is odd: even though we applied dependencies.gradle above, the repositories therein
+  // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
+  repositories {
+    gradlePluginPortal()
+    exclusiveContent {
+      forRepository {
+        maven {
+          url 'https://artifacts.unidata.ucar.edu/repository/unidata-all/'
+        }
+      }
+      // only look for unidata plugin related artifacts from the unidata-all repo
+      filter {
+        includeModule 'edu.ucar.unidata', 'unidata-nexus-gradle'
+      }
+    }
+  }
+
+  dependencies {
+    classpath buildPlugins.nexus
+  }
+}
+
 if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
 
-apply plugin: 'maven-publish'
+apply plugin: 'maven-publish' // gives us the publish task even though we are not going to publish anything to maven
 apply plugin: 'com.github.johnrengelman.shadow'
 apply from: "$rootDir/gradle/any/properties.gradle"  // For Nexus credential properties.
 
-import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
+import edu.ucar.build.publishing.tasks.PublishToRawRepoTask
 
-publishing {
-  // Publish all artifacts we've added to the "archives" configuration of the root project. See fatJars.gradle.
-  publications {
-    rootProject.configurations.archives.allArtifacts.each {
-      if (it instanceof ArchivePublishArtifact) {
-        AbstractArchiveTask task = (it as ArchivePublishArtifact).archiveTask
-        "$task.name"(MavenPublication) {
-          artifactId task.archiveBaseName.get()
-          artifact task
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.security.DigestInputStream
+import java.security.MessageDigest
+
+def createChecksumsTask = tasks.register('createChecksums') {
+  group = 'publishing'
+  description = 'Create .sha1, .sha256, and .md5 checksum files for the fatJars.'
+  String sourceDir = "${rootProject.getBuildDir()}/libs"
+  def files = fileTree(dir: "${sourceDir}", include: '**/*.jar')
+  def algorithms = ["MD5", "SHA-1", "SHA-256"]
+  algorithms.each {algorithm ->
+    MessageDigest md = MessageDigest.getInstance(algorithm)
+    files.each { File jarFile ->
+      InputStream is = null
+      DigestInputStream dis = null
+      byte[] buffer = new byte[2048]
+      try {
+        is = Files.newInputStream(Paths.get(jarFile.absolutePath))
+        dis = new DigestInputStream(is, md)
+        while (dis.read(buffer) != -1) {
+          // just need to read through the file
         }
+        dis.close()
+        is.close()
+      } finally {
+        if (dis != null) {
+          dis.close()
+        }
+        if (is != null) {
+          is.close()
+        }
+      }
+
+      byte[] digest = md.digest()
+      StringBuilder sb = new StringBuilder()
+      for (int b=0; b < digest.length; b++) {
+        sb.append(Integer.toString((digest[b] & 0xff) + 0x100, 16).substring(1))
+      }
+      String checksum = sb.toString()
+      def ext = algorithm.toLowerCase().replace("-","")
+      String outputFilename = "${buildDir}/libs/${jarFile.getName()}.${ext}"
+      new File(outputFilename).withWriter { writer ->
+        writer.write checksum
       }
     }
   }
+  dependsOn buildDap4Lib, buildNcIdv, buildNetcdfAll, buildToolsUI
 }
 
-tasks.withType(GenerateModuleMetadata) {
-  enabled = false
-}
+def publishFatJarsTask = tasks.register('publishFatJars', PublishToRawRepoTask) {
+  group = 'publishing'
+  description = 'Publish fatJars to Nexus downloads under /version/.'
+  host = 'https://artifacts.unidata.ucar.edu/'
+  repoName = 'downloads-netcdf-java'
 
-// The "publish" tasks require credentials for our Nexus server, which they look for in Gradle properties.
-// If those properties (i.e. NEXUS_USERNAME_KEY and NEXUS_PASSWORD_KEY) haven't been provided, the build will fail.
-// Therefore, we only want to configure credentials when a "publish" task is part of the execution plan. Otherwise,
-// unavailable credentials could cause a build to fail even if we aren't doing any publishing. The TaskExecutionGraph
-// allows us to do that.
-gradle.taskGraph.whenReady {TaskExecutionGraph taskGraph ->
-  // This won't find any publishToMavenLocal tasks. Those are of type PublishToMavenLocal
-  Collection<Task> mavenPublishTasks = taskGraph.allTasks.findAll {
-    it instanceof PublishToMavenRepository
-  }
+  publishSrc = new File(rootProject.getBuildDir(), "libs")
+  destPath = "$project.cleanVersion/"
+  dependsOn createChecksumsTask
 
-  mavenPublishTasks.each {
-    it.repository.credentials.with {
-      username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
-      password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
-    }
+  onlyIf {
+    // Will be evaluated at task execution time, not during configuration.
+    // Fails the build if the specified properties haven't been provided.
+    username = getPropertyOrFailBuild NEXUS_USERNAME_KEY
+    password = getPropertyOrFailBuild NEXUS_PASSWORD_KEY
+    return true
   }
 }
+
+publish.dependsOn publishFatJarsTask


### PR DESCRIPTION
## Description of Changes

Port Unidata/netcdf-java#777, Unidata/netcdf-java#778, Unidata/netcdf-java#788 from `5.x` to `7.x`. Also, make sure javadoc build links to oracle java 11 docs, not 8, or else the javadocs will not build.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/790)
<!-- Reviewable:end -->
