### PR TITLE
[5.x]: Port synchronize access to WmoCodeFlagTables getInstance() 

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/WmoCodeFlagTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/WmoCodeFlagTables.java
@@ -47,7 +47,7 @@ public class WmoCodeFlagTables {
 
   private static WmoCodeFlagTables instance;
 
-  public static WmoCodeFlagTables getInstance() {
+  public static synchronized WmoCodeFlagTables getInstance() {
     if (instance == null) {
       instance = new WmoCodeFlagTables();
       try {


### PR DESCRIPTION
## Description of Changes

Backport of Unidata/netcdf-java#784 from `develop` to `maint-5.x`.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/795)
<!-- Reviewable:end -->
