### PR TITLE
start porting Coverage tests to grid

### DIFF
--- a/cdm-core/src/main/java/ucar/array/Array.java
+++ b/cdm-core/src/main/java/ucar/array/Array.java
@@ -59,7 +59,7 @@ public abstract class Array<T> implements Iterable<T> {
 
   /** Get the shape: length of array in each dimension. */
   public int[] getShape() {
-    return indexFn.getShape();
+    return indexFn.getShape(); // use Ints.asList()
   }
 
   /** Get the section: list of Ranges, one for each dimension. */

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
@@ -387,6 +387,8 @@ public class GridHorizCoordinateSystem {
   private final Projection projection;
 
   public GridHorizCoordinateSystem(GridAxisPoint xaxis, GridAxisPoint yaxis, @Nullable Projection projection) {
+    Preconditions.checkNotNull(xaxis);
+    Preconditions.checkNotNull(yaxis);
     this.xaxis = xaxis;
     this.yaxis = yaxis;
     // TODO set the LatLon seam?

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCurvilinear.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCurvilinear.java
@@ -31,8 +31,8 @@ public class GridHorizCurvilinear extends GridHorizCoordinateSystem {
     Preconditions.checkNotNull(yaxis);
     Preconditions.checkNotNull(latdata);
     Preconditions.checkNotNull(londata);
+    Preconditions.checkArgument(java.util.Arrays.equals(londata.getShape(), latdata.getShape()));
     Preconditions.checkArgument(latdata.getRank() == 2);
-    Preconditions.checkArgument(londata.getRank() == 2);
 
     return new GridHorizCurvilinear(xaxis, yaxis, new Curvilinear(), latdata, londata);
   }

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/GridNetcdfDataset.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/GridNetcdfDataset.java
@@ -97,6 +97,7 @@ public class GridNetcdfDataset implements GridDataset {
     }
 
     // Convert coordsys
+    Set<String> alreadyDone = new HashSet<>();
     Map<String, TrackGridCS> trackCsConverted = new HashMap<>();
     for (DatasetClassifier.CoordSysClassifier csc : classifier.getCoordinateSystemsUsed()) {
       if (csc.getName().startsWith("Best/")) {
@@ -112,6 +113,9 @@ public class GridNetcdfDataset implements GridDataset {
       // Assign coordsys to grids
       for (Variable v : ncd.getVariables()) {
         if (v.getFullName().startsWith("Best/")) { // TODO remove Best from grib generation code
+          continue;
+        }
+        if (alreadyDone.contains(v.getFullName())) {
           continue;
         }
         VariableEnhanced ve = (VariableEnhanced) v;
@@ -131,6 +135,7 @@ public class GridNetcdfDataset implements GridDataset {
           if (gcs != null && gcs.getFeatureType() == featureType && Dimensions.isCoordinateSystemFor(domain, v)) {
             Grid grid = new GridVariable(gcs, (VariableDS) ve);
             gridsets.put(gcs, grid);
+            alreadyDone.add(v.getFullName());
             break;
           }
         }
@@ -174,10 +179,6 @@ public class GridNetcdfDataset implements GridDataset {
     this.coordsys = ImmutableList.copyOf(coordsys);
     this.gridAxes = ImmutableList.copyOf(gridAxes);
     this.grids = ImmutableList.copyOf(grids);
-  }
-
-  public FeatureType getCoverageType() {
-    return featureType;
   }
 
   @Override

--- a/cdm-core/src/test/java/ucar/nc2/ft/TestFeatureDatasetFactoryManager.java
+++ b/cdm-core/src/test/java/ucar/nc2/ft/TestFeatureDatasetFactoryManager.java
@@ -20,7 +20,6 @@ public class TestFeatureDatasetFactoryManager {
 
   /** Tests a non-CF compliant trajectory file */
   @Test
-  @Ignore("fixed in following PR")
   public void testSimpleTrajectory() throws IOException {
     Path location_path =
         Paths.get(TestDir.cdmLocalTestDataDir, "trajectory", "aircraft", "uw_kingair-2005-01-19-113957.nc");

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestCoordInterval.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestCoordInterval.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.grid;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TestCoordInterval {
+
+  @Test
+  public void testBasics() {
+    CoordInterval intv = CoordInterval.create(3, 4);
+    assertThat(intv.start()).isEqualTo(3);
+    assertThat(intv.end()).isEqualTo(4);
+    assertThat(intv.midpoint()).isEqualTo(3.5);
+    assertThat(intv.toString()).isEqualTo("3.0-4.0");
+    assertThat(intv.toString(0)).isEqualTo("3-4");
+    assertThat(intv).isEqualTo(CoordInterval.parse(intv.toString()));
+    assertThat(intv.hashCode()).isEqualTo(CoordInterval.parse(intv.toString()).hashCode());
+  }
+
+  @Test
+  public void testFuzzy() {
+    CoordInterval intv = CoordInterval.create(3.001, 4.001);
+    assertThat(intv.start()).isEqualTo(3.001);
+    assertThat(intv.end()).isEqualTo(4.001);
+    assertThat(intv.fuzzyEquals(intv, .00001)).isTrue();
+    assertThat(intv.fuzzyEquals(CoordInterval.create(3, 4), .002)).isTrue();
+  }
+
+  @Test
+  public void testParse() {
+    CoordInterval intv = CoordInterval.parse("3-4.159");
+    assertThat(intv).isNotNull();
+    assertThat(intv.start()).isEqualTo(3);
+    assertThat(intv.end()).isEqualTo(4.159);
+    assertThat(intv.midpoint()).isEqualTo(3.5795);
+
+    assertThat(CoordInterval.parse("3 4.159")).isNull();
+    assertThat(CoordInterval.parse("3")).isNull();
+    assertThat(CoordInterval.parse("bad")).isNull();
+    assertThat(CoordInterval.parse("")).isNull();
+    assertThat(CoordInterval.parse(null)).isNull();
+
+    assertThat(CoordInterval.parse("3-4")).isNotNull();
+    assertThat(CoordInterval.parse("3 - 4")).isNull();
+    assertThat(CoordInterval.parse("3- 4")).isNull();
+    assertThat(CoordInterval.parse(" 3- 4")).isNull();
+    assertThat(CoordInterval.parse(" 3-4 ")).isEqualTo(CoordInterval.parse("3-4"));
+  }
+
+  @Test
+  public void testParseMinusPlus() {
+    CoordInterval intv = CoordInterval.parse("-3-4.159");
+    assertThat(intv).isNotNull();
+    assertThat(intv.start()).isEqualTo(-3);
+    assertThat(intv.end()).isEqualTo(4.159);
+  }
+
+  @Test
+  public void testParseMinusMinus() {
+    CoordInterval intv = CoordInterval.parse("-3--4.159");
+    assertThat(intv).isNotNull();
+    assertThat(intv.start()).isEqualTo(-3);
+    assertThat(intv.end()).isEqualTo(-4.159);
+  }
+
+  @Test
+  public void testParsePlusMinus() {
+    CoordInterval intv = CoordInterval.parse("3--4.159");
+    assertThat(intv).isNotNull();
+    assertThat(intv.start()).isEqualTo(3);
+    assertThat(intv.end()).isEqualTo(-4.159);
+  }
+
+}

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestGridDataset.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestGridDataset.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.grid;
+
+import org.junit.Test;
+import ucar.array.InvalidRangeException;
+import ucar.nc2.Attribute;
+import ucar.nc2.constants.AxisType;
+import ucar.unidata.util.test.TestDir;
+
+import java.io.IOException;
+import java.util.Formatter;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+public class TestGridDataset {
+
+  @Test
+  public void testBasics() throws IOException, InvalidRangeException {
+    String filename = TestDir.cdmLocalTestDataDir + "ncml/fmrc/GFS_Puerto_Rico_191km_20090729_0000.nc";
+    Formatter errlog = new Formatter();
+
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(filename, errlog)) {
+      assertThat(gds).isNotNull();
+      System.out.println("readGridDataset: " + gds.getLocation());
+      assertThat(gds.toString()).startsWith("name = GFS_Puerto_Rico_191km_20090729_0000.nc\n"
+          + "location = ../cdm-core/src/test/data/ncml/fmrc/GFS_Puerto_Rico_191km_20090729_0000.nc\n"
+          + "featureType = GRID");
+
+      Grid grid = gds.findGridByAttribute("Grib_Variable_Id", "VAR_7-0-2-11_L100").orElseThrow();
+      assertThat(grid.getName()).isEqualTo("Temperature_isobaric");
+      Attribute att = grid.attributes().findAttribute("Grib_Variable_Id");
+      assertThat(att).isEqualTo(new Attribute("Grib_Variable_Id", "VAR_7-0-2-11_L100"));
+
+      assertThat(grid.toString()).startsWith("float Temperature_isobaric(time=20, isobaric1=6, y=39, x=45);");
+
+      Optional<Grid> bad = gds.findGridByAttribute("failure", "VAR_7-0-2-11_L100");
+      assertThat(bad).isEmpty();
+
+      // test Grid
+      assertThat(grid.getHorizCoordinateSystem()).isNotNull();
+      assertThat(grid.getTimeCoordinateSystem()).isNotNull();
+
+      // test GridCoordinateSystem
+      assertThat(grid.getCoordinateSystem()).isNotNull();
+      GridCoordinateSystem gcs = grid.getCoordinateSystem();
+      assertThat((Object) gcs.findCoordAxisByType(AxisType.Time)).isNotNull();
+      assertThat((Object) gcs.findCoordAxisByType(AxisType.Ensemble)).isNull();
+
+      assertThat(gcs.toString()).startsWith("Coordinate System (time isobaric1 y x)\n" + " time (GridAxisPoint) \n"
+          + " isobaric1 (GridAxisPoint) \n" + " y (GridAxisPoint) \n" + " x (GridAxisPoint) ");
+
+      assertThat(gcs.showFnSummary()).isEqualTo("GRID(T,Z,Y,X)");
+    }
+  }
+}

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridCurvilinear.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridCurvilinear.java
@@ -99,6 +99,23 @@ public class TestReadGridCurvilinear {
         "reftime time lataxis lonaxis", "2009-11-23T00:00Z", null, new int[] {1, 1, 1684, 1200});
   }
 
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  @Ignore("GRIB curvilinear not ready")
+  public void testCurvilinearGrib() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2";
+    String gridName = "3-D_Temperature_depth_below_sea";
+    System.out.printf("file %s coverage %s%n", filename, gridName);
+
+    Formatter errlog = new Formatter();
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(filename, errlog)) {
+      assertThat(gds).isNotNull();
+      Grid grid = gds.findGrid(gridName).orElseThrow();
+      GridCoordinateSystem csys = grid.getCoordinateSystem();
+      assertThat(csys.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+    }
+  }
+
   private void readGrid(String filename, String gridName, List<Integer> nominalShape, String gcsName, String wantDateS,
       Double wantVert, int[] matShape) throws IOException, InvalidRangeException {
 

--- a/cdm-core/src/test/java/ucar/nc2/internal/grid/TestDatasetClassifier.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/grid/TestDatasetClassifier.java
@@ -365,4 +365,94 @@ public class TestDatasetClassifier {
     }
   }
 
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testBothXYandLatLon() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "ft/coverage/testCFwriter.nc";
+    String gridName = "Temperature";
+    System.out.printf("file %s coverage %s%n", filename, gridName);
+
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(filename)) {
+      Formatter errlog = new Formatter();
+      Optional<GridNetcdfDataset> grido = GridNetcdfDataset.create(ds, errlog);
+      assertThat(grido.isPresent()).isTrue();
+      GridNetcdfDataset gridDataset = grido.get();
+      if (!Iterables.isEmpty(gridDataset.getGrids())) {
+        DatasetClassifier dclassifier = new DatasetClassifier(ds, errlog);
+        DatasetClassifier.CoordSysClassifier classifier =
+            dclassifier.getCoordinateSystemsUsed().stream().findFirst().orElse(null);
+        assertThat(classifier).isNotNull();
+        assertThat(classifier.getFeatureType()).isEqualTo(FeatureType.GRID);
+      }
+    }
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testCurvilinear1D() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "ft/coverage/Run_20091025_0000.nc";
+    String gridName = "temp";
+    System.out.printf("file %s coverage %s%n", filename, gridName);
+
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(filename)) {
+      Formatter errlog = new Formatter();
+      Optional<GridNetcdfDataset> grido = GridNetcdfDataset.create(ds, errlog);
+      assertThat(grido.isPresent()).isTrue();
+      GridNetcdfDataset gridDataset = grido.get();
+      if (!Iterables.isEmpty(gridDataset.getGrids())) {
+        DatasetClassifier dclassifier = new DatasetClassifier(ds, errlog);
+        DatasetClassifier.CoordSysClassifier classifier =
+            dclassifier.getCoordinateSystemsUsed().stream().findFirst().orElse(null);
+        assertThat(classifier).isNotNull();
+        assertThat(classifier.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+      }
+    }
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testCurvilinear() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "conventions/cf/mississippi.nc";
+    String gridName = "temp";
+    System.out.printf("file %s coverage %s%n", filename, gridName);
+
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(filename)) {
+      Formatter errlog = new Formatter();
+      Optional<GridNetcdfDataset> grido = GridNetcdfDataset.create(ds, errlog);
+      assertThat(grido.isPresent()).isTrue();
+      GridNetcdfDataset gridDataset = grido.get();
+      if (!Iterables.isEmpty(gridDataset.getGrids())) {
+        DatasetClassifier dclassifier = new DatasetClassifier(ds, errlog);
+        DatasetClassifier.CoordSysClassifier classifier =
+            dclassifier.getCoordinateSystemsUsed().stream().findFirst().orElse(null);
+        assertThat(classifier).isNotNull();
+        assertThat(classifier.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+      }
+    }
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testCurvilinear2() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "conventions/cf/signell/signell_bathy_fixed.nc";
+    String gridName = "h";
+    System.out.printf("file %s coverage %s%n", filename, gridName);
+
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(filename)) {
+      Formatter errlog = new Formatter();
+      Optional<GridNetcdfDataset> grido = GridNetcdfDataset.create(ds, errlog);
+      assertThat(grido.isPresent()).isTrue();
+      GridNetcdfDataset gridDataset = grido.get();
+      if (!Iterables.isEmpty(gridDataset.getGrids())) {
+        DatasetClassifier dclassifier = new DatasetClassifier(ds, errlog);
+        DatasetClassifier.CoordSysClassifier classifier =
+            dclassifier.getCoordinateSystemsUsed().stream().findFirst().orElse(null);
+        assertThat(classifier).isNotNull();
+        assertThat(classifier.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+      }
+    }
+  }
+
+
+
 }

--- a/cdm-core/src/test/java/ucar/nc2/internal/grid/TestExtractCoordinateValuesMalformed.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/grid/TestExtractCoordinateValuesMalformed.java
@@ -22,7 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 @Ignore("Malformed File")
 public class TestExtractCoordinateValuesMalformed {
 
-  // fdrom cdmUnitTest/conventions/cf/jonathan/fixed.fw0.0Sv.nc
+  // from cdmUnitTest/conventions/cf/jonathan/fixed.fw0.0Sv.nc
   @Test
   public void testContinguousAscending() {
     int n = values.length;

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageSubsetTime.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestCoverageSubsetTime.java
@@ -354,7 +354,7 @@ public class TestCoverageSubsetTime {
     }
   }
 
-  static void testGeoArray(GeoReferencedArray geo, CalendarDate runtime, CalendarDate time, Double offsetVal) {
+  public static void testGeoArray(GeoReferencedArray geo, CalendarDate runtime, CalendarDate time, Double offsetVal) {
     CoverageCoordSys geoCs = geo.getCoordSysForData();
 
     CoverageCoordAxis runtimeAxis = geoCs.getAxis(AxisType.RunTime);

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridClassificationP.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridClassificationP.java
@@ -1,0 +1,110 @@
+/* Copyright */
+package ucar.nc2.grid;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import ucar.nc2.constants.FeatureType;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Test Grid Classifications.
+ */
+@RunWith(Parameterized.class)
+@Category(NeedsCdmUnitTest.class)
+public class TestGridClassificationP {
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> getTestParameters() {
+    List<Object[]> result = new ArrayList<>();
+
+    // NUWG - has CoordinateAlias
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/03061219_ruc.nc", "T", FeatureType.GRID, 4, 31,
+        "GRID(T,Z,Y,X)"});
+    // scalar runtime, with ensemble
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/ECME_RIZ_201201101200_00600_GB",
+        "Total_precipitation_surface", FeatureType.GRID, 4, 5, "GRID(R,TO,E,Y,X)"});
+    /* ensemble, time-offset */
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/MM_cnrm_129_red.ncml", "geopotential",
+        FeatureType.GRID, 6, 1, "GRID(R,TO,E,Z,Y,X)"});
+    // scalar vert
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/ukmo.nc", "temperature_2m", FeatureType.GRID, 4, 1,
+        "GRID(R,TO,Y,X): Z"});
+    // ok
+    result
+        .add(new Object[] {TestDir.cdmUnitTestDir + "gribCollections/tp/GFS_Global_onedeg_ana_20150326_0600.grib2.ncx4",
+            "Temperature_isobaric", FeatureType.GRID, 4, 65, "GRID(R,TO,Z,Y,X)"});
+    // both x,y and lat,lon
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/testCFwriter.nc", "Temperature", FeatureType.GRID, 3,
+        2, "GRID(Z,Y,X)"});
+
+    // GRIB Curvilinear (not ready)
+    // result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2",
+    // "3-D_Temperature_depth_below_sea",
+    // FeatureType.CURVILINEAR, 4, 7, "GRID(T,Z,Y,X)"});
+
+    // x,y axis but no projection
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/Run_20091025_0000.nc", "u", FeatureType.CURVILINEAR,
+        4, 24, "CURVILINEAR(T,Z,Y,X)"});
+
+    /* netcdf Curvilinear, not 1D */
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "conventions/cf/mississippi.nc", "temp", FeatureType.CURVILINEAR,
+        4, 24, "CURVILINEAR(T,Z,Y,X)"});
+
+    // SWATH
+    result.add(new Object[] {
+        TestDir.cdmUnitTestDir + "formats/hdf4/AIRS.2003.01.24.116.L2.RetStd_H.v5.0.14.0.G07295101113.hdf", "",
+        FeatureType.SWATH, 2, 93, "fn"});
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "formats/hdf4/ssec/MYD06_L2.A2006188.1655.005.2006194124315.hdf",
+        "", FeatureType.SWATH, 3, 28, "fn"});
+
+    return result;
+  }
+
+  final String endpoint;
+  final String vname;
+  final FeatureType expectType;
+  final int domain, ncoverages;
+  final String fn;
+
+  public TestGridClassificationP(String endpoint, String vname, FeatureType expectType, int domain, int ncoverages,
+      String fn) {
+    this.endpoint = endpoint;
+    this.vname = vname;
+    this.expectType = expectType;
+    this.domain = domain;
+    this.ncoverages = ncoverages;
+    this.fn = fn;
+  }
+
+  @Test
+  public void testFactory() throws IOException {
+    System.out.printf("Open %s %s%n", endpoint, vname);
+    Formatter errlog = new Formatter();
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+      if (expectType == FeatureType.SWATH) {
+        assertThat(gds).isNull();
+        return;
+      } else {
+        assertThat(gds).isNotNull();
+      }
+
+      Grid grid = gds.findGrid(vname).orElseThrow();
+      GridCoordinateSystem csys = grid.getCoordinateSystem();
+      assertThat(csys.getFeatureType()).isEqualTo(expectType);
+      assertThat(csys.showFnSummary()).isEqualTo(fn);
+
+      assertThat(gds.getGrids()).hasSize(ncoverages);
+    }
+  }
+
+}

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridCompareCoverage.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridCompareCoverage.java
@@ -123,6 +123,9 @@ public class TestGridCompareCoverage {
         }
         System.out.printf("  Grid: %s%n", grid.getName());
         boolean ok = true;
+        if (grid.getName().equals("PB")) {
+          System.out.printf("HEY");
+        }
 
         CoverageCoordSys oldGcs = oldGrid.getCoordSys();
         CoverageCoordAxis oldRuntime = oldGcs.getAxis(AxisType.RunTime);

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridCompareProblem.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridCompareProblem.java
@@ -45,15 +45,15 @@ public class TestGridCompareProblem {
     new TestGridCompareCoverage(filename).compareWithCoverage(true);
   }
 
-  // @Test
+  @Test
   public void testCurvilinear() throws Exception {
     String filename = TestDir.cdmUnitTestDir + "ft/grid/stag/bora_feb-coord.ncml";
     new TestGridCompareCoverage(filename).compareWithCoverage(true);
   }
 
-  // @Test
+  @Test
   public void testCurvilinear2() throws Exception {
-    String filename = TestDir.cdmUnitTestDir + "cf/bora_test_agg.ncml";
+    String filename = TestDir.cdmUnitTestDir + "conventions/cf/bora_test_agg.ncml";
     new TestGridCompareCoverage(filename).compareWithCoverage(true);
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridCurvilinear.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridCurvilinear.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.nc2.grid;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.ma2.Array;
+import ucar.ma2.Index;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft.coverage.TestCoverageSubsetTime;
+import ucar.nc2.ft2.coverage.Coverage;
+import ucar.nc2.ft2.coverage.CoverageCollection;
+import ucar.nc2.ft2.coverage.CoverageCoordSys;
+import ucar.nc2.ft2.coverage.CoverageDatasetFactory;
+import ucar.nc2.ft2.coverage.FeatureDatasetCoverage;
+import ucar.nc2.ft2.coverage.GeoReferencedArray;
+import ucar.nc2.ft2.coverage.HorizCoordSys;
+import ucar.nc2.ft2.coverage.SubsetParams;
+import ucar.unidata.geoloc.LatLonRect;
+import ucar.unidata.util.test.Assert2;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Description
+ *
+ * @author John
+ * @since 8/24/2015
+ */
+@Category(NeedsCdmUnitTest.class)
+public class TestGridCurvilinear {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Test
+  public void TestGribCurvilinear() throws IOException, InvalidRangeException {
+    String endpoint = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2";
+    logger.debug("open {}", endpoint);
+
+    try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
+      assert cc != null;
+      Assert.assertEquals(1, cc.getCoverageCollections().size());
+      CoverageCollection gds = cc.getCoverageCollections().get(0);
+      Assert.assertNotNull(endpoint, gds);
+      Assert.assertEquals(FeatureType.CURVILINEAR, gds.getCoverageType());
+      Assert.assertEquals(7, gds.getCoverageCount());
+
+      HorizCoordSys hcs = gds.getHorizCoordSys();
+      Assert.assertNotNull(endpoint, hcs);
+      Assert.assertTrue(endpoint, !hcs.isProjection());
+      Assert.assertNull(endpoint, hcs.getTransform());
+
+      String covName = "Mixed_layer_depth_surface";
+      Coverage cover = gds.findCoverage(covName);
+      Assert.assertNotNull(covName, cover);
+
+      GeoReferencedArray geo = cover.readData(new SubsetParams());
+      TestCoverageSubsetTime.testGeoArray(geo, null, null, null);
+    }
+  }
+
+  @Test
+  public void TestGribCurvilinearSubset() throws IOException, InvalidRangeException {
+    String endpoint = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2"; // GRIB
+                                                                                                         // Curvilinear
+    logger.debug("open {}", endpoint);
+
+    try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
+      assert cc != null;
+      Assert.assertEquals(1, cc.getCoverageCollections().size());
+      CoverageCollection gds = cc.getCoverageCollections().get(0);
+      Assert.assertNotNull(endpoint, gds);
+      Assert.assertEquals(FeatureType.CURVILINEAR, gds.getCoverageType());
+      Assert.assertEquals(7, gds.getCoverageCount());
+
+      HorizCoordSys hcs = gds.getHorizCoordSys();
+      Assert.assertNotNull(endpoint, hcs);
+      Assert.assertTrue(endpoint, !hcs.isProjection());
+      Assert.assertNull(endpoint, hcs.getTransform());
+
+      String covName = "Mixed_layer_depth_surface";
+      Coverage coverage = gds.findCoverage(covName);
+      Assert.assertNotNull(covName, coverage);
+
+      LatLonRect bbox = new LatLonRect(64.0, -61., 59.0, -52.);
+
+      SubsetParams params = new SubsetParams().set(SubsetParams.timePresent, true).set(SubsetParams.latlonBB, bbox);
+      GeoReferencedArray geo = coverage.readData(params);
+      logger.debug("csys shape={}", Arrays.toString(geo.getCoordSysForData().getShape()));
+
+      Array data = geo.getData();
+      logger.debug("data shape={}", Arrays.toString(data.getShape()));
+      Assert.assertArrayEquals(geo.getCoordSysForData().getShape(), data.getShape());
+
+      int[] expectedShape = new int[] {1, 165, 161};
+      Assert.assertArrayEquals(expectedShape, data.getShape());
+    }
+  }
+
+  @Test
+  public void TestNetcdfCurvilinear() throws IOException, InvalidRangeException {
+    String endpoint = TestDir.cdmUnitTestDir + "ft/coverage/Run_20091025_0000.nc"; // NetCDF has 2D and 1D
+    logger.debug("open {}", endpoint);
+
+    try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
+      assert cc != null;
+      Assert.assertEquals(1, cc.getCoverageCollections().size());
+      CoverageCollection gds = cc.getCoverageCollections().get(0);
+      Assert.assertNotNull(endpoint, gds);
+      Assert.assertEquals(FeatureType.CURVILINEAR, gds.getCoverageType());
+      Assert.assertEquals(24, gds.getCoverageCount());
+
+      String covName = "u";
+      Coverage cover = gds.findCoverage(covName);
+      Assert.assertNotNull(covName, cover);
+
+      SubsetParams params = new SubsetParams().setVertCoord(-.05).set(SubsetParams.timePresent, true);
+      GeoReferencedArray geo = cover.readData(params);
+
+      Array data = geo.getData();
+      Index ima = data.getIndex();
+      int[] expectedShape = new int[] {1, 1, 22, 12};
+      Assert.assertArrayEquals(expectedShape, data.getShape());
+      Assert2.assertNearlyEquals(0.0036624447, data.getDouble(ima.set(0, 0, 0, 0)), 1e-6);
+      Assert2.assertNearlyEquals(0.20564626, data.getDouble(ima.set(0, 0, 21, 11)), 1e-6);
+    }
+  }
+
+  @Test
+  public void TestNetcdfCurvilinear2D() throws IOException {
+    String endpoint = TestDir.cdmUnitTestDir + "transforms/UTM/artabro_20120425.nc"; // NetCDF Curvilinear 2D only
+    logger.debug("open {}", endpoint);
+
+    try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
+      assert cc != null;
+      Assert.assertEquals(1, cc.getCoverageCollections().size());
+      CoverageCollection gds = cc.getCoverageCollections().get(0);
+      Assert.assertNotNull(endpoint, gds);
+      Assert.assertEquals(FeatureType.CURVILINEAR, gds.getCoverageType());
+      Assert.assertEquals(10, gds.getCoverageCount());
+
+      String covName = "hs";
+      Coverage cover = gds.findCoverage(covName);
+      Assert.assertNotNull(covName, cover);
+
+      SubsetParams params = new SubsetParams().set(SubsetParams.timePresent, true);
+      GeoReferencedArray geo = cover.readData(params);
+
+      Array data = geo.getData();
+      Index ima = data.getIndex();
+      int[] expectedShape = new int[] {1, 151, 171};
+      Assert.assertArrayEquals(expectedShape, data.getShape());
+      Assert2.assertNearlyEquals(1.782, data.getDouble(ima.set(0, 0, 0)), 1e-6);
+      Assert2.assertNearlyEquals(1.769, data.getDouble(ima.set(0, 11, 0)), 1e-6);
+    } catch (InvalidRangeException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void TestNetcdfCurvilinear2Dsubset() throws IOException, InvalidRangeException {
+    String endpoint = TestDir.cdmUnitTestDir + "transforms/UTM/artabro_20120425.nc"; // NetCDF Curvilinear 2D only
+    logger.debug("open {}", endpoint);
+
+    try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(endpoint)) {
+      assertThat(cc).isNotNull();
+      assertThat(cc.getCoverageCollections().size()).isEqualTo(1);
+      CoverageCollection gds = cc.getCoverageCollections().get(0);
+      assertWithMessage(endpoint).that(gds).isNotNull();
+      assertThat(gds.getCoverageType()).isEqualTo(FeatureType.CURVILINEAR);
+      assertThat(gds.getCoverageCount()).isEqualTo(10);
+
+      String covName = "hs";
+      Coverage coverage = gds.findCoverage(covName);
+      assertWithMessage(covName).that(coverage).isNotNull();
+      CoverageCoordSys cs = coverage.getCoordSys();
+      assertWithMessage("coordSys").that(cs).isNotNull();
+      HorizCoordSys hcs = cs.getHorizCoordSys();
+      assertWithMessage("HorizCoordSys").that(hcs).isNotNull();
+      assertWithMessage("cordSys").that(cs.getShape().length).isEqualTo(3);
+      logger.debug("org shape={}", Arrays.toString(cs.getShape()));
+      int[] expectedOrgShape = new int[] {85, 151, 171};
+      assertThat(expectedOrgShape).isEqualTo(cs.getShape());
+
+      LatLonRect bbox = new LatLonRect(43.489, -8.5353, 43.371, -8.2420);
+
+      SubsetParams params = new SubsetParams().set(SubsetParams.timePresent, true).setLatLonBoundingBox(bbox);
+      GeoReferencedArray geo = coverage.readData(params);
+      logger.debug("geoCs shape={}", Arrays.toString(geo.getCoordSysForData().getShape()));
+
+      Array data = geo.getData();
+      logger.debug("data shape={}", Arrays.toString(data.getShape()));
+      assertThat(geo.getCoordSysForData().getShape()).isEqualTo(data.getShape());
+
+      // make sure subset bounding box is contained in geoarray hcs.
+      assertThat(bbox.containedIn(geo.getCoordSysForData().getHorizCoordSys().calcLatLonBoundingBox()));
+
+      int[] expectedShape = new int[] {1, 99, 105};
+      assertThat(expectedShape).isEqualTo(data.getShape());
+
+      // verified manually, both visually and by looking at the array using the indices associated with
+      // the closest grid point the lat lon value of the geogrid lat/lon value for index (0,0) and (11,0).
+      Index ima = data.getIndex();
+      assertThat(data.getDouble(ima.set(0, 0, 0))).isWithin(1.0e-8).of(1.7829999923706055);
+      assertThat(data.getDouble(ima.set(0, 11, 0))).isWithin(1.0e-8).of(1.7669999599456787);
+    }
+  }
+
+  @Test
+  public void testNetcdf2D() throws Exception {
+    String filename = TestDir.cdmUnitTestDir + "conventions/cf/mississippi.nc";
+    logger.debug("open {}", filename);
+
+    try (FeatureDatasetCoverage cc = CoverageDatasetFactory.open(filename)) {
+      Assert.assertNotNull(filename, cc);
+      CoverageCollection gcs = cc.findCoverageDataset(FeatureType.CURVILINEAR);
+      Assert.assertNotNull("gcs", gcs);
+      String gribId = "salt";
+      Coverage coverage = gcs.findCoverage(gribId);
+      Assert.assertNotNull(gribId, coverage);
+
+      CoverageCoordSys cs = coverage.getCoordSys();
+      Assert.assertNotNull("coordSys", cs);
+      HorizCoordSys hcs = cs.getHorizCoordSys();
+      Assert.assertNotNull("HorizCoordSys", hcs);
+
+      int[] expectedOrgShape = new int[] {1, 20, 64, 128};
+      Assert.assertArrayEquals(expectedOrgShape, cs.getShape());
+      logger.debug("org shape={}", Arrays.toString(cs.getShape()));
+
+      // just try to bisect ot along the width
+      LatLonRect bbox = new LatLonRect(90, -180, -90, -90);
+
+      SubsetParams params = new SubsetParams().set(SubsetParams.timePresent, true).set(SubsetParams.latlonBB, bbox);
+      GeoReferencedArray geo = coverage.readData(params);
+      logger.debug("geoCs shape={}", Arrays.toString(geo.getCoordSysForData().getShape()));
+
+      Array data = geo.getData();
+      logger.debug("data shape={}", Arrays.toString(data.getShape()));
+      Assert.assertArrayEquals(geo.getCoordSysForData().getShape(), data.getShape());
+
+      int[] expectedShape = new int[] {1, 20, 64, 75};
+      Assert.assertArrayEquals(expectedShape, data.getShape());
+    }
+  }
+}

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridReadHorizStride.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridReadHorizStride.java
@@ -28,7 +28,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 /** Test {@link GridHorizCoordinateSystem} reading with horizontal strides */
 @Category(NeedsCdmUnitTest.class)
-// @Ignore("Grid data reading not ready yet")
 public class TestGridReadHorizStride {
 
   @Test

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridSubsetTime.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridSubsetTime.java
@@ -1,0 +1,773 @@
+package ucar.nc2.grid;
+
+import com.google.common.primitives.Ints;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.array.Array;
+import ucar.array.InvalidRangeException;
+import ucar.ma2.Range;
+import ucar.nc2.calendar.CalendarDate;
+import ucar.nc2.calendar.CalendarDateRange;
+import ucar.nc2.constants.AxisType;
+import ucar.nc2.ft.coverage.GribCoverageValidator;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis.Spacing;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis1D;
+import ucar.nc2.ft2.coverage.CoverageCoordSys;
+import ucar.nc2.ft2.coverage.SubsetParams;
+import ucar.nc2.ft2.coverage.TimeOffsetAxis;
+import ucar.nc2.grib.collection.GribDataReader;
+import ucar.unidata.util.test.Assert2;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Formatter;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Test CoverageSubsetTime, esp 2DTime
+ */
+@Category(NeedsCdmUnitTest.class)
+public class TestGridSubsetTime {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @BeforeClass
+  public static void before() {
+    GribDataReader.validator = new GribCoverageValidator();
+  }
+
+  @AfterClass
+  public static void after() {
+    GribDataReader.validator = null;
+  }
+
+  @Test // there is no interval with offset value = 51
+  public void testNoIntervalFound() throws IOException, InvalidRangeException {
+    String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+    String covName = "Momentum_flux_u-component_surface_Mixed_intervals_Average";
+
+    System.out.format("testNoIntervalFound Dataset %s coverage %s%n", endpoint, covName);
+
+    Formatter errlog = new Formatter();
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+      assertThat(gds).isNotNull();
+      Grid grid = gds.findGrid(covName).orElseThrow();
+      GridCoordinateSystem csys = grid.getCoordinateSystem();
+      assertThat(csys).isNotNull();
+
+      GridSubset params = GridSubset.create();
+      CalendarDate runtime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T12:00:00Z").orElseThrow();
+      params.setRunTimeCoord(runtime);
+      Long offsetVal = 51L; // should fail
+      params.setTimeOffsetCoord(offsetVal);
+      System.out.printf("  subset %s%n", params);
+
+      GridReferencedArray geo = grid.readData(params);
+      testGeoArray(geo, runtime, null, offsetVal);
+
+      // should be empty, but instead its a bunch of NaNs
+      Array<Number> datan = geo.data();
+      assertThat(Float.isNaN(datan.iterator().next().floatValue())).isTrue();
+    }
+  }
+
+  /*
+   * @Test // 1 runtime, 1 timeOffset (Time2DCoordSys case 1a)
+   * public void test1Runtime1TimeOffset() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Momentum_flux_u-component_surface_Mixed_intervals_Average";
+   * 
+   * System.out.format("test1Runtime1TimeOffset Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * CalendarDate runtime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T06:00:00Z").orElseThrow();
+   * params.set(SubsetParams.runtime, runtime);
+   * double offsetVal = 205.0;
+   * params.set(SubsetParams.timeOffset, offsetVal);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * testGeoArray(geo, runtime, null, offsetVal);
+   * 
+   * // LOOK need to test data
+   * }
+   * }
+   * 
+   * 
+   * // Momentum_flux_u-component_surface_Mixed_intervals_Average runtime=2015-03-01T00:00:00Z (0) ens=0.000000 (-1)
+   * // time=2015-03-06T19:30:00Z (46) vert=0.000000 (-1)
+   * 
+   * @Test // 1 runtime, 1 time (Time2DCoordSys case 1b)
+   * public void test1Runtime1TimeIntervalEdge() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Momentum_flux_u-component_surface_Mixed_intervals_Average";
+   * 
+   * System.out.format("test1Runtime1TimeIntervalEdge Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * CalendarDate runtime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T00:00:00Z").orElseThrow();
+   * params.set(SubsetParams.runtime, runtime);
+   * CalendarDate time = CalendarDate.fromUdunitIsoDate(null, "2015-03-06T19:30:00Z").orElseThrow(); // (6,12), (12,18)
+   * params.set(SubsetParams.time, time);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * testGeoArray(geo, runtime, time, null);
+   * 
+   * Array data = geo.getData();
+   * Index ai = data.getIndex();
+   * float testValue = data.getFloat(ai.set(0, 0, 3, 0));
+   * Assert2.assertNearlyEquals(0.244f, testValue);
+   * }
+   * }
+   * 
+   * 
+   * // Momentum_flux_u-component_surface_Mixed_intervals_Average runtime=2015-03-01T06:00:00Z (1) ens=0.000000 (-1)
+   * // time=2015-03-01T12:00:00Z (1) vert=0.000000 (-1)
+   * 
+   * @Test // 1 runtime, 1 time (Time2DCoordSys case 1b)
+   * public void test1Runtime1TimeInterval() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Momentum_flux_u-component_surface_Mixed_intervals_Average";
+   * 
+   * System.out.format("test1Runtime1TimeInterval Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * CalendarDate runtime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T06:00:00Z").orElseThrow();
+   * params.set(SubsetParams.runtime, runtime);
+   * CalendarDate time = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T11:00:00Z").orElseThrow(); // (6,12), (12,18)
+   * params.set(SubsetParams.time, time);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * testGeoArray(geo, runtime, time, null);
+   * 
+   * Array data = geo.getData();
+   * Index ai = data.getIndex();
+   * float testValue = data.getFloat(ai.set(0, 0, 2, 2));
+   * Assert2.assertNearlyEquals(0.073f, testValue);
+   * }
+   * }
+   * 
+   * // Slice Total_ozone_entire_atmosphere_single_layer runtime=2015-03-01T06:00:00Z (1) ens=0.000000 (-1)
+   * // time=2015-03-01T12:00:00Z (2) vert=0.000000 (-1)
+   * 
+   * @Test // 1 runtime, 1 time (Time2DCoordSys case 1b)
+   * public void test1Runtime1Time() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Total_ozone_entire_atmosphere_single_layer";
+   * 
+   * System.out.format("test1Runtime1Time Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * CalendarDate runtime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T06:00:00Z").orElseThrow();
+   * params.set(SubsetParams.runtime, runtime);
+   * CalendarDate time = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T12:00:00Z").orElseThrow();
+   * params.set(SubsetParams.time, time);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * testGeoArray(geo, runtime, time, null);
+   * 
+   * Array data = geo.getData();
+   * Index ai = data.getIndex();
+   * float testValue = data.getFloat(ai.set(0, 0, 1, 0));
+   * Assert2.assertNearlyEquals(371.5, testValue);
+   * }
+   * }
+   * 
+   * @Test // 1 runtime, all times (Time2DCoordSys case 1c)
+   * public void testConstantRuntime() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Momentum_flux_u-component_surface_Mixed_intervals_Average";
+   * 
+   * System.out.format("testConstantRuntime Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * CalendarDate runtime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T12:00:00Z").orElseThrow();
+   * params.set(SubsetParams.runtime, runtime);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * CoverageCoordSys geoCs = geo.getCoordSysForData();
+   * 
+   * CoverageCoordAxis runtimeAxis = geoCs.getAxis(AxisType.RunTime);
+   * Assert.assertNotNull(runtimeAxis);
+   * Assert.assertTrue(runtimeAxis instanceof CoverageCoordAxis1D);
+   * Assert.assertEquals(1, runtimeAxis.getNcoords());
+   * CoverageCoordAxis1D runtimeAxis1D = (CoverageCoordAxis1D) runtimeAxis;
+   * Assert.assertEquals("runtime coord", runtime, runtimeAxis.makeDate(runtimeAxis1D.getCoordMidpoint(0)));
+   * 
+   * CoverageCoordAxis1D timeAxis = (CoverageCoordAxis1D) geoCs.getAxis(AxisType.TimeOffset);
+   * Assert.assertNotNull(timeAxis);
+   * Assert.assertEquals(92, timeAxis.getNcoords());
+   * Assert.assertEquals(Spacing.discontiguousInterval, timeAxis.getSpacing());
+   * Assert2.assertNearlyEquals(0.0, timeAxis.getStartValue());
+   * Assert2.assertNearlyEquals(384.0, timeAxis.getEndValue());
+   * 
+   * // LOOK need to test data
+   * }
+   * }
+   * 
+   * @Test // all runtimes, 1 timeOffset (Time2DCoordSys case 2a)
+   * public void testConstantOffset() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Momentum_flux_u-component_surface_Mixed_intervals_Average";
+   * 
+   * System.out.format("testConstantOffset Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * double offsetVal = 205.0;
+   * params.set(SubsetParams.timeOffset, offsetVal);
+   * params.set(SubsetParams.runtimeAll, true);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = cover.readData(params);
+   * CoverageCoordSys geoCs = geo.getCoordSysForData();
+   * 
+   * CoverageCoordAxis1D runtimeAxis = (CoverageCoordAxis1D) geoCs.getAxis(AxisType.RunTime);
+   * Assert.assertNotNull(runtimeAxis);
+   * Assert.assertEquals(4, runtimeAxis.getNcoords());
+   * Assert.assertEquals(Spacing.regularPoint, runtimeAxis.getSpacing());
+   * Assert2.assertNearlyEquals(0.0, runtimeAxis.getCoordMidpoint(0));
+   * Assert2.assertNearlyEquals(3600 * 6.0, runtimeAxis.getResolution());
+   * 
+   * CoverageCoordAxis timeAxis = geoCs.getAxis(AxisType.TimeOffset);
+   * Assert.assertNotNull(timeAxis);
+   * Assert.assertTrue(timeAxis instanceof CoverageCoordAxis1D);
+   * Assert.assertEquals(1, timeAxis.getNcoords());
+   * CoverageCoordAxis1D timeAxis1D = (CoverageCoordAxis1D) timeAxis;
+   * if (timeAxis.isInterval()) {
+   * Assert.assertTrue("time coord lower", timeAxis1D.getCoordEdge1(0) <= offsetVal); // lower <= time
+   * Assert.assertTrue("time coord lower", timeAxis1D.getCoordEdge2(0) >= offsetVal); // upper >= time
+   * 
+   * } else {
+   * Assert2.assertNearlyEquals(offsetVal, timeAxis1D.getCoordMidpoint(0));
+   * }
+   * 
+   * // LOOK need to test data
+   * }
+   * }
+   * 
+   * @Test // all runtimes, 1 time (Time2DCoordSys case 2a) not time interval
+   * 
+   * @Ignore("Confusing time and reftime")
+   * public void testConstantForecast() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Pressure_convective_cloud_bottom";
+   * 
+   * System.out.format("testConstantForecast Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * CalendarDate time = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T15:00:00Z").orElseThrow();
+   * params.set(SubsetParams.time, time);
+   * params.set(SubsetParams.runtimeAll, true);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = cover.readData(params);
+   * CoverageCoordSys geoCs = geo.getCoordSysForData();
+   * 
+   * CoverageCoordAxis1D runtimeAxis = (CoverageCoordAxis1D) geoCs.getAxis(AxisType.RunTime);
+   * Assert.assertNotNull(runtimeAxis);
+   * Assert.assertEquals(3, runtimeAxis.getNcoords());
+   * Assert.assertEquals(Spacing.irregularPoint, runtimeAxis.getSpacing());
+   * Assert2.assertNearlyEquals(0.0, runtimeAxis.getCoordMidpoint(0));
+   * Assert2.assertNearlyEquals(6.0, runtimeAxis.getResolution());
+   * 
+   * CoverageCoordAxis timeAxis = geoCs.getAxis(AxisType.Time);
+   * if (timeAxis != null) {
+   * Assert.assertTrue(timeAxis instanceof CoverageCoordAxis1D);
+   * Assert.assertEquals(1, timeAxis.getNcoords());
+   * CoverageCoordAxis1D timeAxis1D = (CoverageCoordAxis1D) timeAxis;
+   * if (timeAxis.isInterval()) {
+   * CalendarDate lower = timeAxis1D.makeDate(timeAxis1D.getCoordEdge1(0));
+   * Assert.assertTrue("time coord lower", !lower.isAfter(time)); // lower <= time
+   * CalendarDate upper = timeAxis1D.makeDate(timeAxis1D.getCoordEdge2(0));
+   * Assert.assertTrue("time coord lower", !upper.isBefore(time)); // upper >= time
+   * 
+   * } else {
+   * Assert.assertEquals("time coord", time, timeAxis1D.makeDate(timeAxis1D.getCoordMidpoint(0)));
+   * }
+   * }
+   * 
+   * CoverageCoordAxis timeOffsetAxis = geoCs.getAxis(AxisType.TimeOffset);
+   * if (timeOffsetAxis != null) {
+   * Assert.assertTrue(timeOffsetAxis instanceof TimeOffsetAxis);
+   * Assert.assertEquals(3, timeOffsetAxis.getNcoords());
+   * Assert.assertEquals(CoverageCoordAxis.DependenceType.dependent, timeOffsetAxis.getDependenceType());
+   * Assert.assertEquals(Spacing.irregularPoint, timeOffsetAxis.getSpacing()); // LOOK wrong
+   * }
+   * }
+   * }
+   */
+
+  private static void testGeoArray(GridReferencedArray geo, CalendarDate runtime, CalendarDate time, Long offsetVal) {
+    MaterializedCoordinateSystem geoCs = geo.getMaterializedCoordinateSystem();
+
+    GridTimeCoordinateSystem tcs = geoCs.getTimeCoordSystem();
+    assertThat(tcs).isNotNull();
+    GridAxisPoint runtimeAxis = tcs.getRunTimeAxis();
+    assertThat((Object) runtimeAxis).isNotNull();
+
+    assertThat(runtimeAxis.getNominalSize()).isEqualTo(1);
+    if (runtime != null) {
+      assertThat(runtime).isEqualTo(tcs.getRuntimeDate(0));
+    }
+
+    GridAxis<?> timeAxis = tcs.getTimeOffsetAxis(0);
+    assertThat((Object) timeAxis).isNotNull();
+    assertThat(timeAxis.getNominalSize()).isEqualTo(1);
+
+    if (offsetVal != null) {
+      time = tcs.getCalendarDateUnit().makeCalendarDate(offsetVal);
+    }
+
+    /*
+     * if (time != null) {
+     * if (timeAxis.isInterval()) {
+     * GridAxisInterval timeAxisInt = (GridAxisInterval) timeAxis;
+     * CalendarDate lower = timeAxis1D.makeDate(timeAxis1D.getCoordEdge1(0));
+     * Assert.assertTrue("time coord lower", !lower.isAfter(time)); // lower <= time
+     * CalendarDate upper = timeAxis1D.makeDate(timeAxis1D.getCoordEdge2(0));
+     * Assert.assertTrue("time coord lower", !upper.isBefore(time)); // upper >= time
+     * } else {
+     * assertThat(time).isEqualTo(tcs.getTimesForRuntime(0).get(0));
+     * }
+     * }
+     */
+
+    List<Integer> shapeCs = geoCs.getMaterializedShape();
+    int[] dataShape = geo.data().getShape();
+    assertThat(shapeCs).isEqualTo(Ints.asList(dataShape));
+  }
+
+  /*
+   * ////////////////////////////////////////////////////////////////////////////////////////////
+   * // Best
+   * 
+   * @Test
+   * public void testBestPresent() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Temperature_altitude_above_msl";
+   * 
+   * System.out.format("testBestPresent Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * params.set(SubsetParams.timePresent, true);
+   * params.setVertCoord(3658.0);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * 
+   * // should not be missing !
+   * assert !Float.isNaN(geo.getData().getFloat(0));
+   * 
+   * Array data = geo.getData();
+   * Index ai = data.getIndex();
+   * float testValue = data.getFloat(ai.set(0, 0, 3, 0));
+   * Assert2.assertNearlyEquals(244.8f, testValue);
+   * }
+   * }
+   * 
+   * @Test
+   * public void testBestTimeCoord() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Temperature_altitude_above_msl";
+   * 
+   * System.out.format("testBestTimeCoord Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * params.setTime(CalendarDate.fromUdunitIsoDate(null, "2015-03-03T00:00:00Z").orElseThrow());
+   * params.setVertCoord(3658.0);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * 
+   * // should not be missing !
+   * assert !Float.isNaN(geo.getData().getFloat(0));
+   * 
+   * Array data = geo.getData();
+   * Index ai = data.getIndex();
+   * float testValue = data.getFloat(ai.set(0, 0, 0, 0));
+   * Assert2.assertNearlyEquals(244.3f, testValue);
+   * }
+   * }
+   * 
+   * @Test
+   * public void testBestTimeOffsetCoord() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
+   * String covName = "Temperature_altitude_above_msl";
+   * 
+   * System.out.format("testBestTimeOffsetCoord Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * params.setTimeOffset(48.0);
+   * params.setVertCoord(3658.0);
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * 
+   * // should not be missing !
+   * assert !Float.isNaN(geo.getData().getFloat(0));
+   * 
+   * Array data = geo.getData();
+   * Index ai = data.getIndex();
+   * float testValue = data.getFloat(ai.set(0, 0, 3, 0));
+   * Assert2.assertNearlyEquals(250.5, testValue);
+   * }
+   * }
+   * 
+   * ///////////////////////////////////////////////////////////////////////////////////////////
+   * // SRC
+   * 
+   * @Test
+   * public void testSrcNoParams() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1";
+   * String covName = "Temperature_isobaric";
+   * 
+   * System.out.format("testSrcNoParams Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * System.out.printf("  subset %s%n", params);
+   * GridReferencedArray geo = grid.readData(params);
+   * 
+   * int[] resultShape = geo.getData().getShape();
+   * int[] expectShape = new int[] {36, 29, 65, 93};
+   * Assert.assertArrayEquals("shape", expectShape, resultShape);
+   * }
+   * }
+   * 
+   * @Test
+   * public void testSrcTimePresent() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1";
+   * String covName = "Temperature_isobaric";
+   * 
+   * System.out.format("testSrcTimePresent Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridAxis<?> timeAxis = csys.findCoordAxisByType(AxisType.Time);
+   * Assert.assertNotNull("timeoffset axis", timeAxis);
+   * Assert.assertEquals(36, timeAxis.getNcoords());
+   * 
+   * GridSubset params = GridSubset.create();
+   * params.set(SubsetParams.timePresent, true);
+   * System.out.printf("  subset %s%n", params);
+   * GridReferencedArray geo = grid.readData(params);
+   * 
+   * int[] resultShape = geo.getData().getShape();
+   * int[] expectShape = new int[] {1, 29, 65, 93};
+   * Assert.assertArrayEquals("shape", expectShape, resultShape);
+   * 
+   * CoverageCoordSys geocs = geo.getCoordSysForData();
+   * CoverageCoordAxis toAxis2 = geocs.getAxis(AxisType.Time);
+   * Assert.assertNotNull("timeoffset axis", toAxis2);
+   * Assert.assertEquals(1, toAxis2.getNcoords());
+   * }
+   * }
+   * 
+   * @Test
+   * public void testDiscontiguousIntervalSubsetSingleTime() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/GFS_Global_2p5deg_20150301_0000.grib2.ncx4";
+   * String covName = "Total_precipitation_surface_Mixed_intervals_Accumulation";
+   * 
+   * System.out.format("testDiscontiguousIntervalSubsetSingleTime Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * 
+   * CalendarDate runTime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T00:00:00Z").orElseThrow();
+   * params.setRunTime(runTime);
+   * CalendarDate validTime = CalendarDate.fromUdunitIsoDate(null, "2015-03-02T06:00:00Z").orElseThrow();
+   * params.setTime(validTime);
+   * System.out.printf("  subset %s%n", params);
+   * // expect: any interval [start, stop] containing the requested time
+   * // idx interval
+   * // 08 (24.000000, 27.000000) == (2015-03-02T00:00:00Z, 2015-03-02T03:00:00Z)
+   * // 09 (24.000000, 30.000000) == (2015-03-02T00:00:00Z, 2015-03-02T06:00:00Z)
+   * // 10 (30.000000, 33.000000) == (2015-03-02T06:00:00Z, 2015-03-02T09:00:00Z)
+   * // 11 (30.000000, 36.000000) == (2015-03-02T06:00:00Z, 2015-03-02T12:00:00Z)
+   * // 12 (36.000000, 39.000000) == (2015-03-02T12:00:00Z, 2015-03-02T15:00:00Z)
+   * int expectedStartIndex = 9;
+   * int expectedEndIndex = 11;
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * assertThat(geo).isNotNull();
+   * CoverageCoordAxis timeAxis = geo.findCoordAxis("time");
+   * assertThat(timeAxis).isNotNull();
+   * assertThat(timeAxis.getSpacing()).isEqualTo(Spacing.discontiguousInterval);
+   * assertThat(timeAxis.getRange()).isEqualTo(new Range(expectedStartIndex, expectedEndIndex));
+   * 
+   * // multiple matches
+   * params = new SubsetParams();
+   * params.setRunTime(runTime);
+   * validTime = CalendarDate.fromUdunitIsoDate(null, "2015-03-02T7:00:00Z").orElseThrow();
+   * params.setTime(validTime);
+   * expectedStartIndex = 10;
+   * expectedEndIndex = 11;
+   * 
+   * geo = grid.readData(params);
+   * assertThat(geo).isNotNull();
+   * timeAxis = geo.findCoordAxis("time");
+   * assertThat(timeAxis).isNotNull();
+   * assertThat(timeAxis.getSpacing()).isEqualTo(Spacing.discontiguousInterval);
+   * assertThat(timeAxis.getRange()).isEqualTo(new Range(expectedStartIndex, expectedEndIndex));
+   * }
+   * }
+   * 
+   * @Test
+   * public void testDiscontiguousIntervalSubsetSpecificOffsets() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/GFS_Global_2p5deg_20150301_0000.grib2.ncx4";
+   * String covName = "Total_precipitation_surface_Mixed_intervals_Accumulation";
+   * 
+   * System.out.format("testDiscontiguousIntervalSubsetSpecificOffsets Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * CalendarDate runTime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T00:00:00Z").orElseThrow();
+   * params.setRunTime(runTime);
+   * double intervalStart = 30;
+   * double intervalStop = 33;
+   * params.setTimeOffsetIntv(new double[] {intervalStart, intervalStop});
+   * System.out.printf("  subset %s%n", params);
+   * // expect: any interval [(]start, stop] containing the requested time
+   * // idx interval
+   * // 08 (24.000000, 27.000000) == (2015-03-02T00:00:00Z, 2015-03-02T03:00:00Z)
+   * // 09 (24.000000, 30.000000) == (2015-03-02T00:00:00Z, 2015-03-02T06:00:00Z)
+   * // 10 (30.000000, 33.000000) == (2015-03-02T06:00:00Z, 2015-03-02T09:00:00Z)
+   * // 11 (30.000000, 36.000000) == (2015-03-02T06:00:00Z, 2015-03-02T12:00:00Z)
+   * // 12 (36.000000, 39.000000) == (2015-03-02T12:00:00Z, 2015-03-02T15:00:00Z)
+   * int expectedStartIndex = 10; // only one match :-)
+   * int expectedEndIndex = expectedStartIndex;
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * assertThat(geo).isNotNull();
+   * CoverageCoordAxis timeAxis = geo.findCoordAxis("time");
+   * assertThat(timeAxis).isNotNull();
+   * assertThat(timeAxis.getSpacing()).isEqualTo(Spacing.discontiguousInterval);
+   * assertThat(timeAxis.getRange()).isEqualTo(new Range(expectedStartIndex, expectedEndIndex));
+   * 
+   * params = new SubsetParams();
+   * params.setRunTime(runTime);
+   * intervalStart = 30;
+   * intervalStop = 36;
+   * params.setTimeOffsetIntv(new double[] {intervalStart, intervalStop});
+   * System.out.printf("  subset %s%n", params);
+   * // expect: any interval [(]start, stop] containing the requested time
+   * // idx interval
+   * // 08 (24.000000, 27.000000) == (2015-03-02T00:00:00Z, 2015-03-02T03:00:00Z)
+   * // 09 (24.000000, 30.000000) == (2015-03-02T00:00:00Z, 2015-03-02T06:00:00Z)
+   * // 10 (30.000000, 33.000000) == (2015-03-02T06:00:00Z, 2015-03-02T09:00:00Z)
+   * // 11 (30.000000, 36.000000) == (2015-03-02T06:00:00Z, 2015-03-02T12:00:00Z)
+   * // 12 (36.000000, 39.000000) == (2015-03-02T12:00:00Z, 2015-03-02T15:00:00Z)
+   * expectedStartIndex = 11; // only one match :-)
+   * expectedEndIndex = expectedStartIndex;
+   * 
+   * geo = grid.readData(params);
+   * assertThat(geo).isNotNull();
+   * timeAxis = geo.findCoordAxis("time");
+   * assertThat(timeAxis).isNotNull();
+   * assertThat(timeAxis.getSpacing()).isEqualTo(Spacing.discontiguousInterval);
+   * assertThat(timeAxis.getRange()).isEqualTo(new Range(expectedStartIndex, expectedEndIndex));
+   * 
+   * }
+   * }
+   * 
+   * @Test
+   * public void testDiscontiguousIntervalSubsetSpecificOffsetsNoExactMatch() throws IOException, InvalidRangeException
+   * {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/GFS_Global_2p5deg_20150301_0000.grib2.ncx4";
+   * String covName = "Total_precipitation_surface_Mixed_intervals_Accumulation";
+   * 
+   * System.out.format("testDiscontiguousIntervalSubsetSpecificOffsetsNoExactMatch Dataset %s coverage %s%n", endpoint,
+   * covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * 
+   * CalendarDate runTime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T00:00:00Z").orElseThrow();
+   * params.setRunTime(runTime);
+   * double intervalStart = 30;
+   * double intervalStop = 39;
+   * params.setTimeOffsetIntv(new double[] {intervalStart, intervalStop});
+   * System.out.printf("  subset %s%n", params);
+   * // expect: any interval [(]start, stop] containing the requested time
+   * // idx interval
+   * // 08 (24.000000, 27.000000) == (2015-03-02T00:00:00Z, 2015-03-02T03:00:00Z)
+   * // 09 (24.000000, 30.000000) == (2015-03-02T00:00:00Z, 2015-03-02T06:00:00Z)
+   * // 10 (30.000000, 33.000000) == (2015-03-02T06:00:00Z, 2015-03-02T09:00:00Z)
+   * // 11 (30.000000, 36.000000) == (2015-03-02T06:00:00Z, 2015-03-02T12:00:00Z)
+   * // 12 (36.000000, 39.000000) == (2015-03-02T12:00:00Z, 2015-03-02T15:00:00Z)
+   * // no exact match on interval, so for now match closest midpoint with smallest width
+   * // midpoint is 34.9
+   * // 10 has midpoint of 31.5
+   * // 11 has midpoint of 33
+   * // 12 has midpoint of 37.5
+   * // so index 11 is closest
+   * int expectedStartIndex = 11;
+   * int expectedEndIndex = expectedStartIndex;
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * assertThat(geo).isNotNull();
+   * CoverageCoordAxis timeAxis = geo.findCoordAxis("time");
+   * assertThat(timeAxis).isNotNull();
+   * assertThat(timeAxis.getSpacing()).isEqualTo(Spacing.discontiguousInterval);
+   * assertThat(timeAxis.getRange()).isEqualTo(new Range(expectedStartIndex, expectedEndIndex));
+   * }
+   * }
+   * 
+   * @Test
+   * public void testDiscontiguousIntervalSubsetTimeRange() throws IOException, InvalidRangeException {
+   * String endpoint = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/GFS_Global_2p5deg_20150301_0000.grib2.ncx4";
+   * String covName = "Total_precipitation_surface_Mixed_intervals_Accumulation";
+   * 
+   * System.out.format("testDiscontiguousIntervalSubsetTimeRange Dataset %s coverage %s%n", endpoint, covName);
+   * 
+   * Formatter errlog = new Formatter();
+   * try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+   * assertThat(gds).isNotNull();
+   * Grid grid = gds.findGrid(covName).orElseThrow();
+   * GridCoordinateSystem csys = grid.getCoordinateSystem();
+   * assertThat(csys).isNotNull();
+   * 
+   * GridSubset params = GridSubset.create();
+   * 
+   * CalendarDate runTime = CalendarDate.fromUdunitIsoDate(null, "2015-03-01T00:00:00Z").orElseThrow();
+   * params.setRunTime(runTime);
+   * 
+   * CalendarDate subsetTimeStart = CalendarDate.fromUdunitIsoDate(null, "2015-03-02T06:00:00Z").orElseThrow();
+   * CalendarDate subsetTimeEnd = CalendarDate.fromUdunitIsoDate(null, "2015-03-02T12:00:00Z").orElseThrow();
+   * // expect: any interval containing or ending on the start or end times
+   * // idx keep interval
+   * // 08 N (24.000000, 27.000000) == (2015-03-02T00:00:00Z, 2015-03-02T03:00:00Z)
+   * // 09 Y (24.000000, 30.000000) == (2015-03-02T00:00:00Z, 2015-03-02T06:00:00Z)
+   * // 10 Y (30.000000, 33.000000) == (2015-03-02T06:00:00Z, 2015-03-02T09:00:00Z)
+   * // 11 Y (30.000000, 36.000000) == (2015-03-02T06:00:00Z, 2015-03-02T12:00:00Z)
+   * // 12 N (36.000000, 39.000000) == (2015-03-02T12:00:00Z, 2015-03-02T15:00:00Z)
+   * int expectedStartIndex = 9;
+   * int expectedEndIndex = 11;
+   * params.setTimeRange(CalendarDateRange.of(subsetTimeStart, subsetTimeEnd));
+   * System.out.printf("  subset %s%n", params);
+   * 
+   * GridReferencedArray geo = grid.readData(params);
+   * assertThat(geo).isNotNull();
+   * CoverageCoordAxis timeAxis = geo.findCoordAxis("time");
+   * assertThat(timeAxis).isNotNull();
+   * assertThat(timeAxis.getSpacing()).isEqualTo(Spacing.discontiguousInterval);
+   * assertThat(timeAxis.getRange()).isEqualTo(new Range(expectedStartIndex, expectedEndIndex));
+   * }
+   * }
+   * 
+   */
+
+}

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestRegularTime2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestRegularTime2D.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.nc2.grid;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import ucar.nc2.constants.AxisType;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+import java.io.IOException;
+import java.util.Formatter;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Test Grib 2D time that is regular, not orthogonal.
+ */
+@Category(NeedsCdmUnitTest.class)
+public class TestRegularTime2D {
+
+  @Test
+  public void testRegularTime2D() throws IOException {
+    String filename = TestDir.cdmUnitTestDir + "datasets/NDFD-CONUS-5km/NDFD-CONUS-5km.ncx4";
+    String gridName = "Maximum_temperature_height_above_ground_12_Hour_Maximum";
+    System.out.printf("file %s coverage %s%n", filename, gridName);
+
+    Formatter errlog = new Formatter();
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(filename, errlog)) {
+      assertThat(gds).isNotNull();
+      Grid grid = gds.findGrid(gridName).orElseThrow();
+      assertThat(grid).isNotNull();
+
+      GridCoordinateSystem gcs = grid.getCoordinateSystem();
+      assertThat(gcs).isNotNull();
+
+      assertThat(gcs.getNominalShape()).isEqualTo(ImmutableList.of(4, 4, 1, 689, 1073));
+
+      GridAxisPoint reftime = (GridAxisPoint) gcs.findCoordAxisByType(AxisType.RunTime);
+      assertThat((Object) reftime).isNotNull();
+      assertThat(reftime.getNominalSize()).isEqualTo(4);
+      double[] want = new double[] {0., 12., 24., 36.}; // used to be in hours
+      int hour = 0;
+      for (Number value : reftime) {
+        assertThat(value.doubleValue()).isEqualTo(3600.0 * want[hour++]);
+      }
+
+      GridAxisInterval validtime = (GridAxisInterval) gcs.findCoordAxisByType(AxisType.TimeOffset);
+      assertThat((Object) validtime).isNotNull();
+      assertThat(validtime.getNominalSize()).isEqualTo(4);
+      double[] start = new double[] {84, 108, 132, 156}; // used to be in hours
+      double[] end = new double[] {96, 120, 144, 168}; // used to be in hours
+      hour = 0;
+      for (CoordInterval intv : validtime) {
+        assertThat(intv.start()).isEqualTo(start[hour]);
+        assertThat(intv.end()).isEqualTo(end[hour]);
+        hour++;
+      }
+    }
+  }
+}

--- a/docs/developer/src/site/pages/grid/timeaxes.md
+++ b/docs/developer/src/site/pages/grid/timeaxes.md
@@ -1,0 +1,9 @@
+---
+title: Grid time axes
+last_updated: 2021-08-14
+sidebar: developer_sidebar
+permalink: grid_timeaxis.html
+toc: false
+---
+
+# Grid time Axes


### PR DESCRIPTION
CoordInterval.parse allows negative values; switch to regex parsing.
CoordSysClassifier tweaks for curvilinear grids.
GridNetcdfDataset must track grids already found.
Lots of tests; start porting Coverage tests to grid.
Start adding docs so I can remember how this all works!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/796)
<!-- Reviewable:end -->
