### PR TITLE
GridAxis subset with stride

### DIFF
--- a/cdm-core/src/main/java/thredds/client/catalog/ThreddsMetadata.java
+++ b/cdm-core/src/main/java/thredds/client/catalog/ThreddsMetadata.java
@@ -375,7 +375,7 @@ public class ThreddsMetadata implements ThreddsMetadataContainer {
 
     public LatLonRect getBoundingBox() {
       return isGlobal ? new LatLonRect()
-          : new LatLonRect.Builder(LatLonPoint.create(getLatStart(), getLonStart()), getLatExtent(), getLonExtent())
+          : LatLonRect.builder(LatLonPoint.create(getLatStart(), getLonStart()), getLatExtent(), getLonExtent())
               .build();
     }
   }

--- a/cdm-core/src/main/java/ucar/nc2/ft/point/DsgCollectionHelper.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft/point/DsgCollectionHelper.java
@@ -54,7 +54,7 @@ public class DsgCollectionHelper {
 
     for (PointFeature pf : pfc) {
       if (bbox == null)
-        bbox = new LatLonRect.Builder(pf.getLocation().getLatLon(), .001, .001);
+        bbox = LatLonRect.builder(pf.getLocation().getLatLon(), .001, .001);
       else
         bbox.extend(pf.getLocation().getLatLon());
 

--- a/cdm-core/src/main/java/ucar/nc2/ft/point/PointIteratorAbstract.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft/point/PointIteratorAbstract.java
@@ -41,7 +41,7 @@ public abstract class PointIteratorAbstract implements PointFeatureIterator, Ite
       return;
 
     if (bb == null)
-      bb = new LatLonRect.Builder(pf.getLocation().getLatLon(), .001, .001);
+      bb = LatLonRect.builder(pf.getLocation().getLatLon(), .001, .001);
     else
       bb.extend(pf.getLocation().getLatLon());
 
@@ -60,7 +60,7 @@ public abstract class PointIteratorAbstract implements PointFeatureIterator, Ite
     if (llrect.crossDateline() && (llrect.getWidth() > 350.0)) { // call it global - less confusing
       double lat_min = llrect.getLowerLeftPoint().getLatitude();
       double deltaLat = llrect.getUpperLeftPoint().getLatitude() - lat_min;
-      llrect = new LatLonRect.Builder(LatLonPoint.create(lat_min, -180.0), deltaLat, 360.0).build();
+      llrect = LatLonRect.builder(LatLonPoint.create(lat_min, -180.0), deltaLat, 360.0).build();
     }
 
     info.bbox = llrect;

--- a/cdm-core/src/main/java/ucar/nc2/ft/point/standard/plug/UnidataPointDatasetHelper.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft/point/standard/plug/UnidataPointDatasetHelper.java
@@ -61,7 +61,7 @@ public class UnidataPointDatasetHelper {
     double lon_max = getAttAsDouble(ds, "geospatial_lon_max");
     double lon_min = getAttAsDouble(ds, "geospatial_lon_min");
 
-    return new LatLonRect.Builder(LatLonPoint.create(lat_min, lon_min), lat_max - lat_min, lon_max - lon_min).build();
+    return LatLonRect.builder(LatLonPoint.create(lat_min, lon_min), lat_max - lat_min, lon_max - lon_min).build();
   }
 
   private static double getAttAsDouble(NetcdfDataset ds, String attname) {

--- a/cdm-core/src/main/java/ucar/nc2/ft/point/writer2/WriterCFPointAbstract.java
+++ b/cdm-core/src/main/java/ucar/nc2/ft/point/writer2/WriterCFPointAbstract.java
@@ -523,7 +523,7 @@ abstract class WriterCFPointAbstract implements Closeable {
   void trackBB(LatLonPoint loc, CalendarDate obsDate) {
     if (loc != null) {
       if (llbb == null) {
-        llbb = new LatLonRect.Builder(loc, .001, .001);
+        llbb = LatLonRect.builder(loc, .001, .001);
       } else {
         llbb.extend(loc);
       }

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxis.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxis.java
@@ -191,7 +191,6 @@ public abstract class GridAxis<T> implements Comparable<GridAxis<T>>, Iterable<T
     for (Attribute att : attributes) {
       f.format("%s%s%n", indent, att);
     }
-    f.format("%n");
     indent.decr();
     indent.decr();
   }

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxis.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxis.java
@@ -47,14 +47,17 @@ public abstract class GridAxis<T> implements Comparable<GridAxis<T>>, Iterable<T
     return attributes;
   }
 
+  /** regularPoint, irregularPoint, or nominalPoint. */
   public GridAxisSpacing getSpacing() {
     return spacing;
   }
 
+  /** Is it regularly spaced? */
   public boolean isRegular() {
     return spacing.isRegular();
   }
 
+  /** Is it an interval coordinate? */
   public boolean isInterval() {
     return spacing.isInterval();
   }
@@ -75,11 +78,14 @@ public abstract class GridAxis<T> implements Comparable<GridAxis<T>>, Iterable<T
   /** Nominal in the sense that it may not match the materialized data array. */
   public abstract int getNominalSize();
 
+  /** The nominal value of the coordinate. */
   public abstract Object getCoordinate(int index);
 
+  /** The nominal edges of the coordinate. */
   public abstract CoordInterval getCoordInterval(int index);
 
-  public abstract double getCoordMidpoint(int index);
+  /** The nominal value of the coordinate, cast to a double. */
+  public abstract double getCoordDouble(int index);
 
   public abstract Optional<? extends GridAxis<T>> subset(GridSubset params, Formatter errlog);
 

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxisInterval.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxisInterval.java
@@ -59,9 +59,9 @@ public class GridAxisInterval extends GridAxis<CoordInterval> implements Iterabl
     return getCoordInterval(index);
   }
 
-  /** The midpoint of the interval, cast to a double. */
+  /** The nominal value of the interval, cast to a double. */
   @Override
-  public double getCoordMidpoint(int index) {
+  public double getCoordDouble(int index) {
     return (getCoordEdge1(index) + getCoordEdge2(index)) / 2;
   }
 

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxisPoint.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxisPoint.java
@@ -219,14 +219,14 @@ public class GridAxisPoint extends GridAxis<Number> implements Iterable<Number> 
   void toString(Formatter f, Indent indent) {
     super.toString(f, indent);
 
-    f.format("%snpts: %d start=%f resolution=%f spacing=%s", indent, ncoords, startValue, resolution, spacing);
+    f.format("%s  npts: %d start=%f resolution=%f spacing=%s", indent, ncoords, startValue, resolution, spacing);
     f.format("%s range=%s isSubset=%s", indent, range, isSubset);
-    f.format("%n");
 
     if (values != null && spacing == irregularPoint) {
-      f.format("%scontiguous values (%d)=", indent, values.length);
-      for (double v : values)
+      f.format("%s contiguous values (%d)=", indent, values.length);
+      for (double v : values) {
         f.format("%f,", v);
+      }
       f.format("%n");
     }
   }

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxisSpacing.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxisSpacing.java
@@ -21,7 +21,7 @@ public enum GridAxisSpacing {
    */
   irregularPoint,
   /**
-   * Irregular spaced points values[npts]; edges are not halfway between coords, but are specified in edges[npts+1]
+   * Edges are not halfway between coords, but are specified in edges[npts+1].
    */
   nominalPoint,
 

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridCoordinateSystem.java
@@ -195,6 +195,7 @@ public class GridCoordinateSystem {
     if (tcs != null) {
       f.format("%n%s%n", tcs);
     }
+    f.format("%n%s%n", hcs);
   }
 
   private void showCoordinateAxis(GridAxis<?> axis, Formatter f, boolean showCoords) {

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridCoordinateSystem.java
@@ -184,7 +184,6 @@ public class GridCoordinateSystem {
     showCoordinateAxis(getVerticalAxis(), f, showCoords);
     showCoordinateAxis(getYHorizAxis(), f, showCoords);
     showCoordinateAxis(getXHorizAxis(), f, showCoords);
-    f.format("%n");
 
     if (hcs.getProjection() != null) {
       f.format(" Projection: %s %s%n", hcs.getProjection().getName(), hcs.getProjection().paramsToString());

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
@@ -138,7 +138,8 @@ public class GridHorizCoordinateSystem {
       projbb = null;
     }
 
-    // TODO GridSubset.latlonPoint
+    // LOOK not done: GridSubset.latlonPoint
+
     if (projbb != null) {
       SubsetPointHelper yhelper = new SubsetPointHelper(yaxis);
       Optional<GridAxisPoint.Builder<?>> ybo =

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
@@ -128,8 +128,18 @@ public class GridHorizCoordinateSystem {
     LatLonRect llbb = params.getLatLonBoundingBox();
     ProjectionRect projbb = params.getProjectionBoundingBox();
 
+    if (projbb == null && llbb != null && !isLatLon()) {
+      projbb = getProjection().latLonToProjBB(llbb);
+      llbb = null;
+    }
+
+    if (projbb != null && llbb == null && isLatLon()) {
+      llbb = getProjection().projToLatLonBB(projbb);
+      projbb = null;
+    }
+
     // TODO GridSubset.latlonPoint
-    if (projbb != null) { // TODO ProjectionRect ok for isLatlon = true?
+    if (projbb != null) {
       SubsetPointHelper yhelper = new SubsetPointHelper(yaxis);
       Optional<GridAxisPoint.Builder<?>> ybo =
           yhelper.subsetRange(projbb.getMinY(), projbb.getMaxY(), horizStride, errlog);
@@ -146,7 +156,7 @@ public class GridHorizCoordinateSystem {
       }
       xaxisSubset = xbo.get().build();
 
-    } else if (llbb != null && isLatLon()) { // TODO LatLonRect only used for isLatlon = true?
+    } else if (llbb != null) {
       SubsetPointHelper yhelper = new SubsetPointHelper(yaxis);
       Optional<GridAxisPoint.Builder<?>> ybo =
           yhelper.subsetRange(llbb.getLatMin(), llbb.getLatMax(), horizStride, errlog);

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCurvilinear.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCurvilinear.java
@@ -304,7 +304,7 @@ public class GridHorizCurvilinear extends GridHorizCoordinateSystem {
     Range lonRange = Range.make(lonmin, lonmax, stride);
     GridAxisPoint lonaxisSubset = xaxis.toBuilder().subsetWithRange(lonRange).build();
 
-    // Subset the edge arrays
+    // Subset the edge arrays LOOK cant subset edge array if there is a stride; must recalculate
     Section section = Section.builder().appendRange(Range.make(latmin, latmax + 1, stride))
         .appendRange(Range.make(lonmin, lonmax + 1, stride)).build();
     try {

--- a/cdm-core/src/main/java/ucar/nc2/grid/Grids.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/Grids.java
@@ -56,7 +56,7 @@ public class Grids {
       case contiguousInterval:
       case irregularPoint:
       case nominalPoint:
-        return axis.getCoordMidpoint(0) <= axis.getCoordMidpoint(axis.getNominalSize() - 1);
+        return axis.getCoordDouble(0) <= axis.getCoordDouble(axis.getNominalSize() - 1);
 
       case discontiguousInterval: // actually ambiguous
         return axis.getCoordInterval(0).start() <= axis.getCoordInterval(axis.getNominalSize() - 1).end();

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/CurvilinearCoords.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/CurvilinearCoords.java
@@ -388,10 +388,11 @@ public class CurvilinearCoords {
     } else {
       x = (fyy * diffLon - fxy * diffLat) / det;
       if (fyy == 0) {
-        // should not happen, means that the cell has no height
-        throw new IllegalArgumentException(String.format("cell height == 0 at index %d %d", row, col));
+        // we just happened to land on the same row
+        y = (diffLat - fyx * x);
+      } else {
+        y = (diffLat - fyx * x) / fyy;
       }
-      y = (diffLat - fyx * x) / fyy;
     }
 
     int drow = (int) Math.round(y);

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/GridTimeCS.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/GridTimeCS.java
@@ -85,7 +85,7 @@ public class GridTimeCS extends GridTimeCoordinateSystem {
   private List<CalendarDate> getTimesForObservation() {
     List<CalendarDate> result = new ArrayList<>();
     for (int timeIdx = 0; timeIdx < timeOffsetAxis.getNominalSize(); timeIdx++) {
-      result.add(this.calendarDateUnit.makeCalendarDate((long) timeOffsetAxis.getCoordMidpoint(timeIdx)));
+      result.add(this.calendarDateUnit.makeCalendarDate((long) timeOffsetAxis.getCoordDouble(timeIdx)));
     }
     return result;
   }
@@ -96,7 +96,7 @@ public class GridTimeCS extends GridTimeCoordinateSystem {
     GridAxis<?> timeAxis = getTimeOffsetAxis(runIdx);
     List<CalendarDate> result = new ArrayList<>();
     for (int offsetIdx = 0; offsetIdx < timeAxis.getNominalSize(); offsetIdx++) {
-      result.add(baseForRun.add((long) timeAxis.getCoordMidpoint(offsetIdx), this.offsetPeriod));
+      result.add(baseForRun.add((long) timeAxis.getCoordDouble(offsetIdx), this.offsetPeriod));
     }
     return result;
   }

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetHelpers.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetHelpers.java
@@ -287,7 +287,7 @@ public class SubsetHelpers {
       // only check if target is in discontiguous interval i
       if (intervalContains(orgGridAxis, target, i)) {
         // get midpoint of interval
-        double coord = orgGridAxis.getCoordMidpoint(i);
+        double coord = orgGridAxis.getCoordDouble(i);
         // how close is the midpoint of this interval to our target value?
         double diff = Math.abs(coord - target);
         // Look for the interval with the minimum difference. If multiple intervals have the same
@@ -307,10 +307,10 @@ public class SubsetHelpers {
 
   static int search(GridAxis<?> time, double want) {
     if (time.getNominalSize() == 1) {
-      return DoubleMath.fuzzyEquals(want, time.getCoordMidpoint(0), 1.0e-8) ? 0 : -1;
+      return DoubleMath.fuzzyEquals(want, time.getCoordDouble(0), 1.0e-8) ? 0 : -1;
     }
     if (time.isRegular()) {
-      double fval = (want - time.getCoordMidpoint(0)) / time.getResolution();
+      double fval = (want - time.getCoordDouble(0)) / time.getResolution();
       double ival = Math.rint(fval);
       return DoubleMath.fuzzyEquals(fval, ival, 1.0e-8) ? (int) ival : (int) -ival - 1; // LOOK
     }

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetIntervalHelper.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetIntervalHelper.java
@@ -116,8 +116,8 @@ public class SubsetIntervalHelper {
     }
 
     GridAxisInterval.Builder<?> builder = orgGridAxis.toBuilder();
-    builder.subset(ncoords, orgGridAxis.getCoordMidpoint(subsetRange.first()),
-        orgGridAxis.getCoordMidpoint(subsetRange.last()), resolution, subsetRange);
+    builder.subset(ncoords, orgGridAxis.getCoordDouble(subsetRange.first()),
+        orgGridAxis.getCoordDouble(subsetRange.last()), resolution, subsetRange);
     return builder;
   }
 

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetPointHelper.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetPointHelper.java
@@ -124,7 +124,7 @@ public class SubsetPointHelper {
 
   GridAxisPoint.Builder<?> makeSubsetByIndex(int index) {
     GridAxisPoint.Builder<?> builder = orgGridAxis.toBuilder();
-    double val = orgGridAxis.getCoordMidpoint(index);
+    double val = orgGridAxis.getCoordDouble(index);
     return builder.subsetWithSingleValue(val, Range.make(index, index));
   }
 
@@ -144,11 +144,11 @@ public class SubsetPointHelper {
 
     if (minIndex >= orgGridAxis.getNominalSize()) {
       errlog.format("no points in subset: lower %f > end %f", lower,
-          orgGridAxis.getCoordMidpoint(orgGridAxis.getNominalSize() - 1));
+          orgGridAxis.getCoordDouble(orgGridAxis.getNominalSize() - 1));
       return Optional.empty();
     }
     if (maxIndex < 0) {
-      errlog.format("no points in subset: upper %f < start %f", upper, orgGridAxis.getCoordMidpoint(0));
+      errlog.format("no points in subset: upper %f < start %f", upper, orgGridAxis.getCoordDouble(0));
       return Optional.empty();
     }
 

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetTimeHelper.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/SubsetTimeHelper.java
@@ -171,10 +171,10 @@ public class SubsetTimeHelper {
 
   private static int search(GridAxis<?> time, double want) {
     if (time.getNominalSize() == 1) {
-      return DoubleMath.fuzzyEquals(want, time.getCoordMidpoint(0), 1.0e-8) ? 0 : -1;
+      return DoubleMath.fuzzyEquals(want, time.getCoordDouble(0), 1.0e-8) ? 0 : -1;
     }
     if (time.isRegular()) {
-      double fval = (want - time.getCoordMidpoint(0)) / time.getResolution();
+      double fval = (want - time.getCoordDouble(0)) / time.getResolution();
       double ival = Math.rint(fval);
       return DoubleMath.fuzzyEquals(fval, ival, 1.0e-8) ? (int) ival : (int) -ival - 1; // LOOK
     }

--- a/cdm-core/src/main/java/ucar/unidata/geoloc/LatLonRect.java
+++ b/cdm-core/src/main/java/ucar/unidata/geoloc/LatLonRect.java
@@ -257,7 +257,7 @@ public class LatLonRect {
     if (deltaLon < 0)
       return null;
 
-    return new LatLonRect.Builder(LatLonPoint.create(latMin, lonMin), deltaLat, deltaLon).build();
+    return LatLonRect.builder(LatLonPoint.create(latMin, lonMin), deltaLat, deltaLon).build();
   }
 
   private boolean intersect(double min1, double max1, double min2, double max2) {

--- a/cdm-core/src/main/java/ucar/unidata/geoloc/projection/LatLonProjection.java
+++ b/cdm-core/src/main/java/ucar/unidata/geoloc/projection/LatLonProjection.java
@@ -143,7 +143,7 @@ public class LatLonProjection extends AbstractProjection {
     double deltaLon = world.getWidth();
 
     LatLonPoint llpt = LatLonPoint.create(startLat, startLon);
-    return new LatLonRect.Builder(llpt, deltaLat, deltaLon).build();
+    return LatLonRect.builder(llpt, deltaLat, deltaLon).build();
   }
 
 

--- a/cdm-core/src/test/java/ucar/array/TestRange.java
+++ b/cdm-core/src/test/java/ucar/array/TestRange.java
@@ -108,7 +108,7 @@ public class TestRange {
   }
 
   @Test
-  public void testCopyWithStride() throws InvalidRangeException {
+  public void testCopyWithStride() {
     Range r = Range.make("test", 42);
 
     Range rs = r.copyWithStride(6);
@@ -129,6 +129,19 @@ public class TestRange {
     } catch (Exception e) {
       assertThat(e.getMessage()).contains("stride (-1) must be > 0");
     }
+  }
+
+  @Test
+  public void testCopyWithStride2() {
+    Range r0 = Range.make(0, 10, 3);
+    assertThat(r0.stride()).isEqualTo(3);
+    assertThat(r0.first()).isEqualTo(0);
+    assertThat(r0.last()).isEqualTo(9);
+    assertThat(r0.length()).isEqualTo(4);
+
+    Range r = Range.make("test", 10);
+    Range rs = r.copyWithStride(3);
+    assertThat(r0).isEqualTo(rs);
   }
 
   @Test

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestGridAxis.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestGridAxis.java
@@ -25,8 +25,8 @@ public class TestGridAxis {
     assertThat(axis1D.attributes().findAttributeDouble("aname", 0.0)).isEqualTo(99.0);
 
     assertThat(axis1D.getSpacing()).isEqualTo(GridAxisSpacing.regularPoint);
-    assertThat(axis1D.getCoordMidpoint(0)).isEqualTo(0);
-    assertThat(axis1D.getCoordMidpoint(axis1D.getNominalSize() - 1)).isEqualTo(60);
+    assertThat(axis1D.getCoordDouble(0)).isEqualTo(0);
+    assertThat(axis1D.getCoordDouble(axis1D.getNominalSize() - 1)).isEqualTo(60);
     assertThat(axis1D.getResolution()).isEqualTo(10);
     assertThat(axis1D.getNominalSize()).isEqualTo(7);
     assertThat(Grids.isAscending(axis1D)).isTrue();
@@ -36,7 +36,7 @@ public class TestGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(axis1D)).isEqualTo(MinMax.create(-5.0, 65.0));
 
     for (int i = 0; i < axis1D.getNominalSize(); i++) {
-      assertThat(axis1D.getCoordMidpoint(i)).isEqualTo(10.0 * i);
+      assertThat(axis1D.getCoordDouble(i)).isEqualTo(10.0 * i);
       assertThat(axis1D.getCoordInterval(i).start()).isEqualTo(10.0 * i - 5.0);
       assertThat(axis1D.getCoordInterval(i).end()).isEqualTo(10.0 * i + 5.0);
       assertThat(axis1D.getCoordInterval(i)).isEqualTo(CoordInterval.create(10.0 * i - 5.0, 10.0 * i + 5.0));
@@ -89,8 +89,8 @@ public class TestGridAxis {
 
     assertThat(axis1D.getSpacing()).isEqualTo(GridAxisSpacing.irregularPoint);
     assertThat(axis1D.getNominalSize()).isEqualTo(n);
-    assertThat(axis1D.getCoordMidpoint(0)).isEqualTo(0);
-    assertThat(axis1D.getCoordMidpoint(axis1D.getNominalSize() - 1)).isEqualTo(100);
+    assertThat(axis1D.getCoordDouble(0)).isEqualTo(0);
+    assertThat(axis1D.getCoordDouble(axis1D.getNominalSize() - 1)).isEqualTo(100);
     assertThat(axis1D.getResolution()).isEqualTo(100.0 / (n - 1));
     assertThat(Grids.isAscending(axis1D)).isTrue();
     assertThat(axis1D.isRegular()).isFalse();
@@ -98,7 +98,7 @@ public class TestGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(axis1D)).isEqualTo(MinMax.create(-2.5, 110.0));
 
     for (int i = 0; i < axis1D.getNominalSize(); i++) {
-      assertThat(axis1D.getCoordMidpoint(i)).isEqualTo(values[i]);
+      assertThat(axis1D.getCoordDouble(i)).isEqualTo(values[i]);
       if (i == 0) {
         assertThat(axis1D.getCoordInterval(i).start()).isEqualTo(values[i] - (values[i + 1] - values[i]) / 2);
       } else {
@@ -151,8 +151,8 @@ public class TestGridAxis {
 
     assertThat(axis1D.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
     assertThat(axis1D.getNominalSize()).isEqualTo(n);
-    assertThat(axis1D.getCoordMidpoint(0)).isEqualTo(2);
-    assertThat(axis1D.getCoordMidpoint(axis1D.getNominalSize() - 1)).isEqualTo(80);
+    assertThat(axis1D.getCoordDouble(0)).isEqualTo(2);
+    assertThat(axis1D.getCoordDouble(axis1D.getNominalSize() - 1)).isEqualTo(80);
     assertThat(axis1D.getResolution()).isEqualTo(78.0 / (n - 1));
     assertThat(Grids.isAscending(axis1D)).isTrue();
     assertThat(axis1D.isRegular()).isFalse();
@@ -160,7 +160,7 @@ public class TestGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(axis1D)).isEqualTo(MinMax.create(0, 100.0));
 
     for (int i = 0; i < axis1D.getNominalSize(); i++) {
-      assertThat(axis1D.getCoordMidpoint(i)).isEqualTo(values[i]);
+      assertThat(axis1D.getCoordDouble(i)).isEqualTo(values[i]);
       assertThat(axis1D.getCoordInterval(i).start()).isEqualTo(edges[i]);
       assertThat(axis1D.getCoordInterval(i).end()).isEqualTo(edges[i + 1]);
     }
@@ -230,7 +230,7 @@ public class TestGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(axis1D)).isEqualTo(MinMax.create(-5.0, 65.0));
 
     for (int i = 0; i < axis1D.getNominalSize(); i++) {
-      assertThat(axis1D.getCoordMidpoint(i)).isEqualTo(10.0 * i);
+      assertThat(axis1D.getCoordDouble(i)).isEqualTo(10.0 * i);
       assertThat(axis1D.getCoordInterval(i).start()).isEqualTo(10.0 * i - 5.0);
       assertThat(axis1D.getCoordInterval(i).end()).isEqualTo(10.0 * i + 5.0);
       assertThat(axis1D.getCoordInterval(i)).isEqualTo(CoordInterval.create(10.0 * i - 5.0, 10.0 * i + 5.0));
@@ -276,7 +276,7 @@ public class TestGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(axis1D)).isEqualTo(MinMax.create(0, 100.0));
 
     for (int i = 0; i < axis1D.getNominalSize(); i++) {
-      assertThat(axis1D.getCoordMidpoint(i)).isEqualTo((values[i] + values[i + 1]) / 2);
+      assertThat(axis1D.getCoordDouble(i)).isEqualTo((values[i] + values[i + 1]) / 2);
       assertThat(axis1D.getCoordInterval(i).start()).isEqualTo(values[i]);
       assertThat(axis1D.getCoordInterval(i).end()).isEqualTo(values[i + 1]);
       assertThat(axis1D.getCoordInterval(i)).isEqualTo(CoordInterval.create(values[i], values[i + 1]));
@@ -323,7 +323,7 @@ public class TestGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(axis1D)).isEqualTo(MinMax.create(0, 100));
 
     for (int i = 0; i < axis1D.getNominalSize(); i++) {
-      assertThat(axis1D.getCoordMidpoint(i)).isEqualTo((values[2 * i] + values[2 * i + 1]) / 2);
+      assertThat(axis1D.getCoordDouble(i)).isEqualTo((values[2 * i] + values[2 * i + 1]) / 2);
       assertThat(axis1D.getCoordInterval(i).start()).isEqualTo(values[2 * i]);
       assertThat(axis1D.getCoordInterval(i).end()).isEqualTo(values[2 * i + 1]);
       assertThat(axis1D.getCoordInterval(i)).isEqualTo(CoordInterval.create(values[2 * i], values[2 * i + 1]));
@@ -383,13 +383,13 @@ public class TestGridAxis {
 
   private void testFailures(GridAxis<?> subject) {
     try {
-      subject.getCoordMidpoint(-1);
+      subject.getCoordDouble(-1);
       fail();
     } catch (Exception ok) {
       // ok
     }
     try {
-      subject.getCoordMidpoint(10000);
+      subject.getCoordDouble(10000);
       fail();
     } catch (Exception ok) {
       // ok

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestGridAxisSubsetStrided.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestGridAxisSubsetStrided.java
@@ -1,0 +1,163 @@
+package ucar.nc2.grid;
+
+import org.junit.Test;
+import ucar.array.Range;
+import ucar.nc2.Attribute;
+import ucar.nc2.constants.AxisType;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Test {@link GridAxis} subsetting with strides. */
+public class TestGridAxisSubsetStrided {
+
+  @Test
+  public void testRegularPoint() {
+    GridAxisPoint.Builder<?> builder = GridAxisPoint.builder().setAxisType(AxisType.GeoX).setName("name")
+        .setUnits("unit").setDescription("desc").setRegular(10, 1, 1).setSpacing(GridAxisSpacing.regularPoint);
+    GridAxisPoint axis1D = builder.build();
+
+    GridAxisPoint subset = axis1D.toBuilder().subsetWithStride(3).build();
+    assertThat(subset.getSubsetRange()).isEqualTo(Range.make(0, 9, 3));
+    assertThat(subset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+
+    int count = 0;
+    double[] mid = new double[] {1, 4, 7, 10};
+    for (Number val : subset) {
+      assertThat(val).isEqualTo(mid[count]);
+      count++;
+    }
+
+    double[] edge = new double[] {.5, 3.5, 6.5, 9.5, 10.5};
+    for (int i = 0; i < subset.ncoords; i++) {
+      assertThat(subset.getCoordInterval(i).start()).isEqualTo(edge[i]);
+      assertThat(subset.getCoordInterval(i).end()).isEqualTo(edge[i + 1]);
+    }
+  }
+
+  @Test
+  public void testIrregularPoint() {
+    int n = 7;
+    double[] values = new double[] {0, 5, 10, 20, 40, 80, 100};
+    GridAxisPoint.Builder<?> builder = GridAxisPoint.builder().setAxisType(AxisType.TimeOffset).setName("name")
+        .setNcoords(n).setValues(values).setSpacing(GridAxisSpacing.irregularPoint);
+    GridAxisPoint axis1D = builder.build();
+
+    GridAxisPoint subset = axis1D.toBuilder().subsetWithStride(2).build();
+    assertThat(subset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+
+    double[] mid = new double[] {0, 10, 40, 100};
+    int count = 0;
+    for (Number val : subset) {
+      assertThat(val).isEqualTo(mid[count]);
+      count++;
+    }
+
+    double[] edge = new double[] {-2.5, 7.5, 30, 90, 110};
+    for (int i = 0; i < subset.ncoords; i++) {
+      assertThat(subset.getCoordInterval(i).start()).isEqualTo(edge[i]);
+      assertThat(subset.getCoordInterval(i).end()).isEqualTo(edge[i + 1]);
+    }
+  }
+
+  @Test
+  public void testNominalPoint() {
+    int n = 6;
+    double[] values = new double[] {2, 4, 8, 15, 50, 80, 100, 111};
+    double[] edges = new double[] {0, 3, 5, 10, 20, 80, 100, 101, 111};
+    GridAxisPoint.Builder<?> builder = GridAxisPoint.builder().setAxisType(AxisType.Time).setName("name")
+        .setUnits("unit").setDescription("desc").setNcoords(n).setValues(values).setEdges(edges)
+        .setSpacing(GridAxisSpacing.nominalPoint).addAttribute(new Attribute("aname", 99.0));
+    GridAxisPoint axis1D = builder.build();
+
+    GridAxisPoint subset = axis1D.toBuilder().subsetWithStride(3).build();
+    assertThat(subset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+
+    int count = 0;
+    double[] mid = new double[] {2, 15, 100};
+    for (Number val : subset) {
+      assertThat(val).isEqualTo(mid[count]);
+      count++;
+    }
+
+    double[] edge = new double[] {0, 10, 100, 111};
+    for (int i = 0; i < subset.ncoords; i++) {
+      assertThat(subset.getCoordInterval(i).start()).isEqualTo(edge[i]);
+      assertThat(subset.getCoordInterval(i).end()).isEqualTo(edge[i + 1]);
+    }
+  }
+
+  @Test
+  public void testRegularDescending() {
+    GridAxisPoint.Builder<?> builder = GridAxisPoint.builder().setAxisType(AxisType.Pressure).setName("name")
+        .setUnits("unit").setDescription("desc").setRegular(7, 100.0, -10.0).setSpacing(GridAxisSpacing.regularPoint);
+    GridAxisPoint axis1D = builder.build();
+
+    GridAxisPoint subset = axis1D.toBuilder().subsetWithStride(2).build();
+    assertThat(subset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+
+    int count = 0;
+    double[] mid = new double[] {100, 80, 60, 40};
+    for (Number val : subset) {
+      assertThat(val).isEqualTo(mid[count]);
+      count++;
+    }
+
+    double[] edge = new double[] {105, 85, 65, 45, 35};
+    for (int i = 0; i < subset.ncoords; i++) {
+      assertThat(subset.getCoordInterval(i).start()).isEqualTo(edge[i]);
+      assertThat(subset.getCoordInterval(i).end()).isEqualTo(edge[i + 1]);
+    }
+  }
+
+  @Test
+  public void testIrregularDescending() {
+    int n = 7;
+    double[] values = new double[] {0, -5, -10, -20, -40, -80, -100};
+    GridAxisPoint.Builder<?> builder = GridAxisPoint.builder().setAxisType(AxisType.TimeOffset).setName("name")
+        .setNcoords(n).setValues(values).setSpacing(GridAxisSpacing.irregularPoint);
+    GridAxisPoint axis1D = builder.build();
+
+    GridAxisPoint subset = axis1D.toBuilder().subsetWithStride(2).build();
+    assertThat(subset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+
+    double[] mid = new double[] {0, -10, -40, -100};
+    int count = 0;
+    for (Number val : subset) {
+      assertThat(val).isEqualTo(mid[count]);
+      count++;
+    }
+
+    double[] edge = new double[] {2.5, -7.5, -30, -90, -110};
+    for (int i = 0; i < subset.ncoords; i++) {
+      assertThat(subset.getCoordInterval(i).start()).isEqualTo(edge[i]);
+      assertThat(subset.getCoordInterval(i).end()).isEqualTo(edge[i + 1]);
+    }
+  }
+
+  @Test
+  public void testNominalDescending() {
+    int n = 6;
+    double[] values = new double[] {-2, -4, -8, -15, -50, -80, -100, -111};
+    double[] edges = new double[] {0, -3, -5, -10, -20, -80, -100, -101, -111};
+    GridAxisPoint.Builder<?> builder = GridAxisPoint.builder().setAxisType(AxisType.Time).setName("name")
+        .setUnits("unit").setDescription("desc").setNcoords(n).setValues(values).setEdges(edges)
+        .setSpacing(GridAxisSpacing.nominalPoint).addAttribute(new Attribute("aname", 99.0));
+    GridAxisPoint axis1D = builder.build();
+
+    GridAxisPoint subset = axis1D.toBuilder().subsetWithStride(3).build();
+    assertThat(subset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+
+    int count = 0;
+    double[] mid = new double[] {-2, -15, -100};
+    for (Number val : subset) {
+      assertThat(val).isEqualTo(mid[count]);
+      count++;
+    }
+
+    double[] edge = new double[] {0, -10, -100, -111};
+    for (int i = 0; i < subset.ncoords; i++) {
+      assertThat(subset.getCoordInterval(i).start()).isEqualTo(edge[i]);
+      assertThat(subset.getCoordInterval(i).end()).isEqualTo(edge[i + 1]);
+    }
+  }
+}

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestGridHorizCoordinateSystemSubsetting.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestGridHorizCoordinateSystemSubsetting.java
@@ -24,17 +24,16 @@ public class TestGridHorizCoordinateSystemSubsetting {
   @Test
   public void testRegularWithStride() {
     GridAxisPoint.Builder<?> xbuilder = GridAxisPoint.builder().setAxisType(AxisType.GeoX).setName("xname")
-        .setUnits("km").setDescription("desc").setRegular(9, 0.0, 10.0).setSpacing(GridAxisSpacing.regularPoint)
-        .addAttribute(new Attribute("aname", 99.0));
+        .setUnits("km").setDescription("desc").setRegular(9, 0.0, 10.0).setSpacing(GridAxisSpacing.regularPoint);
     GridAxisPoint xaxis = xbuilder.build();
 
     GridAxisPoint.Builder<?> ybuilder = GridAxisPoint.builder().setAxisType(AxisType.GeoY).setName("yname")
-        .setUnits("km").setDescription("desc").setRegular(7, 0.0, 11.0).setSpacing(GridAxisSpacing.regularPoint)
-        .addAttribute(new Attribute("aname", 99.0));
+        .setUnits("km").setDescription("desc").setRegular(7, 0.0, 11.0).setSpacing(GridAxisSpacing.regularPoint);
     GridAxisPoint yaxis = ybuilder.build();
 
     Projection project = new FlatEarth();
     GridHorizCoordinateSystem hcs = new GridHorizCoordinateSystem(xaxis, yaxis, project);
+    System.out.printf("hcs = %s%n", hcs);
 
     Formatter errlog = new Formatter();
     GridHorizCoordinateSystem subset = hcs.subset(GridSubset.create().setHorizStride(3), errlog).orElseThrow();
@@ -46,10 +45,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
     assertThat(subset.getSubsetRanges()).isEqualTo(ImmutableList.of(Range.make(0, 6, 3), Range.make(0, 8, 3)));
     assertThat(subset.getShape()).isEqualTo(ImmutableList.of(3, 3));
 
-    assertThat(subset.getGeoUnits()).isEqualTo("km");
-    assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("-15, -16.5, 90, 99"));
-    assertThat(subset.getLatLonBoundingBox()).isNotNull();
-
     GridHorizCoordinateSystem copy =
         new GridHorizCoordinateSystem(hcs.getXHorizAxis(), hcs.getYHorizAxis(), hcs.getProjection());
     assertThat(copy).isEqualTo(hcs);
@@ -57,14 +52,16 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint ysubset = subset.getYHorizAxis();
     assertThat((Object) ysubset).isNotNull();
-    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.regularPoint);
+    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+    System.out.printf("ysubset = %s%n", ysubset);
+
     GridAxisPoint xsubset = subset.getXHorizAxis();
     assertThat((Object) xsubset).isNotNull();
-    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.regularPoint);
+    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+    System.out.printf("xsubset = %s%n", xsubset);
 
     int count = 0;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(count * 33);
       count++;
     }
@@ -72,11 +69,14 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     count = 0;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(count * 30);
       count++;
     }
     assertThat(count).isEqualTo(3);
+
+    assertThat(subset.getGeoUnits()).isEqualTo("km");
+    assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("-5, -5.5, 90, 77"));
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
   }
 
   @Test
@@ -107,10 +107,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
     assertThat(subset.getSubsetRanges()).isEqualTo(ImmutableList.of(Range.make(0, 6, 2), Range.make(0, 8, 2)));
     assertThat(subset.getShape()).isEqualTo(ImmutableList.of(4, 5));
 
-    assertThat(subset.getGeoUnits()).isEqualTo("km");
-    assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("-10, -5, 100, 135"));
-    assertThat(subset.getLatLonBoundingBox()).isNotNull();
-
     GridHorizCoordinateSystem copy =
         new GridHorizCoordinateSystem(hcs.getXHorizAxis(), hcs.getYHorizAxis(), hcs.getProjection());
     assertThat(copy).isEqualTo(hcs);
@@ -118,11 +114,11 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint ysubset = subset.getYHorizAxis();
     assertThat((Object) ysubset).isNotNull();
-    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.irregularPoint);
+    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+    System.out.printf("ysubset = %s%n", ysubset);
 
     int count = 0;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(values[count * 2]);
       count++;
     }
@@ -130,15 +126,19 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint xsubset = subset.getXHorizAxis();
     assertThat((Object) xsubset).isNotNull();
-    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.regularPoint);
+    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+    System.out.printf("xsubset = %s%n", xsubset);
 
     count = 0;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(count * 20);
       count++;
     }
     assertThat(count).isEqualTo(5);
+
+    assertThat(subset.getGeoUnits()).isEqualTo("km");
+    assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("-5, -2.5, 90, 112.5"));
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
   }
 
   @Test
@@ -172,10 +172,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
     assertThat(subset.getSubsetRanges()).isEqualTo(ImmutableList.of(Range.make(0, 6, 2), Range.make(0, 4, 2)));
     assertThat(subset.getShape()).isEqualTo(ImmutableList.of(4, 3));
 
-    assertThat(subset.getGeoUnits()).isEqualTo("km");
-    // assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("-10, -5, 100, 135"));
-    assertThat(subset.getLatLonBoundingBox()).isNotNull();
-
     GridHorizCoordinateSystem copy =
         new GridHorizCoordinateSystem(hcs.getXHorizAxis(), hcs.getYHorizAxis(), hcs.getProjection());
     assertThat(copy).isEqualTo(hcs);
@@ -183,14 +179,15 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint ysubset = subset.getYHorizAxis();
     assertThat((Object) ysubset).isNotNull();
-    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.irregularPoint);
+    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+    System.out.printf("ysubset = %s%n", ysubset);
     GridAxisPoint xsubset = subset.getXHorizAxis();
     assertThat((Object) xsubset).isNotNull();
     assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
+    System.out.printf("xsubset = %s%n", xsubset);
 
     int count = 0;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(yvalues[count * 2]);
       count++;
     }
@@ -198,17 +195,20 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     count = 0;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(xvalues[count * 2]);
       count++;
     }
     assertThat(count).isEqualTo(3);
 
     for (int i = 0; i < xsubset.getNominalSize(); i++) {
-      assertThat(xsubset.getCoordMidpoint(i)).isEqualTo(xvalues[2 * i]);
+      assertThat(xsubset.getCoordDouble(i)).isEqualTo(xvalues[2 * i]);
       assertThat(xsubset.getCoordInterval(i).start()).isEqualTo(xedges[2 * i]);
       assertThat(xsubset.getCoordInterval(i).end()).isEqualTo(xedges[2 * (i + 1)]);
     }
+
+    assertThat(subset.getGeoUnits()).isEqualTo("km");
+    assertThat(subset.getBoundingBox().nearlyEquals(ProjectionRect.fromSpec("-0, -2.5, 100, 112.5"))).isTrue();
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
   }
 
   @Test
@@ -252,7 +252,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     int count = 3;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(count * 110);
       count++;
     }
@@ -266,7 +265,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     count = 2;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(count * 100);
       count++;
     }
@@ -314,7 +312,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     int count = 1;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(values[count]);
       count++;
     }
@@ -327,7 +324,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     count = 2;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(count * 10);
       count++;
     }
@@ -380,7 +376,6 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     int count = 1;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(yvalues[count]);
       count++;
     }
@@ -393,14 +388,13 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     count = 1;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(xvalues[count]);
       count++;
     }
     assertThat(count).isEqualTo(6);
 
     for (int i = 0; i < xsubset.getNominalSize(); i++) {
-      assertThat(xsubset.getCoordMidpoint(i)).isEqualTo(xvalues[i + 1]);
+      assertThat(xsubset.getCoordDouble(i)).isEqualTo(xvalues[i + 1]);
       assertThat(xsubset.getCoordInterval(i).start()).isEqualTo(xedges[i + 1]);
       assertThat(xsubset.getCoordInterval(i).end()).isEqualTo(xedges[i + 2]);
     }
@@ -428,32 +422,36 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint ysubset = subset.getYHorizAxis();
     assertThat((Object) ysubset).isNotNull();
-    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.regularPoint);
+    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
     assertThat(ysubset.getSubsetRange()).isEqualTo(Range.make(3, 6, 3));
     assertThat(ysubset.getNominalSize()).isEqualTo(2);
+    System.out.printf("ysubset = %s%n", ysubset);
 
     int count = 0;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo((3 + 3 * count) * 110);
       count++;
     }
     assertThat(count).isEqualTo(2);
 
-
     GridAxisPoint xsubset = subset.getXHorizAxis();
     assertThat((Object) xsubset).isNotNull();
-    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.regularPoint);
+    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
     assertThat(xsubset.getSubsetRange()).isEqualTo(Range.make(2, 5, 3));
     assertThat(xsubset.getNominalSize()).isEqualTo(2);
+    System.out.printf("xsubset = %s%n", xsubset);
 
     count = 0;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo((2 + 3 * count) * 100);
       count++;
     }
     assertThat(count).isEqualTo(2);
+
+    assertThat(subset.getGeoUnits()).isEqualTo("km");
+    assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("150, 275, 600, 660"));
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
   }
 
   @Test
@@ -479,13 +477,13 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint ysubset = subset.getYHorizAxis();
     assertThat((Object) ysubset).isNotNull();
-    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.irregularPoint);
+    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
     assertThat(ysubset.getSubsetRange()).isEqualTo(Range.make(1, 5, 2));
     assertThat(ysubset.getNominalSize()).isEqualTo(3);
+    System.out.printf("ysubset = %s%n", ysubset);
 
     int count = 0;
     for (Number val : ysubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(values[1 + 2 * count]);
       count++;
     }
@@ -493,17 +491,22 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint xsubset = subset.getXHorizAxis();
     assertThat((Object) xsubset).isNotNull();
-    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.regularPoint);
+    assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
     assertThat(xsubset.getSubsetRange()).isEqualTo(Range.make(2, 6, 2));
     assertThat(xsubset.getNominalSize()).isEqualTo(3);
+    System.out.printf("xsubset = %s%n", xsubset);
 
     count = 0;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo((2 + 2 * count) * 10);
       count++;
     }
     assertThat(count).isEqualTo(3);
+
+    assertThat(subset.getGeoUnits()).isEqualTo("km");
+    assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("15, 2.5, 60, 107.5"));
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
   }
 
   @Test
@@ -532,9 +535,10 @@ public class TestGridHorizCoordinateSystemSubsetting {
 
     GridAxisPoint ysubset = subset.getYHorizAxis();
     assertThat((Object) ysubset).isNotNull();
-    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.irregularPoint);
+    assertThat(ysubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
     assertThat(ysubset.getSubsetRange()).isEqualTo(Range.make(1, 3, 2));
     assertThat(ysubset.getNominalSize()).isEqualTo(2);
+    System.out.printf("ysubset = %s%n", ysubset);
 
     int count = 0;
     for (Number val : ysubset) {
@@ -548,20 +552,25 @@ public class TestGridHorizCoordinateSystemSubsetting {
     assertThat(xsubset.getSpacing()).isEqualTo(GridAxisSpacing.nominalPoint);
     assertThat(xsubset.getSubsetRange()).isEqualTo(Range.make(1, 5, 2));
     assertThat(xsubset.getNominalSize()).isEqualTo(3);
+    System.out.printf("xsubset = %s%n", xsubset);
 
     count = 0;
     for (Number val : xsubset) {
-      System.out.printf(" %s%n", val);
       assertThat(val).isEqualTo(xvalues[1 + 2 * count]);
       count++;
     }
     assertThat(count).isEqualTo(3);
 
     for (int i = 0; i < xsubset.getNominalSize(); i++) {
-      assertThat(xsubset.getCoordMidpoint(i)).isEqualTo(xvalues[1 + 2 * i]);
+      assertThat(xsubset.getCoordDouble(i)).isEqualTo(xvalues[1 + 2 * i]);
       assertThat(xsubset.getCoordInterval(i).start()).isEqualTo(xedges[1 + 2 * i]);
       int maxIdx = Math.min(1 + 2 * (i + 1), xedges.length - 1);
       assertThat(xsubset.getCoordInterval(i).end()).isEqualTo(xedges[maxIdx]);
     }
+
+    assertThat(subset.getGeoUnits()).isEqualTo("km");
+    assertThat(subset.getBoundingBox()).isEqualTo(ProjectionRect.fromSpec("3, 2.5, 97, 57.5"));
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
+    assertThat(subset.getLatLonBoundingBox()).isNotNull();
   }
 }

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestReadCurvilinearFindIndex.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestReadCurvilinearFindIndex.java
@@ -99,4 +99,58 @@ public class TestReadCurvilinearFindIndex {
     }
   }
 
+  @Test
+  public void TestGribCurvilinear() throws IOException, InvalidRangeException {
+    String endpoint = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2";
+    String gridName = "Mixed_layer_depth_surface";
+    System.out.printf("open %s %s%n", endpoint, gridName);
+
+    Formatter errlog = new Formatter();
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+      assertThat(gds).isNotNull();
+      assertThat(gds.getGrids()).hasSize(7);
+      Grid grid = gds.findGrid(gridName).orElseThrow();
+      assertThat(grid).isNotNull();
+
+      GridCoordinateSystem cs = grid.getCoordinateSystem();
+      assertThat(cs).isNotNull();
+      assertThat(cs.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+      System.out.printf("GridCoordinateSystem = %s%n", cs);
+      GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
+      assertThat(hcs).isNotNull();
+      assertThat(hcs.isCurvilinear()).isTrue();
+      System.out.printf("GridHorizCoordinateSystem = %s%n", hcs);
+
+      Optional<GridHorizCoordinateSystem.CoordReturn> cro = hcs.findXYindexFromCoord(-6.6, -6.6);
+      assertThat(cro).isPresent();
+      GridHorizCoordinateSystem.CoordReturn cr = cro.get();
+      System.out.printf("%nCoordReturn = %s%n", cr);
+      assertThat(cr.xindex).isEqualTo(124);
+      assertThat(cr.yindex).isEqualTo(393);
+
+      // -23.479818, -4.231693
+      cro = hcs.findXYindexFromCoord(-23.479818, -4.231693);
+      assertThat(cro).isPresent();
+      cr = cro.get();
+      System.out.printf("%nCoordReturn = %s%n", cr);
+      assertThat(cr.xindex).isEqualTo(145);
+      assertThat(cr.yindex).isEqualTo(523);
+
+      // -23.152880, -4.558632
+      cro = hcs.findXYindexFromCoord(-23.152880, -4.558632);
+      assertThat(cro).isPresent();
+      cr = cro.get();
+      System.out.printf("%nCoordReturn = %s%n", cr);
+      assertThat(cr.xindex).isEqualTo(143);
+      assertThat(cr.yindex).isEqualTo(520);
+
+      cro = hcs.findXYindexFromCoord(0, 0);
+      assertThat(cro).isPresent();
+      cr = cro.get();
+      System.out.printf("%nCoordReturn = %s%n", cr);
+      assertThat(cr.yindex).isEqualTo(343);
+      assertThat(cr.xindex).isEqualTo(167);
+    }
+  }
+
 }

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridCurvilinear.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridCurvilinear.java
@@ -7,10 +7,10 @@ package ucar.nc2.grid;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import ucar.array.Array;
+import ucar.array.Arrays;
 import ucar.array.InvalidRangeException;
 import ucar.nc2.calendar.CalendarDate;
 import ucar.nc2.constants.FeatureType;
@@ -91,16 +91,13 @@ public class TestReadGridCurvilinear {
   }
 
   @Test
-  @Ignore("Grib Curvilinear not done yet")
   public void testGribCurvilinear() throws IOException, InvalidRangeException {
     String filename = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2";
     readGrid(filename, "Sea_Surface_Height_Relative_to_Geoid_surface", ImmutableList.of(1, 1, 1684, 1200),
-        "reftime time lataxis lonaxis", "2009-11-23T00:00Z", null, new int[] {1, 1, 1684, 1200});
+        "reftime time Lat Lon", "2009-11-23T00:00Z", null, new int[] {1, 1, 1684, 1200});
   }
 
   @Test
-  @Category(NeedsCdmUnitTest.class)
-  @Ignore("GRIB curvilinear not ready")
   public void testCurvilinearGrib() throws IOException {
     String filename = TestDir.cdmUnitTestDir + "ft/fmrc/rtofs/ofs.20091122/ofs_atl.t00z.F024.grb.grib2";
     String gridName = "3-D_Temperature_depth_below_sea";
@@ -170,9 +167,11 @@ public class TestReadGridCurvilinear {
 
       GridHorizCoordinateSystem mhcs = mcs.getHorizCoordinateSystem();
       assertThat(mhcs).isInstanceOf(GridHorizCurvilinear.class);
+      int count = 0;
       for (GridHorizCoordinateSystem.CellBounds bound : mhcs.cells()) {
-        System.out.printf("%s%n", bound);
+        count++;
       }
+      assertThat(count).isEqualTo(Arrays.computeSize(matShape));
       System.out.printf("  llbb = %s%n", mhcs.getLatLonBoundingBox());
       System.out.printf("  mapArea = %s%n", mhcs.getBoundingBox());
     }

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridDataset.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridDataset.java
@@ -125,7 +125,7 @@ public class TestReadGridDataset {
       GridAxis<?> vert = mcs.getVerticalAxis();
       if (vert != null) {
         assertThat(vert.getNominalSize()).isEqualTo(1);
-        assertThat(vert.getCoordMidpoint(0)).isEqualTo(expectVert);
+        assertThat(vert.getCoordDouble(0)).isEqualTo(expectVert);
       }
 
       GridTimeCoordinateSystem mtcs = mcs.getTimeCoordSystem();

--- a/cdm-core/src/test/java/ucar/nc2/internal/grid/TestCoordAxisToGridAxis.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/grid/TestCoordAxisToGridAxis.java
@@ -58,7 +58,7 @@ public class TestCoordAxisToGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(gridAxis)).isEqualTo(MinMax.create(-5.0, 65));
 
     for (int i = 0; i < gridAxis.getNominalSize(); i++) {
-      assertThat(gridAxis.getCoordMidpoint(i)).isEqualTo(10.0 * i);
+      assertThat(gridAxis.getCoordDouble(i)).isEqualTo(10.0 * i);
       CoordInterval intv = gridAxis.getCoordInterval(i);
       assertThat(intv.start()).isEqualTo(10.0 * i - 5.0);
       assertThat(intv.end()).isEqualTo(10.0 * i + 5.0);
@@ -116,7 +116,7 @@ public class TestCoordAxisToGridAxis {
     assertThat(Grids.getCoordEdgeMinMax(gridAxis)).isEqualTo(MinMax.create(-0.5, 25));
 
     for (int i = 0; i < gridAxis.getNominalSize(); i++) {
-      assertThat(gridAxis.getCoordMidpoint(i)).isEqualTo(timeOffsets[i]);
+      assertThat(gridAxis.getCoordDouble(i)).isEqualTo(timeOffsets[i]);
     }
 
     int count = 0;

--- a/cdm-core/src/test/java/ucar/nc2/internal/grid/TestGridTimeCS.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/grid/TestGridTimeCS.java
@@ -69,7 +69,7 @@ public class TestGridTimeCS {
       assertThat(times).hasSize(ntimes);
       int offsetIdx = 0;
       for (CalendarDate time : times) {
-        long what = (long) offset.getCoordMidpoint(offsetIdx);
+        long what = (long) offset.getCoordDouble(offsetIdx);
         CalendarDate expected = baseForRun.add(what, CalendarPeriod.Field.Day);
         // System.out.printf(" (%d,%d) got= %s want= %s%n", runidx, offsetIdx, time, expected);
         assertThat(time).isEqualTo(expected);
@@ -126,7 +126,7 @@ public class TestGridTimeCS {
       assertThat(times).hasSize(ntimes);
       int offsetIdx = 0;
       for (CalendarDate time : times) {
-        CalendarDate expected = baseForRun.add((long) offset.getCoordMidpoint(offsetIdx++), subject.getOffsetPeriod());
+        CalendarDate expected = baseForRun.add((long) offset.getCoordDouble(offsetIdx++), subject.getOffsetPeriod());
         // System.out.printf(" (%d,%d) got= %s want= %s%n", runidx, offsetIdx, time, expected);
         assertThat(time).isEqualTo(expected);
       }
@@ -158,7 +158,7 @@ public class TestGridTimeCS {
     assertThat(times).hasSize(ntimes);
     CalendarDate baseDate = subject.getBaseDate();
     for (int idx = 0; idx < ntimes; idx++) {
-      CalendarDate expected = baseDate.add((long) timeAxis.getCoordMidpoint(idx), subject.getOffsetPeriod());
+      CalendarDate expected = baseDate.add((long) timeAxis.getCoordDouble(idx), subject.getOffsetPeriod());
       System.out.printf(" (%d)  got= %s want= %s%n", idx, times.get(idx), expected);
       assertThat(times.get(idx)).isEqualTo(expected);
     }

--- a/cdm-core/src/test/java/ucar/unidata/geoloc/projection/TestVerticalPerspectiveView.java
+++ b/cdm-core/src/test/java/ucar/unidata/geoloc/projection/TestVerticalPerspectiveView.java
@@ -34,7 +34,7 @@ public class TestVerticalPerspectiveView {
     System.out.println(" limit = " + limit);
     System.out.println(" limit*90 = " + limit * 90);
 
-    LatLonRect rect = new LatLonRect.Builder(LatLonPoint.create(-45.0, -45.0), -45.0, -45.0).build();
+    LatLonRect rect = LatLonRect.builder(LatLonPoint.create(-45.0, -45.0), -45.0, -45.0).build();
     ProjectionRect r = a.latLonToProjBB(rect);
     System.out.println(" ProjectionRect result = " + r);
   }

--- a/cdm-test-utils/src/main/java/ucar/unidata/util/test/CheckPointFeatureDataset.java
+++ b/cdm-test-utils/src/main/java/ucar/unidata/util/test/CheckPointFeatureDataset.java
@@ -222,7 +222,7 @@ public class CheckPointFeatureDataset {
     // try a subset
     LatLonRect bb = sfc.getBoundingBox();
     Assert.assertNotNull(bb);
-    LatLonRect bb2 = new LatLonRect.Builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
+    LatLonRect bb2 = LatLonRect.builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
     System.out.println(" BB Subset= " + bb2.toString2());
     StationTimeSeriesFeatureCollection sfcSub = sfc.subset(bb2);
     int countSub = countLocations(sfcSub);
@@ -526,7 +526,7 @@ public class CheckPointFeatureDataset {
     }
 
     // subset with a bounding box, test result is in the bounding box
-    LatLonRect bb2 = new LatLonRect.Builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
+    LatLonRect bb2 = LatLonRect.builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
     PointFeatureCollection subset = pfc.subset(bb2, null);
     if (show) {
       System.out.println(" subset bb= " + bb2.toString2());
@@ -577,28 +577,28 @@ public class CheckPointFeatureDataset {
       countLocations(pfc);
 
       LatLonRect bb = pfc.getBoundingBox();
-      LatLonRect bb2 = new LatLonRect.Builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
-      PointFeatureCollection subset = pfc.subset(bb2, (CalendarDateRange) null);
+      LatLonRect bb2 = LatLonRect.builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
+      PointFeatureCollection subset = pfc.subset(bb2, null);
       countLocations(subset);
 
     } else if (fc instanceof StationTimeSeriesFeatureCollection) {
       StationTimeSeriesFeatureCollection sfc = (StationTimeSeriesFeatureCollection) fc;
-      PointFeatureCollection pfcAll = sfc.flatten(null, (CalendarDateRange) null);
+      PointFeatureCollection pfcAll = sfc.flatten(null, null);
       System.out.printf("Unique Locations all = %d %n", countLocations(pfcAll));
 
       LatLonRect bb = sfc.getBoundingBox();
       assert bb != null;
-      LatLonRect bb2 = new LatLonRect.Builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
-      PointFeatureCollection pfcSub = sfc.flatten(bb2, (CalendarDateRange) null);
+      LatLonRect bb2 = LatLonRect.builder(bb.getLowerLeftPoint(), bb.getHeight() / 2, bb.getWidth() / 2).build();
+      PointFeatureCollection pfcSub = sfc.flatten(bb2, null);
       System.out.printf("Unique Locations sub1 = %d %n", countLocations(pfcSub));
 
       StationTimeSeriesFeatureCollection sfcSub = sfc.subset(bb2);
-      PointFeatureCollection pfcSub2 = sfcSub.flatten(null, (CalendarDateRange) null);
+      PointFeatureCollection pfcSub2 = sfcSub.flatten(null, null);
       System.out.printf("Unique Locations sub2 = %d %n", countLocations(pfcSub2));
 
       // Dons
       sfc = sfc.subset(bb2);
-      PointFeatureCollection subDon = sfc.flatten(bb2, (CalendarDateRange) null);
+      PointFeatureCollection subDon = sfc.flatten(bb2, null);
       System.out.printf("Unique Locations subDon = %d %n", countLocations(subDon));
     }
 

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridCompareCoverage.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridCompareCoverage.java
@@ -167,7 +167,7 @@ public class TestGridCompareCoverage {
     CoverageCoordAxis1D oldRuntime1D = (CoverageCoordAxis1D) oldRuntime;
 
     for (int runtimeIdx = 0; runtimeIdx < oldRuntime1D.getNcoords(); runtimeIdx++) {
-      double timeCoord = runtime.getCoordMidpoint(runtimeIdx);
+      double timeCoord = runtime.getCoordDouble(runtimeIdx);
       double timeCoordOld = oldRuntime1D.getCoordMidpoint(runtimeIdx);
       assertThat(timeCoord).isEqualTo(timeCoordOld);
 

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridCurvilinear.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridCurvilinear.java
@@ -43,10 +43,13 @@ public class TestGridCurvilinear {
       GridCoordinateSystem cs = grid.getCoordinateSystem();
       assertThat(cs).isNotNull();
       assertThat(cs.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+      assertThat(cs.getNominalShape()).isEqualTo(ImmutableList.of(432, 11, 22, 12));
+
       GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
       assertThat(hcs).isNotNull();
       assertThat(hcs.isCurvilinear()).isTrue();
       assertThat(hcs).isInstanceOf(GridHorizCurvilinear.class);
+
       System.out.printf("  getLatLonBoundingBox = %s%n", hcs.getLatLonBoundingBox());
       System.out.printf("  getBoundingBox = %s%n", hcs.getBoundingBox());
 
@@ -61,14 +64,12 @@ public class TestGridCurvilinear {
       // read data with ProjectionRect subsetting
       ProjectionRect prect = ProjectionRect.fromSpec("-73.966053, 40.076202, 0.3246, 0.242");
       GridReferencedArray geoSubsetP = grid.readData(new GridSubset().setTimePresent().setProjectionBoundingBox(prect));
-      assertThat(geoSubsetP.data().getShape()).isEqualTo(new int[] {1, 1, 11, 16});
+      assertThat(geoSubsetP.data().getShape()).isEqualTo(new int[] {1, 11, 11, 6});
 
-      /*
-       * read data with latlon subsetting
-       * LatLonRect bbox = LatLonRect.fromSpec("40.076201, -73.966053, 0.242, 0.3246");
-       * GridReferencedArray geoSubset = grid.readData(new GridSubset().setTimePresent().setLatLonBoundingBox(bbox));
-       * assertThat(geoSubset.data().getShape()).isEqualTo(new int[] {1, 1, 11, 6});
-       */
+      // read data with ProjectionRect subsetting
+      LatLonRect llbb = LatLonRect.fromSpec("40.076202, -73.966053, 0.242, 0.3246");
+      GridReferencedArray geoSubsetP1 = grid.readData(new GridSubset().setTimePresent().setLatLonBoundingBox(llbb));
+      assertThat(geoSubsetP1.data().getShape()).isEqualTo(new int[] {1, 11, 11, 6});
     }
   }
 
@@ -119,16 +120,16 @@ public class TestGridCurvilinear {
       GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
       assertThat(hcs).isNotNull();
       assertThat(hcs.isCurvilinear()).isTrue();
-      assertThat(hcs.getShape()).isEqualTo(ImmutableList.of(1, 151, 171));
+      assertThat(hcs.getShape()).isEqualTo(ImmutableList.of(151, 171));
 
       LatLonRect bbox = new LatLonRect(43.489, -8.5353, 43.371, -8.2420);
       GridReferencedArray geo = grid.readData(new GridSubset().setTimePresent().setLatLonBoundingBox(bbox));
 
-      int[] expectedShape = new int[] {1, 99, 105};
+      int[] expectedShape = new int[] {1, 102, 108};
       assertThat(geo.data().getShape()).isEqualTo(expectedShape);
 
-      assertThat(geo.data().get(0, 0, 0).doubleValue()).isWithin(1.7829999923706055);
-      assertThat(geo.data().get(0, 11, 0).doubleValue()).isWithin(1.7669999599456787);
+      assertThat(geo.data().get(0, 0, 0).doubleValue()).isWithin(TOL).of(1.781000018119812);
+      assertThat(geo.data().get(0, 11, 0).doubleValue()).isWithin(TOL).of(1.7699999809265137);
     }
   }
 
@@ -147,18 +148,20 @@ public class TestGridCurvilinear {
       GridCoordinateSystem cs = grid.getCoordinateSystem();
       assertThat(cs).isNotNull();
       assertThat(cs.getFeatureType()).isEqualTo(FeatureType.CURVILINEAR);
+      assertThat(cs.getNominalShape()).isEqualTo(ImmutableList.of(1, 20, 64, 128));
+
       GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
       assertThat(hcs).isNotNull();
       assertThat(hcs.isCurvilinear()).isTrue();
 
-      LatLonRect bbox = new LatLonRect(43.489, -8.5353, 43.371, -8.2420);
+      LatLonRect bbox = LatLonRect.fromSpec("27.437455, -91.697438, 2.892091, 3.935719");
       GridReferencedArray geo = grid.readData(new GridSubset().setTimePresent().setLatLonBoundingBox(bbox));
 
-      int[] expectedShape = new int[] {1, 20, 64, 75};
+      int[] expectedShape = new int[] {1, 20, 64, 95};
       assertThat(geo.data().getShape()).isEqualTo(expectedShape);
 
-      assertThat(geo.data().get(0, 0, 0).doubleValue()).isWithin(1.7829999923706055);
-      assertThat(geo.data().get(0, 11, 0).doubleValue()).isWithin(1.7669999599456787);
+      assertThat(geo.data().get(0, 0, 0, 0).doubleValue()).isWithin(TOL).of(35.410011291503906);
+      assertThat(geo.data().get(0, 11, 11, 11).doubleValue()).isWithin(TOL).of(35.51934051513672);
     }
   }
 
@@ -171,7 +174,7 @@ public class TestGridCurvilinear {
     Formatter errlog = new Formatter();
     try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
       assertThat(gds).isNotNull();
-      assertThat(gds.getGrids()).hasSize(13);
+      assertThat(gds.getGrids()).hasSize(7);
       Grid grid = gds.findGrid(gridName).orElseThrow();
       assertThat(grid).isNotNull();
 
@@ -183,7 +186,7 @@ public class TestGridCurvilinear {
       assertThat(hcs.isCurvilinear()).isTrue();
 
       GridReferencedArray geo = grid.readData(new GridSubset());
-      int[] expectedShape = new int[] {1, 165, 161};
+      int[] expectedShape = new int[] {1, 1, 1684, 1200};
       assertThat(geo.data().getShape()).isEqualTo(expectedShape);
     }
   }
@@ -211,7 +214,7 @@ public class TestGridCurvilinear {
       LatLonRect bbox = new LatLonRect(64.0, -61., 59.0, -52.);
 
       GridReferencedArray geo = grid.readData(new GridSubset().setTimePresent().setLatLonBoundingBox(bbox));
-      int[] expectedShape = new int[] {1, 165, 161};
+      int[] expectedShape = new int[] {1, 1, 168, 164};
       assertThat(geo.data().getShape()).isEqualTo(expectedShape);
     }
   }
@@ -238,11 +241,11 @@ public class TestGridCurvilinear {
 
       GridReferencedArray geo = grid.readData(new GridSubset().setTimePresent().setHorizStride(2));
 
-      int[] expectedShape = new int[] {1, 20, 64, 75};
+      int[] expectedShape = new int[] {1, 1, 1684 / 2, 1200 / 2};
       assertThat(geo.data().getShape()).isEqualTo(expectedShape);
 
-      assertThat(geo.data().get(0, 0, 0).doubleValue()).isWithin(1.7829999923706055);
-      assertThat(geo.data().get(0, 11, 0).doubleValue()).isWithin(1.7669999599456787);
+      assertThat(Double.isNaN(geo.data().get(0, 0, 0, 0).floatValue())).isTrue();
+      assertThat(geo.data().get(0, 0, 400, 300).floatValue()).isWithin((float) TOL).of(9.5f);
     }
   }
 }

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridReadHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridReadHorizSubset.java
@@ -235,9 +235,9 @@ public class TestGridReadHorizSubset {
 
   private void checkLatLonSubset(GridHorizCoordinateSystem hcs, Grid coverage, LatLonRect bbox, int[] expectedShape)
       throws Exception {
-    // System.out.printf(" coverage llbb = %s width=%f%n", hcs.getLatLonBoundingBox().toString2(),
-    // hcs.getLatLonBoundingBox().getWidth());
-    // System.out.printf(" constrain bbox= %s width=%f%n", bbox.toString2(), bbox.getWidth());
+    System.out.printf(" coverage llbb = %s width=%f%n", hcs.getLatLonBoundingBox().toString2(),
+        hcs.getLatLonBoundingBox().getWidth());
+    System.out.printf(" constrain bbox= %s width=%f%n", bbox.toString2(), bbox.getWidth());
 
     GridReferencedArray geoArray = coverage.getReader().setLatLonBoundingBox(bbox).setTimePresent().read();
     assertThat(geoArray).isNotNull();

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridReadHorizSubset.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridReadHorizSubset.java
@@ -2,7 +2,7 @@
 package ucar.nc2.grid;
 
 import com.google.common.base.Preconditions;
-import org.junit.Ignore;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -45,6 +45,7 @@ public class TestGridReadHorizSubset {
 
       GridCoordinateSystem cs = coverage.getCoordinateSystem();
       assertThat(cs).isNotNull();
+      assertThat(cs.getNominalShape()).isEqualTo(ImmutableList.of(1, 1, 1237, 1237));
       GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
       assertThat(hcs).isNotNull();
 
@@ -67,8 +68,8 @@ public class TestGridReadHorizSubset {
       assertThat(geo.getMaterializedCoordinateSystem()).isNotNull();
       assertThat(geo.getMaterializedCoordinateSystem().getHorizCoordinateSystem()).isNotNull();
 
-      int[] expectedShape = new int[] {363, 479};
-      assertThat(geo.getMaterializedCoordinateSystem().getHorizCoordinateSystem().getShape()).isEqualTo(expectedShape);
+      assertThat(geo.getMaterializedCoordinateSystem().getHorizCoordinateSystem().getShape())
+          .isEqualTo(ImmutableList.of(363, 479));
     }
   }
 
@@ -90,17 +91,16 @@ public class TestGridReadHorizSubset {
       GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
       assertThat(hcs).isNotNull();
 
-      LatLonRect bbox = new LatLonRect.Builder(LatLonPoint.create(40.0, -100.0), 10.0, 20.0).build();
+      LatLonRect bbox = LatLonRect.builder(LatLonPoint.create(40.0, -100.0), 10.0, 20.0).build();
       checkLatLonSubset(hcs, coverage, bbox, new int[] {141, 281});
 
-      bbox = new LatLonRect.Builder(LatLonPoint.create(-40.0, -180.0), 120.0, 300.0).build();
+      bbox = LatLonRect.builder(LatLonPoint.create(-40.0, -180.0), 120.0, 300.0).build();
       checkLatLonSubset(hcs, coverage, bbox, new int[] {800, 1300});
     }
   }
 
   // longitude subsetting (CoordAxis1D regular) }
   @Test
-  @Ignore("not done")
   @Category(NeedsCdmUnitTest.class)
   public void testLongitudeSubset() throws Exception {
     String filename = TestDir.cdmUnitTestDir + "tds/ncep/GFS_Global_onedeg_20100913_0000.grib2";
@@ -119,7 +119,7 @@ public class TestGridReadHorizSubset {
       GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
       assertThat(hcs).isNotNull();
 
-      LatLonRect bbox = new LatLonRect.Builder(LatLonPoint.create(40.0, -100.0), 10.0, 20.0).build();
+      LatLonRect bbox = LatLonRect.builder(LatLonPoint.create(40.0, -100.0), 10.0, 20.0).build();
       checkLatLonSubset(hcs, coverage, bbox, new int[] {1, 11, 21});
     }
   }
@@ -135,16 +135,18 @@ public class TestGridReadHorizSubset {
       assertThat(gds).isNotNull();
 
       String gribId = "VAR_2-0-0_L1";
-      Grid coverage = gds.findGridByAttribute(Grib.VARIABLE_ID_ATTNAME, gribId).orElseThrow(); // "Land_cover_0__sea_1__land_surface");
-      assertThat(coverage).isNotNull();
+      Grid grid = gds.findGridByAttribute(Grib.VARIABLE_ID_ATTNAME, gribId).orElseThrow(); // "Land_cover_0__sea_1__land_surface");
+      assertThat(grid).isNotNull();
+      System.out.printf("grid %s%n", grid.getName());
 
-      GridCoordinateSystem cs = coverage.getCoordinateSystem();
+      GridCoordinateSystem cs = grid.getCoordinateSystem();
       assertThat(cs).isNotNull();
+      assertThat(cs.getNominalShape()).isEqualTo(ImmutableList.of(1, 65, 361, 720));
       GridHorizCoordinateSystem hcs = cs.getHorizCoordinateSystem();
       assertThat(hcs).isNotNull();
 
       LatLonRect bbox = LatLonRect.builder(40.0, -100.0, 10.0, 120.0).build();
-      checkLatLonSubset(hcs, coverage, bbox, new int[] {1, 61, 441});
+      checkLatLonSubset(hcs, grid, bbox, new int[] {61, 441});
     }
   }
 
@@ -170,7 +172,7 @@ public class TestGridReadHorizSubset {
       // Next, create the subset param and make the request
       final CalendarDate validTime = CalendarDate.fromUdunitIsoDate(null, "2010-09-21T00:00:00Z").orElseThrow();
       // subset across the seam
-      final LatLonRect subsetLatLonRequest = new LatLonRect.Builder(LatLonPoint.create(-15, -10), 30, 20).build();
+      final LatLonRect subsetLatLonRequest = LatLonRect.builder(LatLonPoint.create(-15, -10), 30, 20).build();
       final int stride = 2;
 
       // make subset

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridSubsetCurvilinear.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridSubsetCurvilinear.java
@@ -384,7 +384,7 @@ public class TestGridSubsetCurvilinear {
     subsetParams.setVariables(Collections.singletonList(covVarName));
     double deltaLat = subsetLatLon2.getLatitude() - subsetLatLon1.getLatitude();
     double deltaLon = subsetLatLon2.getLongitude() - subsetLatLon1.getLongitude();
-    LatLonRect subsetBoundingBox = (new LatLonRect.Builder(subsetLatLon1, deltaLat, deltaLon)).build();
+    LatLonRect subsetBoundingBox = LatLonRect.builder(subsetLatLon1, deltaLat, deltaLon).build();
     subsetParams.setLatLonBoundingBox(subsetBoundingBox);
     GeoReferencedArray covGeoRefArray = coverage.readData(subsetParams);
     LatLonRect covSubsetBoundingBox = covGeoRefArray.getCoordSysForData().getHorizCoordSys().calcLatLonBoundingBox();
@@ -411,7 +411,7 @@ public class TestGridSubsetCurvilinear {
     subsetParams.setVariables(Collections.singletonList(covVarName));
     double deltaLat = subsetLatLon2.getLatitude() - subsetLatLon1.getLatitude();
     double deltaLon = subsetLatLon2.getLongitude() - subsetLatLon1.getLongitude();
-    LatLonRect subsetBoundingBox = (new LatLonRect.Builder(subsetLatLon1, deltaLat, deltaLon)).build();
+    LatLonRect subsetBoundingBox = LatLonRect.builder(subsetLatLon1, deltaLat, deltaLon).build();
     subsetParams.setLatLonBoundingBox(subsetBoundingBox);
     subsetParams.setTimeRange(CalendarDateRange.of(subsetCalendarDateStart, subsetCalendarDateEnd));
     GeoReferencedArray covGeoRefArray = coverage.readData(subsetParams);

--- a/grib/src/main/java/ucar/nc2/grib/GdsHorizCoordSys.java
+++ b/grib/src/main/java/ucar/nc2/grib/GdsHorizCoordSys.java
@@ -124,7 +124,7 @@ public class GdsHorizCoordSys {
 
   public LatLonRect getLatLonBB() {
     if (isLatLon()) {
-      return new LatLonRect.Builder(LatLonPoint.create(getStartY(), getStartX()), dy * (ny - 1), dx * (nx - 1)).build();
+      return LatLonRect.builder(LatLonPoint.create(getStartY(), getStartX()), dy * (ny - 1), dx * (nx - 1)).build();
     } else {
       return proj.projToLatLonBB(getProjectionBB());
     }

--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Utils.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Utils.java
@@ -100,8 +100,9 @@ public class Grib2Utils {
   }
 
   //////////////////////////////////////////////////////////////////////////////////
-  // pretty much lame stuff
+  // ad-hoc Conventions for identifying curvilinear coordinates.
   // possibly move to Customizer
+  // LOOK is there some real Convention?
 
   // check if grid template is "Curvilinear Orthogonal", (NCEP 204) methods below only used when thats true
   public static boolean isCurvilinearOrthogonal(int gridTemplate, int center) {
@@ -136,14 +137,29 @@ public class Grib2Utils {
   public enum LatLon2DCoord {
     U_Latitude, U_Longitude, V_Latitude, V_Longitude, P_Latitude, P_Longitude;
 
+    public LatLonCoordType getCoordType() {
+      switch (this) {
+        case U_Latitude:
+        case U_Longitude:
+          return LatLonCoordType.U;
+        case V_Latitude:
+        case V_Longitude:
+          return LatLonCoordType.V;
+        case P_Latitude:
+        case P_Longitude:
+          return LatLonCoordType.P;
+      }
+      throw new IllegalStateException();
+    }
+
     public AxisType getAxisType() {
       return this.name().contains("Latitude") ? AxisType.Lat : AxisType.Lon;
     }
   }
 
   /**
-   * This looks for snippets in the variable name/desc as to whether it wants U, V, or P 2D coordinates
-   * 
+   * This looks for snippets in the variable name/desc as to whether it wants U, V, or P 2D coordinates.
+   *
    * @param desc variable name/desc
    * @return U, V, or P for normal variables, null for the coordinates themselves
    */

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGrid.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGrid.java
@@ -98,7 +98,7 @@ public class GribGrid implements Grid {
     // LOOK it would appear the only thing needed out of it (besides geo referencing) is getSubsetRanges()
     Optional<MaterializedCoordinateSystem> opt = coordinateSystem.subset(subset, errLog);
     if (opt.isEmpty()) {
-      throw new InvalidRangeException(errLog.toString());
+      throw new InvalidRangeException(errLog.toString()); // LOOK lame. Optional, empty, null?
     }
     MaterializedCoordinateSystem subsetCoordSys = opt.get();
     List<RangeIterator> ranges = new ArrayList<>(subsetCoordSys.getSubsetRanges());

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridAxis.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridAxis.java
@@ -207,7 +207,7 @@ public class GribGridAxis {
       public T setRuntimeCoordinate(CoordinateRuntime rtCoord) {
         this.gribCoord = rtCoord;
         this.cdu = rtCoord.getCalendarDateUnit();
-        List<Number> values = rtCoord.getRuntimeOffsetsInTimeUnits().stream().collect(Collectors.toList());
+        List<Number> values = new ArrayList<>(rtCoord.getRuntimeOffsetsInTimeUnits());
         RegularValues regular = calcPointIsRegular(values);
         if (regular != null) {
           setRegular(regular.ncoords, regular.start, regular.increment);

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridDataset.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridDataset.java
@@ -101,13 +101,11 @@ public class GribGridDataset implements GridDataset {
   private final GribCollectionImmutable gribCollection;
   private final GribCollectionImmutable.Dataset dataset;
   private final GribCollectionImmutable.GroupGC group;
-  private final GdsHorizCoordSys hcs; // unique
   private final GridGribHorizHelper hhelper;
   private final Map<Integer, GridAxis<?>> gridAxes; // <index, GridAxis>
-  private final ImmutableList<GridCoordinateSystem> gridCoordinateSystems; // <csHash, GridAxis>
+  private final ImmutableList<GridCoordinateSystem> gridCoordinateSystems;
   private final ImmutableList<GribGrid> grids;
 
-  private final boolean isLatLon;
   private final boolean isCurvilinearOrthogonal;
 
   GribGridDataset(GribCollectionImmutable gribCollection, @Nullable GribCollectionImmutable.Dataset dataset,
@@ -122,9 +120,8 @@ public class GribGridDataset implements GridDataset {
     boolean isGrib1 = gribCollection.isGrib1;
     GribIosp iosp = gribCollection.getIosp();
 
-    // A GribGridDataset has a unique GdsHorizCoordSys. When curvilinear, there may be multiple horiz CS
-    this.hcs = this.group.getGdsHorizCoordSys();
-    this.isLatLon = hcs.isLatLon();
+    // A GribGridDataset has a unique GdsHorizCoordSys. When curvilinear, there may be multiple horizCS
+    GdsHorizCoordSys hcs = this.group.getGdsHorizCoordSys();
     this.isCurvilinearOrthogonal =
         !isGrib1 && Grib2Utils.isCurvilinearOrthogonal(hcs.template, gribCollection.getCenter());
     this.hhelper = new GridGribHorizHelper(gribCollection, hcs, isCurvilinearOrthogonal, this.group.getVariables());

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridDataset.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridDataset.java
@@ -7,7 +7,6 @@ package ucar.nc2.grib.grid;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
@@ -15,12 +14,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.featurecollection.FeatureCollectionConfig;
 import thredds.inventory.CollectionUpdateType;
+import ucar.array.InvalidRangeException;
 import ucar.nc2.AttributeContainer;
-import ucar.nc2.constants.AxisType;
-import ucar.nc2.constants.CF;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.grib.GdsHorizCoordSys;
-import ucar.nc2.grib.collection.Grib;
 import ucar.nc2.grib.collection.GribCdmIndex;
 import ucar.nc2.grib.collection.GribCollectionImmutable;
 import ucar.nc2.grib.collection.GribIosp;
@@ -29,7 +26,6 @@ import ucar.nc2.grib.coord.CoordinateTime2D;
 import ucar.nc2.grib.grib2.Grib2Utils;
 import ucar.nc2.grid.Grid;
 import ucar.nc2.grid.GridAxis;
-import ucar.nc2.grid.GridAxisPoint;
 import ucar.nc2.grid.GridCoordinateSystem;
 import ucar.nc2.grid.GridDataset;
 import ucar.nc2.grid.GridHorizCoordinateSystem;
@@ -105,17 +101,17 @@ public class GribGridDataset implements GridDataset {
   private final GribCollectionImmutable gribCollection;
   private final GribCollectionImmutable.Dataset dataset;
   private final GribCollectionImmutable.GroupGC group;
-  private final GridHorizCoordinateSystem horizCoordinateSystem;
-  private final ImmutableMap<Integer, GridAxis<?>> gridAxes; // <index, GridAxis>
-  private final ImmutableMap<Integer, GridCoordinateSystem> gridCoordinateSystems; // <index hash, >
-  private final ImmutableMap<Integer, GribGridTimeCoordinateSystem> timeCoordinateSystems; // <index hash, >
+  private final GdsHorizCoordSys hcs; // unique
+  private final GridGribHorizHelper hhelper;
+  private final Map<Integer, GridAxis<?>> gridAxes; // <index, GridAxis>
+  private final ImmutableList<GridCoordinateSystem> gridCoordinateSystems; // <csHash, GridAxis>
   private final ImmutableList<GribGrid> grids;
 
   private final boolean isLatLon;
   private final boolean isCurvilinearOrthogonal;
 
-  public GribGridDataset(GribCollectionImmutable gribCollection, @Nullable GribCollectionImmutable.Dataset dataset,
-      @Nullable GribCollectionImmutable.GroupGC group) throws IOException {
+  GribGridDataset(GribCollectionImmutable gribCollection, @Nullable GribCollectionImmutable.Dataset dataset,
+      @Nullable GribCollectionImmutable.GroupGC group) throws IOException, InvalidRangeException {
     Preconditions.checkNotNull(gribCollection);
     this.gribCollection = gribCollection;
     this.dataset = (dataset != null) ? dataset : gribCollection.getDataset(0);
@@ -126,65 +122,71 @@ public class GribGridDataset implements GridDataset {
     boolean isGrib1 = gribCollection.isGrib1;
     GribIosp iosp = gribCollection.getIosp();
 
-    // A GribGridDataset has a unique GridHorizCoordinateSystem LOOK true?
-    GdsHorizCoordSys hcs = this.group.getGdsHorizCoordSys();
+    // A GribGridDataset has a unique GdsHorizCoordSys. When curvilinear, there may be multiple horiz CS
+    this.hcs = this.group.getGdsHorizCoordSys();
     this.isLatLon = hcs.isLatLon();
     this.isCurvilinearOrthogonal =
         !isGrib1 && Grib2Utils.isCurvilinearOrthogonal(hcs.template, gribCollection.getCenter());
-    this.horizCoordinateSystem = makeHorizCS(hcs);
+    this.hhelper = new GridGribHorizHelper(gribCollection, hcs, isCurvilinearOrthogonal, this.group.getVariables());
+
+    Map<Integer, CoordAndAxis> coordIndexMap = new HashMap<>(); // <index, CoordAndAxis>
+    Map<Integer, GribGridTimeCoordinateSystem> timeCsMap = new HashMap<>();
+    Map<Integer, GridCoordinateSystem> csMap = new HashMap<>(); // hashCs, cs
 
     // Each Coordinate becomes a GridAxis
-    HashMap<Integer, CoordAndAxis> coordIndexMap = new HashMap<>(); // <index, CoordAndAxis>
-    ImmutableMap.Builder<Integer, GridAxis<?>> axesBuilder = ImmutableMap.builder(); // <index, GridAxis>
+    this.gridAxes = new HashMap<>(); // <index, GridAxis>
     int coordIndex = 0;
     for (Coordinate coord : this.group.getCoordinates()) {
       CoordAndAxis coordAndAxis = GribGridAxis.create(this.dataset.getType(), coord, iosp);
-      axesBuilder.put(coordIndex, coordAndAxis.axis);
+      this.gridAxes.put(coordIndex, coordAndAxis.axis);
       coordIndexMap.put(coordIndex, coordAndAxis);
       coordIndex++;
     }
-    this.gridAxes = axesBuilder.build();
 
-    // Each unique index list in the VariableIndex becomes a coordinate system
-    HashMap<Integer, Iterable<Integer>> uniqueIndexList = new HashMap<>(); // <hash, List<index>>
-    for (GribCollectionImmutable.VariableIndex vi : this.group.getVariables()) {
-      int hash = makeHash(vi.getCoordinateIndex());
-      uniqueIndexList.put(hash, vi.getCoordinateIndex());
-    }
-    Map<Integer, GribGridTimeCoordinateSystem> timeCsBuilder = new HashMap<>();
-    ImmutableMap.Builder<Integer, GridCoordinateSystem> csBuilder = ImmutableMap.builder();
-    for (Iterable<Integer> indexList : uniqueIndexList.values()) {
-      int hash = makeHash(indexList);
-      csBuilder.put(hash, makeCoordinateSystem(indexList, coordIndexMap, timeCsBuilder));
-    }
-    this.gridCoordinateSystems = csBuilder.build();
-    this.timeCoordinateSystems = ImmutableMap.copyOf(timeCsBuilder);
-
-    // Each VariableIndex becomes a grid
+    // Each VariableIndex becomes a grid, except for curvilinear coordinates
     ArrayList<GribGrid> grids = new ArrayList<>();
-    for (GribCollectionImmutable.VariableIndex vi : this.group.getVariables()) {
-      GridCoordinateSystem ggcs = this.gridCoordinateSystems.get(makeHash(vi.getCoordinateIndex()));
+    for (GribCollectionImmutable.VariableIndex vi : hhelper.getVariables()) {
+      GridHorizCoordinateSystem horizCs = hhelper.getHorizCs(vi);
+      GridCoordinateSystem ggcs =
+          makeCoordinateSystem(vi.getCoordinateIndex(), coordIndexMap, timeCsMap, csMap, horizCs);
       grids.add(new GribGrid(iosp, this.gribCollection, ggcs, vi));
     }
+
     grids.sort((g1, g2) -> CharSequence.compare(g1.getName(), g2.getName()));
     this.grids = ImmutableList.copyOf(grids);
+    this.gridCoordinateSystems = ImmutableList.copyOf(csMap.values());
   }
 
-  private GridHorizCoordinateSystem makeHorizCS(GdsHorizCoordSys hcs) {
-    GridAxisPoint xaxis;
-    GridAxisPoint yaxis;
-    if (hcs.isLatLon()) {
-      xaxis = GridAxisPoint.builder().setName(Grib.LON_AXIS).setAxisType(AxisType.Lon).setUnits("degrees_east")
-          .setRegular(hcs.nx, hcs.startx, hcs.dx).build();
-      yaxis = GridAxisPoint.builder().setName(Grib.LAT_AXIS).setAxisType(AxisType.Lat).setUnits("degrees_north")
-          .setRegular(hcs.ny, hcs.starty, hcs.dy).build();
-    } else {
-      xaxis = GridAxisPoint.builder().setName(Grib.XAXIS).setAxisType(AxisType.GeoX).setUnits("km")
-          .setDescription(CF.PROJECTION_X_COORDINATE).setRegular(hcs.nx, hcs.startx, hcs.dx).build();
-      yaxis = GridAxisPoint.builder().setName(Grib.YAXIS).setAxisType(AxisType.GeoY).setUnits("km")
-          .setDescription(CF.PROJECTION_Y_COORDINATE).setRegular(hcs.ny, hcs.starty, hcs.dy).build();
-    }
-    return new GridHorizCoordinateSystem(xaxis, yaxis, hcs.proj);
+  private GridCoordinateSystem makeCoordinateSystem(Iterable<Integer> indices, Map<Integer, CoordAndAxis> coordIndexMap,
+      Map<Integer, GribGridTimeCoordinateSystem> timeCsMap, Map<Integer, GridCoordinateSystem> csMap,
+      GridHorizCoordinateSystem horizCs) {
+
+    int hash = horizCs.hashCode() + makeHash(indices);
+    return csMap.computeIfAbsent(hash, h -> {
+      GribGridTimeCoordinateSystem tcs = makeTimeCoordinateSystem(indices, coordIndexMap, timeCsMap);
+      ArrayList<GridAxis<?>> axes =
+          new ArrayList<>(Streams.stream(indices).map(this.gridAxes::get).collect(Collectors.toList()));
+      axes.add(hhelper.yaxis);
+      axes.add(hhelper.xaxis);
+      return new GridCoordinateSystem(axes, tcs, horizCs);
+    });
+  }
+
+  private GribGridTimeCoordinateSystem makeTimeCoordinateSystem(Iterable<Integer> indices,
+      Map<Integer, CoordAndAxis> coordIndexMap, Map<Integer, GribGridTimeCoordinateSystem> timeCsMap) {
+
+    List<Integer> timeIndices = Streams.stream(indices).filter(index -> this.gridAxes.get(index).getAxisType().isTime())
+        .collect(Collectors.toList());
+    int hash = makeHash(timeIndices);
+    List<CoordAndAxis> coordAndAxesList = Streams.stream(indices).map(coordIndexMap::get).collect(Collectors.toList());
+    return timeCsMap.computeIfAbsent(hash,
+        h -> GribGridTimeCoordinateSystem.create(dataset.getType(), coordAndAxesList));
+  }
+
+  private int makeHash(Iterable<Integer> indices) {
+    Hasher hasher = Hashing.goodFastHash(32).newHasher();
+    indices.forEach(hasher::putInt);
+    return hasher.hash().asInt();
   }
 
   static class CoordAndAxis {
@@ -203,33 +205,7 @@ public class GribGridDataset implements GridDataset {
     }
   }
 
-  private GridCoordinateSystem makeCoordinateSystem(Iterable<Integer> indices,
-      HashMap<Integer, CoordAndAxis> coordIndexMap, Map<Integer, GribGridTimeCoordinateSystem> timeCsBuilder) {
-
-    GribGridTimeCoordinateSystem tcs = makeTimeCoordinateSystem(indices, coordIndexMap, timeCsBuilder);
-    ArrayList<GridAxis<?>> axes =
-        new ArrayList<>(Streams.stream(indices).map(this.gridAxes::get).collect(Collectors.toList()));
-    axes.add(this.horizCoordinateSystem.getYHorizAxis());
-    axes.add(this.horizCoordinateSystem.getXHorizAxis());
-    return new GridCoordinateSystem(axes, tcs, this.horizCoordinateSystem);
-  }
-
-  private GribGridTimeCoordinateSystem makeTimeCoordinateSystem(Iterable<Integer> indices,
-      HashMap<Integer, CoordAndAxis> coordIndexMap, Map<Integer, GribGridTimeCoordinateSystem> timeCsBuilder) {
-
-    List<Integer> timeIndices = Streams.stream(indices).filter(index -> this.gridAxes.get(index).getAxisType().isTime())
-        .collect(Collectors.toList());
-    int hash = makeHash(timeIndices);
-    List<CoordAndAxis> coordAndAxesList = Streams.stream(indices).map(coordIndexMap::get).collect(Collectors.toList());
-    return timeCsBuilder.computeIfAbsent(hash,
-        h -> GribGridTimeCoordinateSystem.create(dataset.getType(), coordAndAxesList));
-  }
-
-  private int makeHash(Iterable<Integer> indices) {
-    Hasher hasher = Hashing.goodFastHash(32).newHasher();
-    indices.forEach(hasher::putInt);
-    return hasher.hash().asInt();
-  }
+  ////////////////////////////////////////////////////////////////////////
 
   @Override
   public void close() throws IOException {
@@ -253,20 +229,19 @@ public class GribGridDataset implements GridDataset {
 
   @Override
   public FeatureType getFeatureType() {
-    return FeatureType.GRID; // LOOK needed?
+    return isCurvilinearOrthogonal ? FeatureType.CURVILINEAR : FeatureType.GRID;
   }
 
   @Override
   public ImmutableList<GridCoordinateSystem> getGridCoordinateSystems() {
-    return ImmutableList.copyOf(gridCoordinateSystems.values());
+    return this.gridCoordinateSystems;
   }
 
   @Override
   public ImmutableList<GridAxis<?>> getGridAxes() {
     ImmutableList.Builder<GridAxis<?>> builder = ImmutableList.builder();
     builder.addAll(gridAxes.values());
-    builder.add(horizCoordinateSystem.getYHorizAxis());
-    builder.add(horizCoordinateSystem.getXHorizAxis());
+    builder.addAll(hhelper.getHorizAxes()); // always has the same axes, CS may differ when curvilinear
     return builder.build();
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridTimeCoordinateSystem.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridTimeCoordinateSystem.java
@@ -223,7 +223,7 @@ public abstract class GribGridTimeCoordinateSystem extends GridTimeCoordinateSys
 
     @Override
     public String toString() {
-      return "SingleRuntime{" + "runtimeDate=" + runtimeDate + "} " + super.toString();
+      return super.toString() + "\nSingleRuntime{" + "runtimeDate=" + runtimeDate + "}";
     }
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridTimeCoordinateSystem.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridTimeCoordinateSystem.java
@@ -123,6 +123,7 @@ public abstract class GribGridTimeCoordinateSystem extends GridTimeCoordinateSys
   private List<CalendarDate> getTimesForNonObservation(int runIdx) {
     Preconditions.checkArgument(runTimeAxis != null && runIdx >= 0 && runIdx < runTimeAxis.getNominalSize());
     CalendarDate baseForRun = getRuntimeDate(runIdx);
+    Preconditions.checkNotNull(baseForRun);
     GridAxis<?> timeAxis = getTimeOffsetAxis(runIdx);
     List<CalendarDate> result = new ArrayList<>();
     for (int offsetIdx = 0; offsetIdx < timeAxis.getNominalSize(); offsetIdx++) {

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridTimeCoordinateSystem.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridTimeCoordinateSystem.java
@@ -127,7 +127,7 @@ public abstract class GribGridTimeCoordinateSystem extends GridTimeCoordinateSys
     GridAxis<?> timeAxis = getTimeOffsetAxis(runIdx);
     List<CalendarDate> result = new ArrayList<>();
     for (int offsetIdx = 0; offsetIdx < timeAxis.getNominalSize(); offsetIdx++) {
-      result.add(baseForRun.add((long) timeAxis.getCoordMidpoint(offsetIdx), this.offsetPeriod));
+      result.add(baseForRun.add((long) timeAxis.getCoordDouble(offsetIdx), this.offsetPeriod));
     }
     return result;
   }

--- a/grib/src/main/java/ucar/nc2/grib/grid/GridGribHorizHelper.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GridGribHorizHelper.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.grib.grid;
+
+import com.google.common.collect.ImmutableList;
+import ucar.array.Array;
+import ucar.array.InvalidRangeException;
+import ucar.array.Section;
+import ucar.array.SectionIterable;
+import ucar.nc2.constants.AxisType;
+import ucar.nc2.constants.CDM;
+import ucar.nc2.constants.CF;
+import ucar.nc2.grib.GdsHorizCoordSys;
+import ucar.nc2.grib.collection.Grib;
+import ucar.nc2.grib.collection.GribArrayReader;
+import ucar.nc2.grib.collection.GribCollectionImmutable;
+import ucar.nc2.grib.grib2.Grib2Utils;
+import ucar.nc2.grid.GridAxis;
+import ucar.nc2.grid.GridAxisPoint;
+import ucar.nc2.grid.GridAxisSpacing;
+import ucar.nc2.grid.GridHorizCoordinateSystem;
+import ucar.nc2.grid.GridHorizCurvilinear;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class GridGribHorizHelper {
+  final GribCollectionImmutable gribCollection;
+  final GdsHorizCoordSys hcs;
+  final boolean isCurvilinearOrthogonal;
+  final ArrayList<GribCollectionImmutable.VariableIndex> vars;
+  final GridAxisPoint xaxis;
+  final GridAxisPoint yaxis;
+  @Nullable
+  final Map<Grib2Utils.LatLonCoordType, CurvilinearCoordinates> ccMap;
+  final GridHorizCoordinateSystem ghcs;
+
+  GridGribHorizHelper(GribCollectionImmutable gribCollection, GdsHorizCoordSys hcs, boolean isCurvilinearOrthogonal,
+      List<GribCollectionImmutable.VariableIndex> vars) throws InvalidRangeException, IOException {
+    this.gribCollection = gribCollection;
+    this.hcs = hcs;
+    this.isCurvilinearOrthogonal = isCurvilinearOrthogonal;
+    this.vars = new ArrayList<>(vars);
+
+    if (isCurvilinearOrthogonal) {
+      // create fake 1d axes
+      xaxis = GridAxisPoint.builder().setAxisType(AxisType.GeoX).setName(AxisType.Lon.name()).setUnits("")
+          .setDescription("fake 1d xaxis for curvilinear grid").setRegular(hcs.nx, 0.0, 1.0)
+          .setSpacing(GridAxisSpacing.regularPoint).build();
+      yaxis = GridAxisPoint.builder().setAxisType(AxisType.GeoY).setName(AxisType.Lat.name()).setUnits("")
+          .setDescription("fake 1d yaxis for curvilinear grid").setRegular(hcs.ny, 0.0, 1.0)
+          .setSpacing(GridAxisSpacing.regularPoint).build();
+
+    } else {
+
+      if (hcs.isLatLon()) {
+        // LOOK for curvilinear these are nominal, not real
+        xaxis = GridAxisPoint.builder().setName(Grib.LON_AXIS).setAxisType(AxisType.Lon).setUnits(CDM.LON_UNITS)
+            .setRegular(hcs.nx, hcs.startx, hcs.dx).build();
+        yaxis = GridAxisPoint.builder().setName(Grib.LAT_AXIS).setAxisType(AxisType.Lat).setUnits(CDM.LAT_UNITS)
+            .setRegular(hcs.ny, hcs.starty, hcs.dy).build();
+      } else {
+        xaxis = GridAxisPoint.builder().setName(Grib.XAXIS).setAxisType(AxisType.GeoX).setUnits("km")
+            .setDescription(CF.PROJECTION_X_COORDINATE).setRegular(hcs.nx, hcs.startx, hcs.dx).build();
+        yaxis = GridAxisPoint.builder().setName(Grib.YAXIS).setAxisType(AxisType.GeoY).setUnits("km")
+            .setDescription(CF.PROJECTION_Y_COORDINATE).setRegular(hcs.ny, hcs.starty, hcs.dy).build();
+      }
+    }
+
+    this.ccMap = identifyCurvilinearCoordinates();
+    this.ghcs = new GridHorizCoordinateSystem(xaxis, yaxis, hcs.proj);
+
+    if (this.ccMap != null) {
+      for (CurvilinearCoordinates cc : this.ccMap.values()) {
+        cc.makeHorizCS(xaxis, yaxis);
+      }
+    }
+  }
+
+  private class CurvilinearCoordinates {
+    final Grib2Utils.LatLon2DCoord ll2d;
+    GribCollectionImmutable.VariableIndex lat;
+    GribCollectionImmutable.VariableIndex lon;
+    GridHorizCurvilinear horizCS;
+
+    CurvilinearCoordinates(Grib2Utils.LatLon2DCoord ll2d) {
+      this.ll2d = ll2d;
+    }
+
+    void addCoordinate(Grib2Utils.LatLon2DCoord ll2d, GribCollectionImmutable.VariableIndex vi) {
+      if (ll2d.getAxisType() == AxisType.Lat) {
+        if (this.lat != null) {
+          throw new IllegalStateException();
+        } else {
+          this.lat = vi;
+        }
+      } else {
+        if (this.lon != null) {
+          throw new IllegalStateException();
+        } else {
+          this.lon = vi;
+        }
+      }
+    }
+
+    void makeHorizCS(GridAxisPoint xaxis, GridAxisPoint yaxis) throws InvalidRangeException, IOException {
+      int[] shape = new int[] {hcs.ny, hcs.nx};
+      Section section = new Section(shape);
+      SectionIterable want = new ucar.array.SectionIterable(section, shape);
+      Array<Number> latdata = (Array<Number>) GribArrayReader.factory(gribCollection, lat).readData(want);
+      Array<Number> londata = (Array<Number>) GribArrayReader.factory(gribCollection, lon).readData(want);
+
+      this.horizCS = GridHorizCurvilinear.create(xaxis, yaxis, latdata, londata);
+    }
+  }
+
+  private Map<Grib2Utils.LatLonCoordType, CurvilinearCoordinates> identifyCurvilinearCoordinates() {
+    if (!isCurvilinearOrthogonal) {
+      return null;
+    }
+
+    // identify the variables that are actually coordinates
+    List<GribCollectionImmutable.VariableIndex> remove = new ArrayList<>();
+    Map<Grib2Utils.LatLonCoordType, CurvilinearCoordinates> result = new HashMap<>();
+    for (GribCollectionImmutable.VariableIndex vindex : this.vars) {
+      Grib2Utils.LatLon2DCoord ll2d =
+          Grib2Utils.getLatLon2DcoordType(vindex.getDiscipline(), vindex.getCategory(), vindex.getParameter());
+      if (ll2d == null) {
+        continue;
+      }
+
+      CurvilinearCoordinates find =
+          result.computeIfAbsent(ll2d.getCoordType(), (k) -> new CurvilinearCoordinates(ll2d));
+      find.addCoordinate(ll2d, vindex);
+      remove.add(vindex);
+    }
+
+    // remove found coordinates
+    for (GribCollectionImmutable.VariableIndex vindex : remove) {
+      vars.remove(vindex);
+    }
+
+    return result;
+  }
+
+  ImmutableList<GridAxis<?>> getHorizAxes() {
+    return ImmutableList.of(xaxis, yaxis);
+  }
+
+  ImmutableList<GribCollectionImmutable.VariableIndex> getVariables() {
+    return ImmutableList.copyOf(vars);
+  }
+
+  GridHorizCoordinateSystem getHorizCs(GribCollectionImmutable.VariableIndex vindex) {
+    if (ccMap == null) {
+      return ghcs;
+    }
+    Grib2Utils.LatLonCoordType type = Grib2Utils.getLatLon2DcoordType(vindex.makeVariableDescription());
+    if (type == null) {
+      throw new IllegalStateException();
+    }
+    CurvilinearCoordinates find = ccMap.get(type);
+    if (find == null) {
+      throw new IllegalStateException();
+    }
+    return find.horizCS;
+  }
+}

--- a/grib/src/test/java/ucar/nc2/grib/grid/TestGribGridTimeCS.java
+++ b/grib/src/test/java/ucar/nc2/grib/grid/TestGribGridTimeCS.java
@@ -85,7 +85,7 @@ public class TestGribGridTimeCS {
       assertThat(times).hasSize(ntimes);
       CalendarDate baseDate = subject.getBaseDate();
       for (int idx = 0; idx < ntimes; idx++) {
-        CalendarDate expected = baseDate.add((long) timeAxis.getCoordMidpoint(idx), offsetPeriod);
+        CalendarDate expected = baseDate.add((long) timeAxis.getCoordDouble(idx), offsetPeriod);
         System.out.printf(" (%d)  got= %s want= %s%n", idx, times.get(idx), expected);
         assertThat(times.get(idx)).isEqualTo(expected);
       }
@@ -162,7 +162,7 @@ public class TestGribGridTimeCS {
         assertThat(times).hasSize(ntimes);
         int offsetIdx = 0;
         for (CalendarDate time : times) {
-          CalendarDate expected = baseForRun.add((long) offset.getCoordMidpoint(offsetIdx++), offsetPeriod);
+          CalendarDate expected = baseForRun.add((long) offset.getCoordDouble(offsetIdx++), offsetPeriod);
           assertThat(time).isEqualTo(expected);
         }
       }
@@ -233,7 +233,7 @@ public class TestGribGridTimeCS {
         assertThat(times).hasSize(ntimes);
         int offsetIdx = 0;
         for (CalendarDate time : times) {
-          CalendarDate expected = baseForRun.add((long) offset.getCoordMidpoint(offsetIdx++), offsetPeriod);
+          CalendarDate expected = baseForRun.add((long) offset.getCoordDouble(offsetIdx++), offsetPeriod);
           assertThat(time).isEqualTo(expected);
         }
       }
@@ -294,7 +294,7 @@ public class TestGribGridTimeCS {
         assertThat(times.size()).isLessThan(ntimes + 1);
         int offsetIdx = 0;
         for (CalendarDate time : times) {
-          CalendarDate expected = baseForRun.add((long) offset.getCoordMidpoint(offsetIdx++), offsetPeriod);
+          CalendarDate expected = baseForRun.add((long) offset.getCoordDouble(offsetIdx++), offsetPeriod);
           // System.out.printf(" (%d,%d) got= %s want= %s%n", runidx, offsetIdx, time, expected);
           assertThat(time).isEqualTo(expected);
         }

--- a/grib/src/test/java/ucar/nc2/grib/grid/TestReadGribGridDatasetFactory.java
+++ b/grib/src/test/java/ucar/nc2/grib/grid/TestReadGribGridDatasetFactory.java
@@ -88,7 +88,7 @@ public class TestReadGribGridDatasetFactory {
         CoordInterval intv = timeAxis1D.getCoordInterval(i);
         assertThat(intv.start()).isEqualTo(expected[i]);
         assertThat(intv.end()).isEqualTo(expected[i + 1]);
-        assertThat(timeAxis1D.getCoordMidpoint(i)).isEqualTo((expected[i] + expected[i + 1]) / 2);
+        assertThat(timeAxis1D.getCoordDouble(i)).isEqualTo((expected[i] + expected[i + 1]) / 2);
       }
       MinMax maxmin = Grids.getCoordEdgeMinMax(timeAxis1D);
       assertThat(maxmin.min()).isEqualTo(expected[0]);
@@ -117,7 +117,7 @@ public class TestReadGribGridDatasetFactory {
       double[] expected = new double[] {10.000000, 20.000000, 30.000000, 50.000000, 70.000000, 100.000000};
       double[] bounds = new double[] {5, 15.000000, 25.000000, 40.000000, 60.000000, 85.000000, 115.000000};
       for (int i = 0; i < vertAxis.getNominalSize(); i++) {
-        assertThat(vertAxis.getCoordMidpoint(i)).isEqualTo(expected[i]);
+        assertThat(vertAxis.getCoordDouble(i)).isEqualTo(expected[i]);
         CoordInterval intv = vertAxis.getCoordInterval(i);
         assertThat(intv.start()).isEqualTo(bounds[i]);
         assertThat(intv.end()).isEqualTo(bounds[i + 1]);
@@ -153,7 +153,7 @@ public class TestReadGribGridDatasetFactory {
         CoordInterval intv = timeAxisIntv.getCoordInterval(i);
         assertThat(intv.start()).isEqualTo(bounds1[i]);
         assertThat(intv.end()).isEqualTo(bounds2[i]);
-        assertThat(timeAxisIntv.getCoordMidpoint(i)).isEqualTo((bounds1[i] + bounds2[i]) / 2);
+        assertThat(timeAxisIntv.getCoordDouble(i)).isEqualTo((bounds1[i] + bounds2[i]) / 2);
       }
 
       int count = 0;

--- a/opendap/src/test/java/ucar/nc2/ft/coverage/TestDodsCoverage.java
+++ b/opendap/src/test/java/ucar/nc2/ft/coverage/TestDodsCoverage.java
@@ -46,7 +46,7 @@ public class TestDodsCoverage {
       // Assert.assertArrayEquals(new int[]{65, 361, 720}, cs.getShape());
 
       LatLonRect llbb = gcs.getLatlonBoundingBox();
-      LatLonRect llbb_subset = new LatLonRect.Builder(llbb.getLowerLeftPoint(), 20.0, llbb.getWidth() / 2).build();
+      LatLonRect llbb_subset = LatLonRect.builder(llbb.getLowerLeftPoint(), 20.0, llbb.getWidth() / 2).build();
 
       checkLatLonSubset(gcs, coverage, llbb_subset, new int[] {1, 35, 45});
     }

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/gis/shapefile/EsriShapefileRenderer.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/gis/shapefile/EsriShapefileRenderer.java
@@ -97,8 +97,7 @@ public class EsriShapefileRenderer extends GisFeatureRendererMulti {
 
   public LatLonRect getPreferredArea() {
     Rectangle2D bb = esri.getBoundingBox();
-    return new LatLonRect.Builder(LatLonPoint.create(bb.getMinY(), bb.getMinX()), bb.getHeight(), bb.getWidth())
-        .build();
+    return LatLonRect.builder(LatLonPoint.create(bb.getMinY(), bb.getMinX()), bb.getHeight(), bb.getWidth()).build();
   }
 
   protected java.util.List<GisFeature> getFeatures() {

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/DataState.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/DataState.java
@@ -12,6 +12,7 @@ import ucar.nc2.grid.GridAxisPoint;
 import ucar.nc2.grid.GridCoordinateSystem;
 import ucar.nc2.grid.GridDataset;
 import ucar.nc2.grid.GridTimeCoordinateSystem;
+import ucar.nc2.grid.MaterializedCoordinateSystem;
 import ucar.ui.util.NamedObject;
 import ucar.unidata.geoloc.ProjectionRect;
 
@@ -21,8 +22,9 @@ import javax.annotation.Nullable;
 class DataState {
   GridDataset gridDataset;
   Grid grid;
-  GridCoordinateSystem gcs;
-  GridTimeCoordinateSystem tcs;
+  GridCoordinateSystem gcs; // from the grid object
+  GridTimeCoordinateSystem tcs; // from the grid object
+  MaterializedCoordinateSystem mcs; // from the currently read (materialized) data array
 
   @Nullable
   GridAxisPoint rtaxis;

--- a/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/GridRenderer.java
+++ b/toolsui/uicdm/src/main/java/ucar/nc2/ui/grid3/GridRenderer.java
@@ -121,12 +121,12 @@ public class GridRenderer {
    * @return String representation of value
    */
   public String getXYvalueStr(ProjectionPoint loc) {
-    if ((dataState.grid == null) || (geodata == null)) {
+    if ((dataState.grid == null) || (geodata == null) || (dataState.mcs == null)) {
       return "";
     }
 
-    // find the grid indexes
-    GridHorizCoordinateSystem hcs = dataState.gcs.getHorizCoordinateSystem();
+    // find the grid indexes in the materialized grid array
+    GridHorizCoordinateSystem hcs = dataState.mcs.getHorizCoordinateSystem();
     Optional<GridHorizCoordinateSystem.CoordReturn> opt =
         hcs.findXYindexFromCoord(loc.getX(), loc.getY(), dataState.index);
 
@@ -188,7 +188,8 @@ public class GridRenderer {
     }
 
     geodata = reader.read();
-    dataState.saveState();
+    dataState.saveState(); // ?
+    dataState.mcs = geodata.getMaterializedCoordinateSystem();
     System.out.printf("readHSlice %s done%n", dataState.grid.getName());
     return geodata;
   }


### PR DESCRIPTION
If you subset a GridAxisPoint by adding a stride, the edges have to be calculated and it becomes a nominalPoint.
GridAxis.getCoordMidpoint -> getCoordDouble, since its not necessarily the midpoint of the interval.
ui.GridRenderer needs to find xy index in the materialized coordinate system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/815)
<!-- Reviewable:end -->
