### PR TITLE
[7.x]: Gradle upgrade/tweaks and dependency upgrades

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against latest 11, 14 of zulu and temurin java
-        java-version: [ 11, 14 ]
+        # test against latest 11, 14 of zulu and 11 of temurin java
+        java-version: [ 11 ]
         java-vendor: [ 'zulu', 'temurin' ]
+        include:
+          - java-version: 14
+            java-vendor: 'zulu'
     steps:
       - uses: actions/checkout@v2
       - name: Build and test with Gradle (${{ matrix.java-vendor }} ${{ matrix.java-version }})

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ gradle.projectsEvaluated {
 
 tasks.named('wrapper') {
   distributionType = Wrapper.DistributionType.ALL
-  gradleVersion = '6.8.2'
+  gradleVersion = '6.9.1'
 }
 
 // Set up properties needed for all testing, adds "testAll" task to root

--- a/cdm-lite/build.gradle
+++ b/cdm-lite/build.gradle
@@ -10,7 +10,7 @@ apply from: "$rootDir/gradle/any/gretty.gradle"
 
 dependencies {
   api enforcedPlatform(project(':netcdf-java-platform'))
-  api enforcedPlatform('org.springframework:spring-framework-bom:5.3.4')
+  api enforcedPlatform('org.springframework:spring-framework-bom:5.3.9')
   testImplementation enforcedPlatform(project(':netcdf-java-testing-platform'))
 
   api project(':cdm-core')

--- a/docs/gradle/helpers.gradle
+++ b/docs/gradle/helpers.gradle
@@ -56,7 +56,7 @@ def getNexusPath(docSetInfo, versioned = true) {
     persistentNameNexus = branchName != 'develop' ? 'dev' : 'current'
   }
   def nexusVersion = versioned ? "${docSetInfo.version}" : "${persistentNameNexus}"
-  "${topLevelRawRepoDir}/${nexusVersion}"
+  "${nexusVersion}"
 }
 
 //////////////////////////

--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -32,6 +32,6 @@ ext {
   depVersion.junit = '4.13.2'
   // need to define the versions of protobuf and grpc here because they are needed in the protobuf configuration
   // closure, and the version defined in eiter the java platform cannot be accessed from within the closure.
-  depVersion.protobuf = '3.12.4'
-  depVersion.grpc = '1.36.0'
+  depVersion.protobuf = '3.17.2'
+  depVersion.grpc = '1.40.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description of Changes

* Upgrade to Gradle 6.9.1
* Bump 3rd party dependencies
* Publish docs under version and not project-name/version on nexus.
* Temurin does not have java 14 builds, so remove from github test matrix

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/819)
<!-- Reviewable:end -->
