### PR TITLE
GridTimeCoordinateSystem cleanup.

### DIFF
--- a/cdm-core/src/main/java/ucar/nc2/calendar/CalendarPeriod.java
+++ b/cdm-core/src/main/java/ucar/nc2/calendar/CalendarPeriod.java
@@ -180,57 +180,31 @@ public class CalendarPeriod {
     return field.chronoUnit;
   }
 
-  /*
+  /**
    * Get the conversion factor of the other CalendarPeriod to this one
    * 
    * @param from convert from this
    * 
    * @return conversion factor, so that getConvertFactor(from) * from = this
-   * 
-   * @deprecated dont use because these are fixed length and thus approximate.
-   *
-   * @Deprecated
-   * public double getConvertFactor(CalendarPeriod from) {
-   * if (field == Field.Month || field == Field.Year) {
-   * log.warn(" CalendarDate.convert on Month or Year");
-   * }
-   * 
-   * return (double) from.millisecs() / millisecs();
-   * }
-   * 
-   * /*
-   * Get the duration in milliseconds -+
-   * 
-   * @return the duration in seconds
-   * 
-   * @deprecated dont use because these are fixed length and thus approximate.
-   *
-   * @Deprecated
-   * public double getValueInMillisecs() {
-   * if (field == Field.Month)
-   * return 30.0 * 24.0 * 60.0 * 60.0 * 1000.0 * value;
-   * else if (field == Field.Year)
-   * return 365.0 * 24.0 * 60.0 * 60.0 * 1000.0 * value;
-   * else
-   * return millisecs();
-   * }
-   * 
-   * private int millisecs() {
-   * if (field == Field.Millisec)
-   * return value;
-   * else if (field == Field.Second)
-   * return 1000 * value;
-   * else if (field == Field.Minute)
-   * return 60 * 1000 * value;
-   * else if (field == Field.Hour)
-   * return 60 * 60 * 1000 * value;
-   * else if (field == Field.Day)
-   * return 24 * 60 * 60 * 1000 * value;
-   * 
-   * else
-   * throw new IllegalStateException("Illegal Field = " + field);
-   * }
    */
+  public double getConvertFactor(CalendarPeriod from) {
+    return (double) from.millisecs() / millisecs();
+  }
+
+  private int millisecs() {
+    if (field == Field.Millisec)
+      return value;
+    else if (field == Field.Second)
+      return 1000 * value;
+    else if (field == Field.Minute)
+      return 60 * 1000 * value;
+    else if (field == Field.Hour)
+      return 60 * 60 * 1000 * value;
+    else if (field == Field.Day)
+      return 24 * 60 * 60 * 1000 * value;
+    else
+      throw new IllegalStateException("Illegal Field = " + field);
+  }
 
   /*
    * LOOK from old TimeCoord code, which is better ??

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxisInterval.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxisInterval.java
@@ -277,6 +277,20 @@ public class GridAxisInterval extends GridAxis<CoordInterval> implements Iterabl
       return self();
     }
 
+    public T scaleValues(double factor) {
+      if (spacing == GridAxisSpacing.regularPoint) {
+        this.startValue *= factor;
+        this.endValue *= factor;
+        return self();
+      }
+      if (values != null) {
+        for (int i = 0; i < values.length; i++) {
+          values[i] *= factor;
+        }
+      }
+      return self();
+    }
+
     public T subset(int ncoords, double startValue, double endValue, double resolution, Range range) {
       this.ncoords = ncoords;
       this.startValue = startValue;

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxisPoint.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxisPoint.java
@@ -388,6 +388,24 @@ public class GridAxisPoint extends GridAxis<Number> implements Iterable<Number> 
       return self();
     }
 
+    public T scaleValues(double factor) {
+      if (spacing == GridAxisSpacing.regularPoint) {
+        this.resolution *= factor;
+        return self();
+      }
+      if (values != null) {
+        for (int i = 0; i < values.length; i++) {
+          values[i] *= factor;
+        }
+      }
+      if (edges != null) {
+        for (int i = 0; i < edges.length; i++) {
+          edges[i] *= factor;
+        }
+      }
+      return self();
+    }
+
     public T subsetWithSingleValue(double startValue, Range range) {
       Preconditions.checkNotNull(range);
       this.spacing = GridAxisSpacing.regularPoint;

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridReader.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridReader.java
@@ -65,6 +65,11 @@ public class GridReader {
     return this;
   }
 
+  public GridReader setRunTimeLatest() {
+    req.put(GridSubset.runtimeLatest, true);
+    return this;
+  }
+
   public GridReader setEnsCoord(Object coord) {
     Preconditions.checkArgument(coord instanceof Double);
     req.put(GridSubset.ensCoord, coord);

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridSubset.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridSubset.java
@@ -21,7 +21,7 @@ import java.util.*;
 /**
  * Coordinate value-based subsetting of a Grid.
  * LOOK problem is that the valid combinations for time are not obvious.
- * maybe should check, eg set vertCoord when there isnt any? or ignore?
+ * LOOK maybe should check, eg set vertCoord when there isnt any? or ignore?
  */
 public class GridSubset {
   public static final String gridName = "gridName"; // value = String

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/GridTimeCS.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/GridTimeCS.java
@@ -58,11 +58,10 @@ public class GridTimeCS extends GridTimeCoordinateSystem {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  @Nullable
   @Override
   public CalendarDate getRuntimeDate(int runIdx) {
     if (this.runTimeAxis == null) {
-      return null;
+      return this.runtimeDateUnit.getBaseDateTime();
     } else {
       return runtimeDateUnit.makeCalendarDate(this.runTimeAxis.getCoordinate(runIdx).longValue());
     }
@@ -71,34 +70,6 @@ public class GridTimeCS extends GridTimeCoordinateSystem {
   @Override
   public GridAxis<?> getTimeOffsetAxis(int runIdx) {
     return timeOffsetAxis; // default
-  }
-
-  @Override
-  public List<CalendarDate> getTimesForRuntime(int runIdx) {
-    if (this.type == Type.Observation) {
-      return getTimesForObservation();
-    } else {
-      return getTimesForNonObservation(runIdx);
-    }
-  }
-
-  private List<CalendarDate> getTimesForObservation() {
-    List<CalendarDate> result = new ArrayList<>();
-    for (int timeIdx = 0; timeIdx < timeOffsetAxis.getNominalSize(); timeIdx++) {
-      result.add(this.runtimeDateUnit.makeCalendarDate((long) timeOffsetAxis.getCoordDouble(timeIdx)));
-    }
-    return result;
-  }
-
-  private List<CalendarDate> getTimesForNonObservation(int runIdx) {
-    Preconditions.checkArgument(runTimeAxis != null && runIdx >= 0 && runIdx < runTimeAxis.getNominalSize());
-    CalendarDate baseForRun = getRuntimeDate(runIdx);
-    GridAxis<?> timeAxis = getTimeOffsetAxis(runIdx);
-    List<CalendarDate> result = new ArrayList<>();
-    for (int offsetIdx = 0; offsetIdx < timeAxis.getNominalSize(); offsetIdx++) {
-      result.add(baseForRun.add((long) timeAxis.getCoordDouble(offsetIdx), this.offsetPeriod));
-    }
-    return result;
   }
 
   @Override
@@ -119,11 +90,6 @@ public class GridTimeCS extends GridTimeCoordinateSystem {
     Observation(GridAxis<?> time, CalendarDateUnit runtimeDateUnit) {
       // LOOK MRMS_Radar_20201027_0000.grib2.ncx4 time2D has runtime in seconds, but period name is minutes
       super(Type.Observation, null, time, runtimeDateUnit);
-    }
-
-    @Override
-    public CalendarDate getBaseDate() {
-      return runtimeDateUnit.getBaseDateTime();
     }
 
     @Override

--- a/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridDataset.java
+++ b/cdm-core/src/test/java/ucar/nc2/grid/TestReadGridDataset.java
@@ -95,7 +95,7 @@ public class TestReadGridDataset {
       assertThat(tcs == null).isEqualTo(ntimes == 0);
       if (tcs != null) {
         assertThat((Object) tcs.getRunTimeAxis()).isNull();
-        assertThat(tcs.getRuntimeDate(0)).isNull();
+        assertThat(tcs.getRuntimeDate(0)).isEqualTo(tcs.getRuntimeDateUnit().getBaseDateTime());
         assertThat(tcs.getRuntimeDateUnit().toString()).isEqualTo(timeUnit);
         assertThat((Object) tcs.getTimeOffsetAxis(0)).isNotNull();
         List<CalendarDate> dates = tcs.getTimesForRuntime(0);

--- a/cdm-core/src/test/java/ucar/nc2/internal/grid/TestGridTimeCS.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/grid/TestGridTimeCS.java
@@ -53,6 +53,7 @@ public class TestGridTimeCS {
       assertThat(offset.getDependenceType()).isEqualTo(GridAxisDependenceType.independent);
       assertThat(offset.getDependsOn()).isEqualTo(new ArrayList<>());
       assertThat(offset.getUnits()).isEqualTo("hours");
+      assertThat(subject.getOffsetPeriod()).isEqualTo(CalendarPeriod.of("hours"));
       assertThat((Object) offset).isEqualTo(timeAxis);
     }
 
@@ -70,8 +71,7 @@ public class TestGridTimeCS {
       int offsetIdx = 0;
       for (CalendarDate time : times) {
         long what = (long) offset.getCoordDouble(offsetIdx);
-        CalendarDate expected = baseForRun.add(what, CalendarPeriod.Field.Day);
-        // System.out.printf(" (%d,%d) got= %s want= %s%n", runidx, offsetIdx, time, expected);
+        CalendarDate expected = baseForRun.add(what, subject.getOffsetPeriod());
         assertThat(time).isEqualTo(expected);
         offsetIdx++;
       }
@@ -110,6 +110,7 @@ public class TestGridTimeCS {
       assertThat(offset.getDependenceType()).isEqualTo(GridAxisDependenceType.independent);
       assertThat(offset.getDependsOn()).isEqualTo(new ArrayList<>());
       assertThat(offset.getUnits()).isEqualTo("hours");
+      assertThat(subject.getOffsetPeriod()).isEqualTo(CalendarPeriod.of("hours"));
       assertThat((Object) offset).isEqualTo(timeAxis);
     }
 
@@ -127,7 +128,6 @@ public class TestGridTimeCS {
       int offsetIdx = 0;
       for (CalendarDate time : times) {
         CalendarDate expected = baseForRun.add((long) offset.getCoordDouble(offsetIdx++), subject.getOffsetPeriod());
-        // System.out.printf(" (%d,%d) got= %s want= %s%n", runidx, offsetIdx, time, expected);
         assertThat(time).isEqualTo(expected);
       }
     }
@@ -152,14 +152,14 @@ public class TestGridTimeCS {
     assertThat(subject.getSubsetRanges()).isEqualTo(ImmutableList.of(new Range(ntimes)));
 
     assertThat((Object) subject.getTimeOffsetAxis(0)).isEqualTo(timeAxis);
-    assertThat(subject.getRuntimeDate(0)).isNull();
+    assertThat(subject.getRuntimeDate(0)).isEqualTo(cdu.getBaseDateTime());
+    assertThat(subject.getOffsetPeriod()).isEqualTo(CalendarPeriod.of("days"));
 
     List<CalendarDate> times = subject.getTimesForRuntime(0);
     assertThat(times).hasSize(ntimes);
     CalendarDate baseDate = subject.getBaseDate();
     for (int idx = 0; idx < ntimes; idx++) {
       CalendarDate expected = baseDate.add((long) timeAxis.getCoordDouble(idx), subject.getOffsetPeriod());
-      System.out.printf(" (%d)  got= %s want= %s%n", idx, times.get(idx), expected);
       assertThat(times.get(idx)).isEqualTo(expected);
     }
   }

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGribGridSubsetP.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGribGridSubsetP.java
@@ -1,0 +1,196 @@
+package ucar.nc2.grid;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import ucar.nc2.calendar.CalendarDate;
+import ucar.nc2.calendar.CalendarDateUnit;
+import ucar.nc2.grib.collection.GribDataReader;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Mostly checks GridReferencedArray matches request.
+ * Requires that the data exist, not just the gbx9.
+ */
+@RunWith(Parameterized.class)
+@Category(NeedsCdmUnitTest.class)
+public class TestGribGridSubsetP {
+
+  @BeforeClass
+  public static void before() {
+    GribDataReader.validator = new GribCoverageValidator();
+  }
+
+  @AfterClass
+  public static void after() {
+    GribDataReader.validator = null;
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> getTestParameters() {
+    List<Object[]> result = new ArrayList<>();
+
+    ////////////// dt
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ft/coverage/03061219_ruc.nc", "RH", null, "2003-06-12T22:00:00Z",
+        null, 400.0}); // projection, no reftime, no timeOffset
+
+    ////////////// grib
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "ncss/GFS/CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1",
+        "Pressure_surface", "2012-02-27T00:00:00Z", null, 42.0, null}); // projection, scalar reftime
+
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4",
+        "Momentum_flux_u-component_surface_Mixed_intervals_Average", "2015-03-01T06:00:00Z", "2015-03-01T12:00:00Z",
+        null, null}); // time
+
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4",
+        "Momentum_flux_u-component_surface_Mixed_intervals_Average", "2015-03-01T06:00:00Z", null, 213.0, null}); // time
+                                                                                                                  // offset
+
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4",
+        "Ozone_Mixing_Ratio_isobaric", "2015-03-01T06:00:00Z", null, 213.0, null}); // all levels
+
+    result.add(new Object[] {TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4",
+        "Ozone_Mixing_Ratio_isobaric", "2015-03-01T06:00:00Z", null, 213.0, 10000.}); // specific level
+    // */
+    return result;
+  }
+
+  String endpoint, covName;
+  CalendarDate rt_val, time_val;
+  Double time_offset, vert_level;
+
+  public TestGribGridSubsetP(String endpoint, String covName, String rt_val, String time_val, Double time_offset,
+      Double vert_level) {
+    this.endpoint = endpoint;
+    this.covName = covName;
+    this.rt_val = (rt_val == null) ? null : CalendarDate.fromUdunitIsoDate(null, rt_val).orElseThrow();
+    this.time_val = (time_val == null) ? null : CalendarDate.fromUdunitIsoDate(null, time_val).orElseThrow();
+    this.time_offset = time_offset;
+    this.vert_level = vert_level;
+  }
+
+  @Test
+  public void testGridCoverageDatasetFmrc() throws IOException, ucar.array.InvalidRangeException {
+    Formatter errlog = new Formatter();
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+      assertThat(gds).isNotNull();
+      Grid cover = gds.findGrid(covName).orElseThrow();
+      assertThat(cover).isNotNull();
+
+      readOne(cover, rt_val, time_val, time_offset, vert_level);
+    }
+  }
+
+  static void readOne(Grid grid, CalendarDate rt_val, CalendarDate time_val, Double time_offset, Double vert_level)
+      throws IOException, ucar.array.InvalidRangeException {
+    System.out.printf("===Request Subset %s runtime=%s time=%s timeOffset=%s vert=%s%n", grid.getName(), rt_val,
+        time_val, time_offset, vert_level);
+
+    GridSubset subset = new GridSubset();
+    if (rt_val != null)
+      subset.setRunTime(rt_val);
+    if (time_val != null)
+      subset.setTime(time_val);
+    if (time_offset != null)
+      subset.setTimeOffsetCoord(time_offset);
+    if (vert_level != null)
+      subset.setVertCoord(vert_level);
+
+    GridReferencedArray geoArray = grid.readData(subset);
+    MaterializedCoordinateSystem mcs = geoArray.getMaterializedCoordinateSystem();
+    assertThat(mcs).isNotNull();
+    System.out.printf(" data shape=%s%n", java.util.Arrays.toString(geoArray.data().getShape()));
+
+    GridHorizCoordinateSystem hcs2 = mcs.getHorizCoordinateSystem();
+    assertThat(hcs2).isNotNull();
+
+    GridTimeCoordinateSystem tcs = mcs.getTimeCoordSystem();
+    if (rt_val != null) {
+      assertThat(tcs).isNotNull();
+      GridAxisPoint runAxis = tcs.getRunTimeAxis();
+      assertThat((Object) runAxis).isNotNull();
+      assertThat(runAxis.getNominalSize()).isEqualTo(1);
+      double val = runAxis.getCoordDouble(0);
+      CalendarDate runDate = tcs.getRuntimeDateUnit().makeCalendarDate((long) val);
+      assertThat(runDate).isEqualTo(rt_val);
+    }
+
+    if (time_val != null || time_offset != null) {
+      assertThat(tcs).isNotNull();
+      GridAxis<?> timeOffsetAxis = tcs.getTimeOffsetAxis(0);
+      assertThat((Object) timeOffsetAxis).isNotNull();
+
+      assertThat(timeOffsetAxis.getNominalSize()).isEqualTo(1);
+      CalendarDateUnit cdu = tcs.makeOffsetDateUnit(0);
+      assertThat(cdu).isNotNull();
+
+      if (time_val != null) {
+        if (timeOffsetAxis.isInterval()) {
+          CoordInterval intv = timeOffsetAxis.getCoordInterval(0);
+          CalendarDate edge1 = cdu.makeCalendarDate((long) intv.start());
+          CalendarDate edge2 = cdu.makeCalendarDate((long) intv.end());
+
+          assertThat(!edge1.isAfter(time_val)).isTrue();
+          assertThat(!edge2.isBefore(time_val)).isTrue();
+
+        } else {
+          double val2 = timeOffsetAxis.getCoordDouble(0);
+          CalendarDate forecastDate = cdu.makeCalendarDate((long) val2);
+          assertThat(forecastDate).isEqualTo(time_val);
+        }
+
+      } else {
+        if (timeOffsetAxis.isInterval()) {
+          CoordInterval intv = timeOffsetAxis.getCoordInterval(0);
+          assertThat(intv.start() <= time_offset).isTrue();
+          assertThat(intv.end() >= time_offset).isTrue();
+
+        } else {
+          double val2 = timeOffsetAxis.getCoordDouble(0);
+          assertThat(val2).isEqualTo(time_offset);
+        }
+      }
+
+      if (vert_level != null) {
+        GridAxis<?> zAxis = mcs.getVerticalAxis();
+        assertThat((Object) zAxis).isNotNull();
+        assertThat(zAxis.getNominalSize()).isEqualTo(1);
+        double val = zAxis.getCoordDouble(0);
+        assertThat(val).isEqualTo(vert_level);
+      }
+    }
+  }
+
+
+  @Test
+  public void testFmrcStride() throws IOException, ucar.array.InvalidRangeException {
+    Formatter errlog = new Formatter();
+    try (GridDataset gds = GridDatasetFactory.openGridDataset(endpoint, errlog)) {
+      assertThat(gds).isNotNull();
+      Grid cover = gds.findGrid(covName).orElseThrow();
+      assertThat(cover).isNotNull();
+      GridHorizCoordinateSystem hcs = cover.getHorizCoordinateSystem();
+
+      GridReferencedArray geoArray = cover.getReader().setHorizStride(2).read();
+      MaterializedCoordinateSystem msys = geoArray.getMaterializedCoordinateSystem();
+      GridHorizCoordinateSystem mhcs = msys.getHorizCoordinateSystem();
+
+      int dim = 0;
+      for (int size : mhcs.getShape()) {
+        assertThat(size).isEqualTo((1 + hcs.getShape().get(dim++)) / 2);
+      }
+    }
+  }
+
+}

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestReadTime2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestReadTime2D.java
@@ -83,7 +83,7 @@ public class TestReadTime2D {
       GridTimeCoordinateSystem tcs = grid.getTimeCoordinateSystem();
       assertThat(tcs).isNotNull();
       assertThat(tcs.getNominalShape()).isEqualTo(ImmutableList.of(6, 21));
-      assertThat(tcs.getOffsetPeriod()).isEqualTo(CalendarPeriod.of(1, CalendarPeriod.Field.Second));
+      assertThat(tcs.getOffsetPeriod()).isEqualTo(CalendarPeriod.of(1, CalendarPeriod.Field.Hour));
       assertThat(tcs.getRuntimeDateUnit().getCalendarPeriod()).isEqualTo(tcs.getOffsetPeriod());
 
       GridAxisPoint reftime = tcs.getRunTimeAxis();

--- a/grib/src/test/java/ucar/nc2/grib/grid/TestGribGridTimeCS.java
+++ b/grib/src/test/java/ucar/nc2/grib/grid/TestGribGridTimeCS.java
@@ -77,16 +77,16 @@ public class TestGribGridTimeCS {
       assertThat(subject.getSubsetRanges()).isEqualTo(ImmutableList.of(new Range(ntimes)));
 
       assertThat((Object) subject.getRunTimeAxis()).isNull();
-      assertThat(subject.getRuntimeDate(0)).isNull();
+      assertThat(subject.getRuntimeDate(0)).isEqualTo(subject.getBaseDate());
       GridAxis<?> timeAxis = subject.getTimeOffsetAxis(0);
       assertThat((Object) timeAxis).isNotNull();
+      assertThat(subject.getOffsetPeriod()).isEqualTo(CalendarPeriod.of(timeAxis.getUnits()));
 
       List<CalendarDate> times = subject.getTimesForRuntime(0);
       assertThat(times).hasSize(ntimes);
       CalendarDate baseDate = subject.getBaseDate();
       for (int idx = 0; idx < ntimes; idx++) {
         CalendarDate expected = baseDate.add((long) timeAxis.getCoordDouble(idx), offsetPeriod);
-        System.out.printf(" (%d)  got= %s want= %s%n", idx, times.get(idx), expected);
         assertThat(times.get(idx)).isEqualTo(expected);
       }
     }
@@ -152,6 +152,7 @@ public class TestGribGridTimeCS {
         assertThat(offset.getAxisType()).isEqualTo(AxisType.TimeOffset);
         assertThat(offset.getDependenceType()).isEqualTo(GridAxisDependenceType.independent);
         assertThat(offset.getDependsOn()).isEqualTo(new ArrayList<>());
+        assertThat(subject.getOffsetPeriod()).isEqualTo(CalendarPeriod.of(offset.getUnits()));
       }
 
       for (int runidx = 0; runidx < nruntimes; runidx++) {
@@ -200,12 +201,10 @@ public class TestGribGridTimeCS {
       GridTimeCoordinateSystem subject = cs.getTimeCoordinateSystem();
       assertThat(subject).isNotNull();
       assertThat(subject.getType()).isEqualTo(type);
-      // assertThat(subject.getCalendarDateUnit().getCalendarField()).isEqualTo(offsetPeriod);
 
       GridAxisPoint runtime = subject.getRunTimeAxis();
       assertThat((Object) runtime).isNotNull();
       CalendarDateUnit expectedCdu = CalendarDateUnit.fromUdunitString(null, runtime.getUnits()).orElseThrow();
-
       assertThat(subject.getRuntimeDateUnit()).isEqualTo(expectedCdu);
       assertThat(subject.getBaseDate()).isEqualTo(expectedCdu.getBaseDateTime());
 
@@ -224,6 +223,7 @@ public class TestGribGridTimeCS {
         assertThat(offset.getDependenceType()).isEqualTo(GridAxisDependenceType.independent);
         assertThat(offset.getDependsOn()).isEqualTo(new ArrayList<>());
         assertThat(offset.getUnits()).isEqualTo("hours");
+        assertThat(subject.getOffsetPeriod()).isEqualTo(CalendarPeriod.of(offset.getUnits()));
       }
 
       for (int runidx = 0; runidx < nruntimes; runidx++) {
@@ -235,10 +235,6 @@ public class TestGribGridTimeCS {
         int offsetIdx = 0;
         for (CalendarDate time : times) {
           CalendarDate expected = baseForRun.add((long) offset.getCoordDouble(offsetIdx++), offsetPeriod);
-          assertThat(time).isEqualTo(expected);
-        }
-        for (CalendarDate time : times) {
-          CalendarDate expected = expectedCdu.makeCalendarDate((long) offset.getCoordDouble(offsetIdx++));
           assertThat(time).isEqualTo(expected);
         }
       }
@@ -289,6 +285,7 @@ public class TestGribGridTimeCS {
         assertThat(offset.getAxisType()).isEqualTo(AxisType.TimeOffset);
         assertThat(offset.getDependenceType()).isEqualTo(GridAxisDependenceType.independent);
         assertThat(offset.getDependsOn()).isEqualTo(new ArrayList<>());
+        assertThat(subject.getOffsetPeriod()).isEqualTo(CalendarPeriod.of(offset.getUnits()));
       }
 
       for (int runidx = 0; runidx < nruntimes; runidx++) {
@@ -300,7 +297,6 @@ public class TestGribGridTimeCS {
         int offsetIdx = 0;
         for (CalendarDate time : times) {
           CalendarDate expected = baseForRun.add((long) offset.getCoordDouble(offsetIdx++), offsetPeriod);
-          // System.out.printf(" (%d,%d) got= %s want= %s%n", runidx, offsetIdx, time, expected);
           assertThat(time).isEqualTo(expected);
         }
       }


### PR DESCRIPTION
getRuntimeDate() is not Nullable; add makeOffsetDateUnit() convenience method.
CalendarPeriod conversion factor for period <= Day.
GridAxis.scaleValues()
GribGrid: handle when time units change for different offsets (Irregular TwoD time).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/820)
<!-- Reviewable:end -->
