### PR TITLE
[5.x]: Fix documentation layout

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -138,7 +138,7 @@ tasks.register('publishAsVersionedUserGuide', PublishToRawRepoTask) {
   description = 'Publish user guide (versioned) to Nexus under /major.minor/.'
 
   publishSrc = buildJekyllSite.destinationDirectory.get()
-  destPath = "netcdf-java/$project.docVersion/userguide/"
+  destPath = "$project.docVersion/userguide/"
   dependsOn tasks.getByName('buildJekyllSite')
 }
 
@@ -146,7 +146,7 @@ tasks.register('publishAsCurrentUserGuide', PublishToRawRepoTask) {
   description = 'Publish the user guide to Nexus under /current/.'
 
   publishSrc = buildJekyllSite.destinationDirectory.get()
-  destPath = 'netcdf-java/current/userguide/'
+  destPath = 'current/userguide/'
   dependsOn tasks.getByName('buildJekyllSite')
 }
 
@@ -158,42 +158,42 @@ gradle.projectsEvaluated {
     description = 'Publish Javadoc for the CDM subproject to Nexus under /major.minor/.'
 
     publishSrc = tasks.buildJavadocPublicApi.destinationDir
-    destPath = "netcdf-java/$project.docVersion/javadoc/"
+    destPath = "$project.docVersion/javadoc/"
   }
 
   task publishAsCurrentJavadocPublicApi(type: PublishToRawRepoTask, dependsOn: buildJavadocPublicApi) {
     description = 'Publish Javadoc for the CDM subproject to Nexus under /current/.'
 
     publishSrc = tasks.buildJavadocPublicApi.destinationDir
-    destPath = 'netcdf-java/current/javadoc/'
+    destPath = 'current/javadoc/'
   }
 
   task publishAsVersionedJavadocPublicApiWithDeps(type: PublishToRawRepoTask, dependsOn: buildJavadocPublicApiWithDeps) {
     description = 'Publish Javadoc for the CDM subproject to Nexus under /major.minor/.'
 
     publishSrc = tasks.buildJavadocPublicApiWithDeps.destinationDir
-    destPath = "netcdf-java/$project.docVersion/javadoc-with-deprecations/"
+    destPath = "$project.docVersion/javadoc-with-deprecations/"
   }
 
   task publishAsCurrentJavadocPublicApiWithDeps(type: PublishToRawRepoTask, dependsOn: buildJavadocPublicApiWithDeps) {
     description = 'Publish Javadoc for the CDM subproject to Nexus under /current/.'
 
     publishSrc = tasks.buildJavadocPublicApiWithDeps.destinationDir
-    destPath = 'netcdf-java/current/javadoc-with-deprecations/'
+    destPath = 'current/javadoc-with-deprecations/'
   }
 
   task publishAsVersionedJavadocAll(type: PublishToRawRepoTask, dependsOn: buildJavadocAll) {
     description = 'Publish Javadoc for all Java subprojects to Nexus under /major.minor/.'
 
     publishSrc = tasks.buildJavadocAll.destinationDir
-    destPath = "netcdf-java/$project.docVersion/javadocAll/"
+    destPath = "$project.docVersion/javadocAll/"
   }
 
   task publishAsCurrentJavadocAll(type: PublishToRawRepoTask, dependsOn: buildJavadocAll) {
     description = 'Publish Javadoc for all Java subprojects to Nexus under /current/.'
 
     publishSrc = tasks.buildJavadocAll.destinationDir
-    destPath = 'netcdf-java/current/javadocAll/'
+    destPath = 'current/javadocAll/'
   }
 
   // We're deliberately NOT naming this task "publish", because we don't want it running when we do a:
@@ -224,7 +224,7 @@ task deleteVersionedDocsFromNexus(group: 'Documentation', type: DeleteFromNexusT
   description = 'Remove user guide and both Javadoc sets on Nexus under /major.minor/.'
   host = 'https://artifacts.unidata.ucar.edu/'
   searchQueryParameters.repository = 'docs-netcdf-java'
-  searchQueryParameters.group = "/netcdf-java/$project.docVersion/*"
+  searchQueryParameters.group = "/$project.docVersion/*"
 
   onlyIf {
     // Will be evaluated at task execution time, not during configuration.
@@ -239,7 +239,7 @@ task deleteCurrentDocsFromNexus(group: 'Documentation', type: DeleteFromNexusTas
   description = 'Remove user guide and both Javadoc sets on Nexus under /current/.'
   host = 'https://artifacts.unidata.ucar.edu/'
   searchQueryParameters.repository = 'docs-netcdf-java'
-  searchQueryParameters.group = '/netcdf-java/current/*'
+  searchQueryParameters.group = '/current/*'
 
   onlyIf {
     // Will be evaluated at task execution time, not during configuration.

--- a/docs/src/site/_data/topnav.yml
+++ b/docs/src/site/_data/topnav.yml
@@ -18,7 +18,7 @@ topnav_dropdowns:
           - title: GitHub
             external_url: https://github.com/Unidata/netcdf-java
           - title: User guide
-            external_url: https://docs.unidata.ucar.edu/netcdf-java/5.4/userguide/index.html
+            external_url: https://docs.unidata.ucar.edu/netcdf-java/5.5/userguide/index.html
           - title: NcML
             external_url: https://docs.unidata.ucar.edu/thredds/ncml/2.2/index.html
 


### PR DESCRIPTION
## Description of Changes

Do not publish documentation under a top level `netcdf-java/` prefix - start with `version/` or `current/`. Also, forgot that we are on `5.5.0-SNAPSHOT`, so the link in the top navbar should reference version `5.5`. I will push a one-off fix for `5.4`, which will take care of current as well.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/832)
<!-- Reviewable:end -->
