### PR TITLE
[6.x]: Fix doc publishing paths to remove project for netcdf-java docs.

### DIFF
--- a/docs/gradle/helpers.gradle
+++ b/docs/gradle/helpers.gradle
@@ -56,7 +56,7 @@ def getNexusPath(docSetInfo, versioned = true) {
     persistentNameNexus = branchName != 'develop' ? 'dev' : 'current'
   }
   def nexusVersion = versioned ? "${docSetInfo.version}" : "${persistentNameNexus}"
-  "${topLevelRawRepoDir}/${nexusVersion}"
+  topLevelRawRepoDir == 'ncml' ? "${topLevelRawRepoDir}/${nexusVersion}" : "${nexusVersion}"
 }
 
 //////////////////////////


### PR DESCRIPTION
## Description of Changes

Publish 6.x docs under version/ not project/version, except for NcML docs.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/835)
<!-- Reviewable:end -->
