### PR TITLE
GcdmGrid now handles HorizCurvilinear and VerticalTranforms.

### DIFF
--- a/cdm-core/src/main/java/ucar/nc2/geoloc/vertical/VerticalTransform.java
+++ b/cdm-core/src/main/java/ucar/nc2/geoloc/vertical/VerticalTransform.java
@@ -8,7 +8,6 @@ import ucar.array.Array;
 import ucar.array.InvalidRangeException;
 import ucar.array.Range;
 import ucar.nc2.AttributeContainer;
-import ucar.nc2.Dimension;
 import ucar.nc2.dataset.CoordinateSystem;
 import ucar.nc2.dataset.NetcdfDataset;
 
@@ -27,6 +26,10 @@ public interface VerticalTransform {
 
   /** The name of the Coordinate Variable Transform container. */
   String getCtvName();
+
+  /** Get the unit string for the vertical coordinate. */
+  @Nullable
+  String getUnitString();
 
   /**
    * Get the 3D vertical coordinate array for this time step.
@@ -48,10 +51,6 @@ public interface VerticalTransform {
    */
   Array<Number> getCoordinateArray1D(int timeIndex, int xIndex, int yIndex) throws IOException, InvalidRangeException;
 
-  /** Get the unit string for the vertical coordinate. */
-  @Nullable
-  String getUnitString();
-
   /**
    * Create a VerticalTransform as a section of this VerticalTransform.
    * 
@@ -60,12 +59,18 @@ public interface VerticalTransform {
    * @param y_range subset the y dimension, or null if you want all of it
    * @param x_range subset the x dimension, or null if you want all of it
    * @return a new VerticalTransform for the given subset
+   *         LOOK used?
    */
   VerticalTransform subset(Range t_range, Range z_range, Range y_range, Range x_range);
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  /** a Builder of VerticalTransforms. */
+  /**
+   * A Builder of VerticalTransforms.
+   * LOOK Note the use of NetcdfDataset ds, CoordinateSystem csys. VerticalTransform are only
+   * available on Grids built on NetcdfDataset. GRIB does not have these. However, we do want to transport these
+   * over gcdm.
+   */
   interface Builder {
     Optional<VerticalTransform> create(NetcdfDataset ds, CoordinateSystem csys, AttributeContainer params,
         Formatter errlog);

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridAxis.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridAxis.java
@@ -210,7 +210,7 @@ public abstract class GridAxis<T> implements Comparable<GridAxis<T>>, Iterable<T
     GridAxisDependenceType dependenceType = GridAxisDependenceType.independent; // default
     private ArrayList<String> dependsOn; // independent axes or dimensions
 
-    GridAxisSpacing spacing; // required
+    protected GridAxisSpacing spacing; // required
     protected double resolution;
     boolean isSubset;
 

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridCoordinateSystem.java
@@ -212,6 +212,10 @@ public class GridCoordinateSystem {
     showCoordinateAxis(getYHorizAxis(), f, showCoords);
     showCoordinateAxis(getXHorizAxis(), f, showCoords);
 
+    if (getVerticalTransform() != null) {
+      f.format(" VerticalTransform: %s%n", getVerticalTransform());
+    }
+
     if (hcs.getProjection() != null) {
       f.format(" Projection: %s %s%n", hcs.getProjection().getName(), hcs.getProjection().paramsToString());
     }

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridDataset.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridDataset.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import ucar.nc2.Attribute;
 import ucar.nc2.AttributeContainer;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.geoloc.vertical.VerticalTransform;
 
 import java.io.Closeable;
 import java.util.Formatter;
@@ -45,6 +46,12 @@ public interface GridDataset extends Closeable {
           return Optional.of(cov);
     }
     return Optional.empty();
+  }
+
+  /** Find VerticalTransform using its hashCode. */
+  default Optional<VerticalTransform> findVerticalTransformByHash(int hash) {
+    return getGridCoordinateSystems().stream().map(cs -> cs.getVerticalTransform())
+        .filter(vt -> (vt != null) && vt.hashCode() == hash).findFirst();
   }
 
   default void toString(Formatter buf) {

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCoordinateSystem.java
@@ -84,6 +84,10 @@ public class GridHorizCoordinateSystem {
     return rect.getWidth() >= 360;
   }
 
+  public boolean hasAxis(String axisName) {
+    return xaxis.getName().equals(axisName) || yaxis.getName().equals(axisName);
+  }
+
   /**
    * The nominal sizes of the yaxis, xaxis as a list.
    */

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCurvilinear.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridHorizCurvilinear.java
@@ -55,7 +55,7 @@ public class GridHorizCurvilinear extends GridHorizCoordinateSystem {
     return createFromEdges(xaxis, yaxis, latedge, lonedge);
   }
 
-  static GridHorizCurvilinear createFromEdges(GridAxisPoint xaxis, GridAxisPoint yaxis, Array<Double> latedge,
+  public static GridHorizCurvilinear createFromEdges(GridAxisPoint xaxis, GridAxisPoint yaxis, Array<Double> latedge,
       Array<Double> lonedge) {
     Preconditions.checkNotNull(xaxis);
     Preconditions.checkNotNull(yaxis);

--- a/cdm-core/src/main/java/ucar/nc2/grid/GridTimeCoordinateSystem.java
+++ b/cdm-core/src/main/java/ucar/nc2/grid/GridTimeCoordinateSystem.java
@@ -5,7 +5,6 @@
 
 package ucar.nc2.grid;
 
-import com.google.common.base.Preconditions;
 import ucar.nc2.calendar.CalendarDate;
 import ucar.nc2.calendar.CalendarDateUnit;
 import ucar.nc2.calendar.CalendarPeriod;

--- a/cdm-core/src/main/java/ucar/nc2/internal/grid/GridNetcdfDataset.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/grid/GridNetcdfDataset.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Multimap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.nc2.AttributeContainer;
+import ucar.nc2.AttributeContainerMutable;
 import ucar.nc2.Dimension;
 import ucar.nc2.Dimensions;
 import ucar.nc2.Variable;
@@ -196,7 +197,7 @@ public class GridNetcdfDataset implements GridDataset {
 
   @Override
   public AttributeContainer attributes() {
-    return ncd.getRootGroup().attributes();
+    return AttributeContainerMutable.copyFrom(ncd.getRootGroup().attributes()).setName(getName()).toImmutable();
   }
 
   @Override

--- a/cdm-test/src/test/java/ucar/nc2/grid/TestGridVerticalTransforms.java
+++ b/cdm-test/src/test/java/ucar/nc2/grid/TestGridVerticalTransforms.java
@@ -27,24 +27,20 @@ public class TestGridVerticalTransforms {
 
   @Test
   public void testWRF() throws Exception {
-    testDataset(TestDir.cdmUnitTestDir + "conventions/wrf/wrfout_v2_Lambert.nc");
-    testDataset(TestDir.cdmUnitTestDir + "conventions/wrf/wrfout_d01_2006-03-08_21-00-00");
-  }
-
-  private void testDataset(String filename) throws IOException, InvalidRangeException {
+    String filename = TestDir.cdmUnitTestDir + "conventions/wrf/wrfout_v2_Lambert.nc";
     System.out.printf("testWRF %s%n", filename);
     Formatter errlog = new Formatter();
     try (ucar.nc2.grid.GridDataset gds = GridDatasetFactory.openGridDataset(filename, errlog)) {
       assertThat(gds).isNotNull();
 
-      testWrfGrid(gds.findGrid("U").orElseThrow());
-      testWrfGrid(gds.findGrid("V").orElseThrow());
-      testWrfGrid(gds.findGrid("W").orElseThrow());
-      testWrfGrid(gds.findGrid("T").orElseThrow());
+      testWrfGrid(gds.findGrid("U").orElseThrow(), ImmutableList.of(27, 60, 74));
+      testWrfGrid(gds.findGrid("V").orElseThrow(), ImmutableList.of(27, 61, 73));
+      testWrfGrid(gds.findGrid("W").orElseThrow(), ImmutableList.of(28, 60, 73));
+      testWrfGrid(gds.findGrid("T").orElseThrow(), ImmutableList.of(27, 60, 73));
     }
   }
 
-  private void testWrfGrid(Grid grid) throws IOException, InvalidRangeException {
+  private void testWrfGrid(Grid grid, List<Integer> expected) throws IOException, InvalidRangeException {
     GridCoordinateSystem gcs = grid.getCoordinateSystem();
     assertThat(gcs).isNotNull();
     GridHorizCoordinateSystem hcs = gcs.getHorizCoordinateSystem();
@@ -67,21 +63,21 @@ public class TestGridVerticalTransforms {
 
     VerticalTransform vt = gcs.getVerticalTransform();
     assertThat(vt).isNotNull();
-    assertThat(vt).isInstanceOf(ucar.nc2.geoloc.vertical.OceanSigma.class);
+    assertThat(vt).isInstanceOf(ucar.nc2.geoloc.vertical.WrfEta.class);
 
     Array<Number> z3d = vt.getCoordinateArray3D(0);
     Section sv = new Section(z3d.getShape());
     System.out.printf("3dcoord = %s %n", sv);
-    assertThat(Ints.asList(z3d.getShape())).isEqualTo(ImmutableList.of(20, 87, 193));
+    assertThat(Ints.asList(z3d.getShape())).isEqualTo(expected);
 
     Array<Number> z1D = vt.getCoordinateArray1D(0, 10, 10);
-    assertThat(Ints.asList(z1D.getShape())).isEqualTo(ImmutableList.of(20));
+    assertThat(Ints.asList(z1D.getShape())).isEqualTo(expected.subList(0,1));
 
     int timeIndex = 0;
     GridTimeCoordinateSystem tcs = grid.getTimeCoordinateSystem();
     for (Object timeCoord : tcs.getTimeOffsetAxis(0)) {
       Array<Number> zt = vt.getCoordinateArray3D(timeIndex++);
-      assertThat(Ints.asList(zt.getShape())).isEqualTo(ImmutableList.of(20, 87, 193));
+      assertThat(Ints.asList(zt.getShape())).isEqualTo(expected);
     }
 
     Array<Number> vcoord = vt.getCoordinateArray3D(0);

--- a/gcdm/src/main/java/ucar/gcdm/GcdmConverter.java
+++ b/gcdm/src/main/java/ucar/gcdm/GcdmConverter.java
@@ -39,7 +39,7 @@ import ucar.nc2.Sequence;
 import ucar.nc2.Structure;
 import ucar.nc2.Variable;
 
-/** Convert between Gcdm Protos and Netcdf objects, using ucar.ma2.Array for data. */
+/** Convert between Gcdm Protos and Netcdf objects, using ucar.array.Array for data. */
 public class GcdmConverter {
   private static final boolean debugSize = false;
 

--- a/gcdm/src/main/java/ucar/gcdm/GcdmGridConverter.java
+++ b/gcdm/src/main/java/ucar/gcdm/GcdmGridConverter.java
@@ -5,15 +5,17 @@
 
 package ucar.gcdm;
 
-import com.google.common.collect.ImmutableList;
 import ucar.array.Array;
+import ucar.array.ArrayType;
 import ucar.gcdm.client.GcdmGrid;
 import ucar.gcdm.client.GcdmGridDataset;
+import ucar.gcdm.client.GcdmVerticalTransform;
 import ucar.nc2.AttributeContainer;
 import ucar.nc2.calendar.CalendarDate;
 import ucar.nc2.calendar.CalendarDateUnit;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.geoloc.vertical.VerticalTransform;
 import ucar.nc2.grid.Grid;
 import ucar.nc2.grid.GridAxis;
 import ucar.nc2.grid.GridAxisDependenceType;
@@ -23,9 +25,11 @@ import ucar.nc2.grid.GridAxisSpacing;
 import ucar.nc2.grid.GridCoordinateSystem;
 import ucar.nc2.grid.GridDataset;
 import ucar.nc2.grid.GridHorizCoordinateSystem;
+import ucar.nc2.grid.GridHorizCurvilinear;
 import ucar.nc2.grid.GridReferencedArray;
 import ucar.nc2.grid.GridTimeCoordinateSystem;
 import ucar.nc2.grid.MaterializedCoordinateSystem;
+import ucar.nc2.internal.dataset.transform.horiz.ProjectionFactory;
 import ucar.nc2.internal.grid.GridTimeCS;
 import ucar.unidata.geoloc.Projection;
 
@@ -56,18 +60,26 @@ public class GcdmGridConverter {
 
     Set<GridHorizCoordinateSystem> hsyss = new HashSet<>();
     Set<GridTimeCoordinateSystem> tsyss = new HashSet<>();
+    Set<VerticalTransform> vts = new HashSet<>();
     for (GridCoordinateSystem coordsys : org.getGridCoordinateSystems()) {
       builder.addCoordSystems(encodeCoordinateSystem(coordsys));
       hsyss.add(coordsys.getHorizCoordinateSystem());
       if (coordsys.getTimeCoordinateSystem() != null) {
         tsyss.add(coordsys.getTimeCoordinateSystem());
       }
+      if (coordsys.getVerticalTransform() != null) {
+        vts.add(coordsys.getVerticalTransform());
+      }
     }
+
     for (GridHorizCoordinateSystem hsys : hsyss) {
       builder.addHorizCoordSystems(encodeHorizCS(hsys));
     }
     for (GridTimeCoordinateSystem tsys : tsyss) {
       builder.addTimeCoordSystems(encodeTimeCS(tsys));
+    }
+    for (VerticalTransform vt : vts) {
+      builder.addVerticalTransform(encodeVerticalTransform(vt));
     }
     for (Grid grid : org.getGrids()) {
       builder.addGrids(encodeGrid(grid));
@@ -83,16 +95,31 @@ public class GcdmGridConverter {
     for (GcdmGridProto.GridAxis axisp : proto.getGridAxesList()) {
       builder.addGridAxis(decodeGridAxis(axisp));
     }
+
     Map<Integer, GridHorizCoordinateSystem> hsys = new HashMap<>();
     for (GcdmGridProto.GridHorizCoordinateSystem coordsys : proto.getHorizCoordSystemsList()) {
-      hsys.put(coordsys.getId(), decodeHorizCS(coordsys, builder.axes, errlog));
+      GridHorizCoordinateSystem hcs;
+      if (coordsys.getIsCurvilinear()) {
+        hcs = decodeHorizCurvililinear(coordsys);
+      } else {
+        hcs = decodeHorizCS(coordsys, builder.axes, errlog);
+      }
+      hsys.put(coordsys.getId(), hcs);
     }
+
     Map<Integer, GridTimeCoordinateSystem> tsys = new HashMap<>();
     for (GcdmGridProto.GridTimeCoordinateSystem coordsys : proto.getTimeCoordSystemsList()) {
       tsys.put(coordsys.getId(), decodeTimeCS(coordsys, builder.axes));
     }
 
-    Decoder csysDecoder = new Decoder(builder.axes, tsys, hsys);
+    Map<Integer, GcdmVerticalTransform> vtMap = new HashMap<>();
+    for (GcdmGridProto.VerticalTransform vtp : proto.getVerticalTransformList()) {
+      GcdmVerticalTransform vt = decodeVerticalTransform(vtp);
+      builder.addVerticalTransform(vt);
+      vtMap.put(vt.getId(), vt);
+    }
+
+    Decoder csysDecoder = new Decoder(builder.axes, tsys, hsys, vtMap);
     for (GcdmGridProto.GridCoordinateSystem coordsys : proto.getCoordSystemsList()) {
       builder.addCoordSys(csysDecoder.decodeCoordinateSystem(coordsys, errlog));
     }
@@ -106,25 +133,42 @@ public class GcdmGridConverter {
     List<GridAxis<?>> axes;
     Map<Integer, GridTimeCoordinateSystem> tsys;
     Map<Integer, GridHorizCoordinateSystem> hsys;
+    Map<Integer, GcdmVerticalTransform> vts;
 
     Decoder(List<GridAxis<?>> axes, Map<Integer, GridTimeCoordinateSystem> tsys,
-        Map<Integer, GridHorizCoordinateSystem> hsys) {
+        Map<Integer, GridHorizCoordinateSystem> hsys, Map<Integer, GcdmVerticalTransform> vts) {
       this.axes = axes;
       this.tsys = tsys;
       this.hsys = hsys;
+      this.vts = vts;
     }
 
     public GridCoordinateSystem decodeCoordinateSystem(GcdmGridProto.GridCoordinateSystem proto, Formatter errlog) {
       boolean error = false;
       ArrayList<GridAxis<?>> caxes = new ArrayList<>();
+
+      GridHorizCoordinateSystem wantHcs = this.hsys.get(proto.getHorizCoordinatesId());
+      if (wantHcs == null) {
+        errlog.format("Cant find GridHorizCoordinateSystem %d for GridCoordinateSystem %s%n",
+            proto.getHorizCoordinatesId(), proto.getName());
+        error = true;
+      }
+
       for (String axisName : proto.getAxisNamesList()) {
         Optional<GridAxis<?>> want = this.axes.stream().filter(a -> a.getName().equals(axisName)).findFirst();
         if (want.isEmpty()) {
-          errlog.format("Cant find axis named %s%n", axisName);
-          error = true;
+          if (wantHcs.isCurvilinear() && !wantHcs.hasAxis(axisName)) {
+            errlog.format("Cant find axis named %s%n", axisName);
+            error = true;
+          }
         } else {
           caxes.add(want.get());
         }
+      }
+
+      if (wantHcs != null && wantHcs.isCurvilinear()) {
+        caxes.add(wantHcs.getYHorizAxis());
+        caxes.add(wantHcs.getXHorizAxis());
       }
 
       GridTimeCoordinateSystem wantTcs = null;
@@ -137,19 +181,21 @@ public class GcdmGridConverter {
         }
       }
 
-      GridHorizCoordinateSystem wantHcs = this.hsys.get(proto.getHorizCoordinatesId());
-      if (wantHcs == null) {
-        errlog.format("Cant find GridHorizCoordinateSystem %d for GridCoordinateSystem %s%n",
-            proto.getHorizCoordinatesId(), proto.getName());
-        error = true;
+      VerticalTransform vt = null;
+      if (proto.getVerticalTransformId() != 0) {
+        vt = this.vts.get(proto.getVerticalTransformId());
+        if (vt == null) {
+          errlog.format("Cant find VerticalTransform %d for GridCoordinateSystem %s%n", proto.getVerticalTransformId(),
+              proto.getName());
+          error = true;
+        }
       }
 
       if (error) {
         throw new RuntimeException(errlog.toString());
       }
 
-      // LOOK verticalTransform
-      return new GridCoordinateSystem(caxes, wantTcs, null, wantHcs);
+      return new GridCoordinateSystem(caxes, wantTcs, vt, wantHcs);
     }
   }
 
@@ -164,6 +210,9 @@ public class GcdmGridConverter {
     GridTimeCoordinateSystem timeCS = csys.getTimeCoordinateSystem();
     if (timeCS != null) {
       builder.setTimeCoordinatesId(timeCS.hashCode());
+    }
+    if (csys.getVerticalTransform() != null) {
+      builder.setVerticalTransformId(csys.getVerticalTransform().hashCode());
     }
     return builder.build();
   }
@@ -282,7 +331,18 @@ public class GcdmGridConverter {
     builder.setYaxisName(horizCS.getYHorizAxis().getName());
     builder.setIsCurvilinear(horizCS.isCurvilinear());
     builder.setId(horizCS.hashCode());
+    if (horizCS.isCurvilinear()) {
+      encodeHorizCurvililinear((GridHorizCurvilinear) horizCS, builder);
+    }
     return builder.build();
+  }
+
+  private static void encodeHorizCurvililinear(GridHorizCurvilinear horizCurvilinear,
+      GcdmGridProto.GridHorizCoordinateSystem.Builder builder) {
+    builder.setXaxis(encodeGridAxis(horizCurvilinear.getXHorizAxis()));
+    builder.setYaxis(encodeGridAxis(horizCurvilinear.getYHorizAxis()));
+    builder.setLatEdges(GcdmConverter.encodeData(ArrayType.DOUBLE, horizCurvilinear.getLatEdges()));
+    builder.setLonEdges(GcdmConverter.encodeData(ArrayType.DOUBLE, horizCurvilinear.getLonEdges()));
   }
 
   public static GridHorizCoordinateSystem decodeHorizCS(GcdmGridProto.GridHorizCoordinateSystem horizCS,
@@ -293,8 +353,17 @@ public class GcdmGridConverter {
     return new GridHorizCoordinateSystem(xaxis, yaxis, projection);
   }
 
+  public static GridHorizCoordinateSystem decodeHorizCurvililinear(
+      GcdmGridProto.GridHorizCoordinateSystem horizCurvilinear) {
+    GridAxisPoint xaxis = (GridAxisPoint) decodeGridAxis(horizCurvilinear.getXaxis());
+    GridAxisPoint yaxis = (GridAxisPoint) decodeGridAxis(horizCurvilinear.getYaxis());
+    Array<Double> latEdge = GcdmConverter.decodeData(horizCurvilinear.getLatEdges());
+    Array<Double> lonEdge = GcdmConverter.decodeData(horizCurvilinear.getLonEdges());
+
+    return GridHorizCurvilinear.createFromEdges(xaxis, yaxis, latEdge, lonEdge);
+  }
+
   public static GcdmGridProto.GridTimeCoordinateSystem encodeTimeCS(GridTimeCoordinateSystem timeCS) {
-    System.out.printf("  encodeCoordinateSystem %d%n", timeCS.hashCode());
     GcdmGridProto.GridTimeCoordinateSystem.Builder builder = GcdmGridProto.GridTimeCoordinateSystem.newBuilder();
     builder.setType(convertTimeType(timeCS.getType()));
     builder.setCalendarDateUnit(timeCS.getRuntimeDateUnit().toString());
@@ -337,9 +406,6 @@ public class GcdmGridConverter {
     List<GridAxis<?>> timeOffsets =
         proto.getIrregularList().stream().map(a -> decodeGridAxis(a)).collect(Collectors.toList());
 
-    // GridTimeCoordinateSystem.Type type, @Nullable GridAxisPoint runtimeAxis, GridAxis<?> timeOffsetAxis,
-    // CalendarDateUnit calendarDateUnit, CalendarDate calendarDate,
-    // Map<Integer, GridAxis<?>> timeOffsetMap, List<GridAxis<?>> timeOffsets
     return GridTimeCS.create(convertTimeType(proto.getType()), runtimeAxis, timeAxis, dateUnit, timeOffsetMap,
         timeOffsets);
   }
@@ -354,9 +420,23 @@ public class GcdmGridConverter {
     return builder.build();
   }
 
+  @Nullable
   public static Projection decodeProjection(GcdmGridProto.Projection proto, Formatter errlog) {
     AttributeContainer ctv = GcdmConverter.decodeAttributes(proto.getName(), proto.getAttributesList());
-    return ucar.nc2.internal.dataset.transform.horiz.ProjectionFactory.makeProjection(ctv, proto.getGeoUnit(), errlog);
+    return ProjectionFactory.makeProjection(ctv, proto.getGeoUnit(), errlog);
+  }
+
+  public static GcdmGridProto.VerticalTransform encodeVerticalTransform(VerticalTransform vt) {
+    GcdmGridProto.VerticalTransform.Builder builder = GcdmGridProto.VerticalTransform.newBuilder();
+    builder.setId(vt.hashCode());
+    builder.setName(vt.getName());
+    builder.setCtvName(vt.getCtvName());
+    builder.setUnits(vt.getUnitString());
+    return builder.build();
+  }
+
+  public static GcdmVerticalTransform decodeVerticalTransform(GcdmGridProto.VerticalTransform proto) {
+    return new GcdmVerticalTransform(proto.getId(), proto.getName(), proto.getCtvName(), proto.getUnits());
   }
 
   public static GcdmGridProto.Grid encodeGrid(Grid grid) {
@@ -390,7 +470,7 @@ public class GcdmGridConverter {
   }
 
   public static GridReferencedArray decodeGridReferencedArray(GcdmGridProto.GridReferencedArray proto,
-      ImmutableList<GridAxis<?>> axes, Formatter errlog) {
+      Formatter errlog) {
     MaterializedCoordinateSystem.Builder cs =
         decodeMaterializedCoordSys(proto.getMaterializedCoordinateSystem(), errlog);
     Array<Number> data = GcdmConverter.decodeData(proto.getData());
@@ -427,7 +507,7 @@ public class GcdmGridConverter {
 
 
   ////////////////////////////////////////////////////////////////////////////////////
-  // cobvert enums
+  // convert enums
 
   public static GridTimeCoordinateSystem.Type convertTimeType(GcdmGridProto.GridTimeType proto) {
     switch (proto) {

--- a/gcdm/src/main/java/ucar/gcdm/client/GcdmVerticalTransform.java
+++ b/gcdm/src/main/java/ucar/gcdm/client/GcdmVerticalTransform.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.gcdm.client;
+
+import ucar.array.Array;
+import ucar.array.ArrayType;
+import ucar.array.Arrays;
+import ucar.array.InvalidRangeException;
+import ucar.array.Range;
+import ucar.nc2.geoloc.vertical.VerticalTransform;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * Implementation of VerticalTransform that makes a gcmd to get the 3D array.
+ * Not immutable because we need to set the GcdmGridDataset after construction.
+ */
+public class GcdmVerticalTransform implements VerticalTransform {
+  private GcdmGridDataset gridDataset;
+  private final int id;
+  private final String name;
+  private final String ctvName;
+  private final String units;
+
+  public GcdmVerticalTransform(int id, String name, String ctvName, String units) {
+    this.id = id;
+    this.name = name;
+    this.ctvName = ctvName;
+    this.units = units;
+  }
+
+  void setDataset(GcdmGridDataset gridDataset) {
+    this.gridDataset = gridDataset;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getCtvName() {
+    return ctvName;
+  }
+
+  @Nullable
+  @Override
+  public String getUnitString() {
+    return units;
+  }
+
+  @Override
+  public Array<Number> getCoordinateArray3D(int timeIndex) throws IOException, InvalidRangeException {
+    return gridDataset.getVerticalTransform(this.id, this.name, timeIndex);
+  }
+
+  // Implementation that reads the full 3D array and just picks out the specified x, y.
+  // Optimization could cache at least one time index
+  @Override
+  public Array<Number> getCoordinateArray1D(int timeIndex, int xIndex, int yIndex)
+      throws IOException, InvalidRangeException {
+    Array<Number> array3D = getCoordinateArray3D(timeIndex);
+    int nz = array3D.getShape()[0];
+    double[] result = new double[nz];
+
+    int count = 0;
+    for (int z = 0; z < nz; z++) {
+      result[count++] = array3D.get(z, yIndex, xIndex).doubleValue();
+    }
+
+    return Arrays.factory(ArrayType.DOUBLE, new int[] {nz}, result);
+  }
+
+  @Override
+  public VerticalTransform subset(Range t_range, Range z_range, Range y_range, Range x_range) {
+    return null;
+  }
+}

--- a/gcdm/src/main/proto/ucar/gcdm/gcdm_grid.proto
+++ b/gcdm/src/main/proto/ucar/gcdm/gcdm_grid.proto
@@ -39,7 +39,7 @@ enum CdmAxisType {  // related to ucar.nc2.constants.AxisType
   CDM_AXIS_TYPE_DIMENSION = 12;
 }
 
-// could be related to java.ucar.nc2.constants.FeatureType
+// could be related to java.ucar.nc2.constants.
 enum CdmFeatureType {
   CDM_FEATURE_TYPE_UNSPECIFIED = 0;
   CDM_FEATURE_TYPE_GENERAL = 1;
@@ -104,21 +104,21 @@ message GridAxis {
   repeated double edges = 15;
 }
 
-message Projection {
-  string name = 1;
-  string geo_unit = 2;
-  repeated Attribute attributes = 3;
-}
-
 message GridTimeCoordinateSystem {
   GridTimeType type = 1;
   string calendar_date_unit = 2;
   string time_axis_name = 3;
   string runtime_axis_name = 4;
-  int32 id = 5;
+  sint32 id = 5;
 
   map<int32, GridAxis> regular = 6; // <minutes since 0Z, time offset axis>
   repeated GridAxis irregular = 7;  // list of time offset axes
+}
+
+message Projection {
+  string name = 1;
+  string geo_unit = 2;
+  repeated Attribute attributes = 3;
 }
 
 message GridHorizCoordinateSystem {
@@ -126,7 +126,13 @@ message GridHorizCoordinateSystem {
   string xaxis_name = 2;
   string yaxis_name = 3;
   bool is_curvilinear = 4;
-  int32 id = 5;
+  sint32 id = 5;
+
+  // curvilinear only
+  GridAxis xaxis = 6;
+  GridAxis yaxis = 7;
+  Data lat_edges = 8;
+  Data lon_edges = 9;
 }
 
 message GridCoordinateSystem {
@@ -134,6 +140,7 @@ message GridCoordinateSystem {
   repeated string axis_names = 2;
   uint32 horiz_coordinates_id = 3;
   uint32 time_coordinates_id = 4;
+  sint32 vertical_transform_id = 5;
 }
 
 message Grid {
@@ -145,16 +152,24 @@ message Grid {
   string coordinate_system_name = 6;
 }
 
+message VerticalTransform {
+  sint32 id = 1;
+  string name = 2;
+  string ctvName = 3; // needed?
+  string units = 4;
+}
+
 message GridDataset {
   string name = 1;
   string location = 2;
   CdmFeatureType feature_type = 3;
   repeated Attribute attributes = 4;
   repeated GridAxis grid_axes = 5;
-  repeated GridHorizCoordinateSystem horiz_coord_systems = 6; // ordered
-  repeated GridTimeCoordinateSystem time_coord_systems = 7; // ordered
-  repeated GridCoordinateSystem coord_systems = 8; // ordered
+  repeated GridHorizCoordinateSystem horiz_coord_systems = 6;
+  repeated GridTimeCoordinateSystem time_coord_systems = 7;
+  repeated GridCoordinateSystem coord_systems = 8;
   repeated Grid grids = 9;
+  repeated VerticalTransform vertical_transform = 10;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -185,3 +200,23 @@ message GridReferencedArray {
   Data data = 2;
   MaterializedCoordinateSystem materialized_coordinate_system = 3;
 }
+
+////////////////////////////////////////////////////////////////////////////
+// VerticalTransform
+
+message VerticalTransformRequest {
+  sint32 id = 1;
+  string location = 2;
+  string vertical_transform = 3;
+  int32 time_index = 4;
+}
+
+message VerticalTransformResponse {
+  Error error = 1;    // non-empty on error
+  string location = 2;
+  string vertical_transform = 3;
+  int32 time_index = 4;
+
+  Data data3D = 5;
+}
+

--- a/gcdm/src/main/proto/ucar/gcdm/gcdm_server.proto
+++ b/gcdm/src/main/proto/ucar/gcdm/gcdm_server.proto
@@ -16,4 +16,5 @@ service Gcdm {
   rpc GetNetcdfData (DataRequest) returns (stream DataResponse) {}
   rpc GetGridDataset (GridDatasetRequest) returns (GridDatasetResponse) {}
   rpc GetGridData (GridDataRequest) returns (stream GridDataResponse) {}
+  rpc GetVerticalTransform (VerticalTransformRequest) returns (VerticalTransformResponse) {}
 }

--- a/gcdm/src/test/java/ucar/gcdm/TestGcdmGridConverter.java
+++ b/gcdm/src/test/java/ucar/gcdm/TestGcdmGridConverter.java
@@ -114,7 +114,6 @@ public class TestGcdmGridConverter {
 
   public static void compareValuesEqual(GridDataset roundtrip, GridDataset expected, boolean skipTimes) {
     assertThat(roundtrip.getName()).startsWith(expected.getName());
-    // assertThat(roundtrip.getLocation()).isEqualTo(expected.getLocation());
     assertThat(roundtrip.getFeatureType()).isEqualTo(expected.getFeatureType());
     compareValuesEqual(roundtrip.attributes(), expected.attributes());
 

--- a/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDataset.java
+++ b/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDataset.java
@@ -4,8 +4,6 @@
  */
 package ucar.gcdm;
 
-import org.apache.commons.io.filefilter.SuffixFileFilter;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,7 +26,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 /** Test {@link GcdmNetcdfFile} */
 @RunWith(Parameterized.class)
-@Ignore("not ready")
 public class TestGcdmGridDataset {
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {
@@ -36,7 +33,7 @@ public class TestGcdmGridDataset {
     try {
       result.add(new Object[] {TestDir.cdmLocalTestDataDir + "permuteTest.nc"});
 
-      FileFilter ff = TestDir.FileFilterSkipSuffix(".cdl .ncml perverse.nc");
+      FileFilter ff = TestDir.FileFilterSkipSuffix(".cdl .gbx9 aggFmrc.xml cg.ncml");
       TestDir.actOnAllParameterized(TestDir.cdmUnitTestDir + "/ft/grid", ff, result, true);
 
     } catch (Exception e) {
@@ -51,140 +48,268 @@ public class TestGcdmGridDataset {
   public TestGcdmGridDataset(String filename) throws IOException {
     this.filename = filename.replace("\\", "/");
     File file = new File(filename);
-    System.out.printf("getAbsolutePath %s%n", file.getAbsolutePath());
-    System.out.printf("getCanonicalPath %s%n", file.getCanonicalPath());
-
     // LOOK kludge for now. Also, need to auto start up CmdrServer
     this.gcdmUrl = "gcdm://localhost:16111/" + file.getCanonicalPath();
   }
 
   @Test
   public void doOne() throws Exception {
+    System.out.printf("TestGcdmNetcdfFile  %s%n", filename);
+
     Formatter info = new Formatter();
-    try (GridDataset local = GridDatasetFactory.openGridDataset(gcdmUrl, info)) {
+    try (GridDataset local = GridDatasetFactory.openGridDataset(filename, info)) {
       if (local == null) {
-        System.out.printf("TestGcdmNetcdfFile %s NOT a grid%n", filename);
+        System.out.printf("TestGcdmNetcdfFile %s NOT a grid %s%n", filename, info);
         return;
       }
-      System.out.printf("TestGcdmNetcdfFile call server for %s%n", filename);
       try (GridDataset remote = GridDatasetFactory.openGridDataset(gcdmUrl, info)) {
-        assertThat(remote).isNotNull();
+        if (remote == null) {
+          System.out.printf(" Remote %s fails %s%n", filename, info);
+          return;
+        }
         assertThat(remote).isInstanceOf(GcdmGridDataset.class);
-        boolean ok = compareGridDataset(local, remote);
+        boolean ok = compareGridDataset(remote, local);
         if (!ok) {
-          System.out.printf("infp = '%s'%n", info);
+          System.out.printf("info = '%s'%n", info);
         }
         assertThat(ok).isTrue();
 
-        for (Grid localGrid : local.getGrids()) {
-          remote.findGrid(localGrid.getName()).ifPresent(remoteGrid -> compareGrid(localGrid, remoteGrid));
+        for (Grid grid : remote.getGrids()) {
+          local.findGrid(grid.getName()).ifPresent(remoteGrid -> compareGrid(remoteGrid, remoteGrid));
         }
       }
     }
   }
 
-  private boolean compareGridDataset(GridDataset local, GridDataset remote) {
-    System.out.printf("local (%s) = %s%n%n", local.getClass().getName(), local);
-    System.out.printf("====================================================%n");
-    System.out.printf("remote (%s) = %s%n%n", remote.getClass().getName(), remote);
-    System.out.printf("====================================================%n");
+  private boolean compareGridDataset(GridDataset remote, GridDataset local) {
+    System.out.printf(" remote (%s) = %s%n%n", remote.getClass().getName(), remote.getLocation());
+    System.out.printf(" local (%s) = %s%n%n", local.getClass().getName(), local.getLocation());
 
     boolean ok = true;
 
-    assertThat(local.getName()).isEqualTo(remote.getName());
-    assertThat(local.getFeatureType()).isEqualTo(remote.getFeatureType());
+    assertThat(remote.getName()).isEqualTo(local.getName());
+    assertThat(remote.getFeatureType()).isEqualTo(local.getFeatureType());
+    assertThat(remote.attributes()).isEqualTo(local.attributes());
 
-    for (GridCoordinateSystem gcs : local.getGridCoordinateSystems()) {
-      GridCoordinateSystem rcs = remote.getGridCoordinateSystems().stream()
+    assertThat(remote.getGridCoordinateSystems()).hasSize(local.getGridCoordinateSystems().size());
+    for (GridCoordinateSystem gcs : remote.getGridCoordinateSystems()) {
+      GridCoordinateSystem rcs = local.getGridCoordinateSystems().stream()
           .filter(cs -> cs.getName().equals(gcs.getName())).findFirst().orElse(null);
       assertThat(rcs).isNotNull();
-      assertWithMessage(gcs.getName()).that(rcs).isEqualTo(gcs);
+      assertWithMessage(gcs.getName()).that(compareGridCoordinateSystem(gcs, rcs)).isTrue();
     }
 
-    for (GridAxis<?> axis : local.getGridAxes()) {
+    assertThat(remote.getGridAxes()).hasSize(local.getGridAxes().size());
+    for (GridAxis<?> axis : remote.getGridAxes()) {
       GridAxis<?> raxis =
-          remote.getGridAxes().stream().filter(cs -> cs.getName().equals(axis.getName())).findFirst().orElse(null);
+          local.getGridAxes().stream().filter(cs -> cs.getName().equals(axis.getName())).findFirst().orElse(null);
       assertThat((Object) raxis).isNotNull();
-      assertThat((Object) raxis).isEqualTo(axis);
+      System.out.printf(" axis %s%n", axis.getName());
+      assertWithMessage(axis.getName()).that(compareGridAxis(axis, raxis)).isTrue();
     }
 
-    for (Grid grid : local.getGrids()) {
-      Grid rgrid =
-          remote.getGrids().stream().filter(cs -> cs.getName().equals(grid.getName())).findFirst().orElse(null);
+    assertThat(remote.getGrids()).hasSize(local.getGrids().size());
+    for (Grid grid : remote.getGrids()) {
+      Grid rgrid = local.getGrids().stream().filter(cs -> cs.getName().equals(grid.getName())).findFirst().orElse(null);
       assertThat(rgrid).isNotNull();
-      assertWithMessage(grid.getName()).that(rgrid.getCoordinateSystem()).isEqualTo(grid.getCoordinateSystem());
+      System.out.printf(" grid %s%n", grid.getName());
+      assertWithMessage(grid.getName()).that(compareGrid(grid, rgrid)).isTrue();
     }
 
     return ok;
   }
 
-  private static boolean compareGrid(Grid local, Grid remote) {
-    GridSubset subset = GridSubset.create();
-    try {
-      return doRunTime(local, remote, subset);
-    } catch (Exception e) {
-      e.printStackTrace();
-      return false;
+  private boolean compareGridCoordinateSystem(GridCoordinateSystem remote, GridCoordinateSystem local) {
+    boolean ok = true;
+
+    assertThat(remote.getName()).isEqualTo(local.getName());
+    assertThat(remote.getFeatureType()).isEqualTo(local.getFeatureType());
+    assertThat(remote.getVerticalTransform() == null).isEqualTo(local.getVerticalTransform() == null);
+    if (remote.getVerticalTransform() != null) {
+      assertThat(remote.getVerticalTransform().getName()).isEqualTo(local.getVerticalTransform().getName());
     }
+    assertThat(remote.getNominalShape()).isEqualTo(local.getNominalShape());
+    assertThat(remote.isZPositive()).isEqualTo(local.isZPositive());
+
+    assertWithMessage(remote.getName())
+        .that(compareGridHorizCoordinateSystem(remote.getHorizCoordinateSystem(), local.getHorizCoordinateSystem()))
+        .isTrue();
+    assertWithMessage(remote.getName())
+        .that(compareGridTimeCoordinateSystem(remote.getTimeCoordinateSystem(), local.getTimeCoordinateSystem()))
+        .isTrue();
+
+    assertThat(remote.getGridAxes()).hasSize(local.getGridAxes().size());
+    for (GridAxis<?> axis : remote.getGridAxes()) {
+      GridAxis<?> raxis =
+          local.getGridAxes().stream().filter(cs -> cs.getName().equals(axis.getName())).findFirst().orElse(null);
+      assertThat((Object) raxis).isNotNull();
+    }
+
+    return ok;
   }
 
-  private static boolean doRunTime(Grid local, Grid remote, GridSubset subset) throws Exception {
+  private boolean compareGridHorizCoordinateSystem(GridHorizCoordinateSystem remote, GridHorizCoordinateSystem local) {
     boolean ok = true;
-    GridTimeCoordinateSystem tcs = local.getCoordinateSystem().getTimeCoordinateSystem();
+
+    assertThat(remote.getProjection()).isEqualTo(local.getProjection());
+    assertThat(remote.getBoundingBox()).isEqualTo(local.getBoundingBox());
+    assertThat(remote.getLatLonBoundingBox()).isEqualTo(local.getLatLonBoundingBox());
+    assertThat(remote.getShape()).isEqualTo(local.getShape());
+    assertThat(remote.getXHorizAxis().getName()).isEqualTo(local.getXHorizAxis().getName());
+    assertThat(remote.getYHorizAxis().getName()).isEqualTo(local.getYHorizAxis().getName());
+    assertThat(remote.isCurvilinear()).isEqualTo(local.isCurvilinear());
+    assertThat(remote.isGlobalLon()).isEqualTo(local.isGlobalLon());
+    assertThat(remote.isLatLon()).isEqualTo(local.isLatLon());
+    assertThat(remote.getGeoUnits()).isEqualTo(local.getGeoUnits());
+
+    return ok;
+  }
+
+  private boolean compareGridTimeCoordinateSystem(GridTimeCoordinateSystem remote, GridTimeCoordinateSystem local) {
+    boolean ok = true;
+    assertThat(remote == null).isEqualTo(local == null);
+    if (remote == null) {
+      return ok;
+    }
+
+    assertThat(remote.getType()).isEqualTo(local.getType());
+    assertThat(remote.getNominalShape()).isEqualTo(local.getNominalShape());
+    assertThat(remote.getBaseDate()).isEqualTo(local.getBaseDate());
+    assertThat(remote.getOffsetPeriod()).isEqualTo(local.getOffsetPeriod());
+    assertThat(remote.getRuntimeDateUnit()).isEqualTo(local.getRuntimeDateUnit());
+
+    assertThat(remote.getRunTimeAxis() == null).isEqualTo(local.getRunTimeAxis() == null);
+    if (remote.getRunTimeAxis() != null) {
+      assertThat(remote.getRunTimeAxis().getName()).isEqualTo(local.getRunTimeAxis().getName());
+      assertThat(remote.getRunTimeAxis().getNominalSize()).isEqualTo(local.getRunTimeAxis().getNominalSize());
+      int nruns = remote.getRunTimeAxis().getNominalSize();
+      for (int i = 0; i < nruns; i++) {
+        assertThat(remote.getRuntimeDate(i)).isEqualTo(local.getRuntimeDate(i));
+        assertThat(compareGridAxis(remote.getTimeOffsetAxis(i), local.getTimeOffsetAxis(i))).isTrue();
+      }
+    } else {
+      assertThat(remote.getRuntimeDate(0)).isEqualTo(local.getRuntimeDate(0));
+      assertThat(compareGridAxis(remote.getTimeOffsetAxis(0), local.getTimeOffsetAxis(0))).isTrue();
+    }
+
+    assertThat(compareGridAxis(remote.getTimeOffsetAxis(0), local.getTimeOffsetAxis(0))).isTrue();
+
+    return ok;
+  }
+
+  private boolean compareGridAxis(GridAxis<?> remote, GridAxis<?> local) {
+    boolean ok = true;
+
+    assertThat(remote.getName()).isEqualTo(local.getName());
+    assertThat(remote.getNominalSize()).isEqualTo(local.getNominalSize());
+    assertThat(remote.getAxisType()).isEqualTo(local.getAxisType());
+    assertThat(remote.getUnits()).isEqualTo(local.getUnits());
+    assertThat(remote.getDescription()).isEqualTo(local.getDescription());
+    assertThat(remote.getDependenceType()).isEqualTo(local.getDependenceType());
+    assertThat(remote.getDependsOn()).isEqualTo(local.getDependsOn());
+    assertThat(remote.getSpacing()).isEqualTo(local.getSpacing());
+    assertThat(remote.getResolution()).isEqualTo(local.getResolution());
+    assertThat(remote.isInterval()).isEqualTo(local.isInterval());
+    assertThat(remote.isRegular()).isEqualTo(local.isRegular());
+
+    if (remote.isInterval()) {
+      GridAxisInterval intvLocal = (GridAxisInterval) remote;
+      GridAxisInterval intvRemote = (GridAxisInterval) local;
+      for (int i = 0; i < remote.getNominalSize(); i++) {
+        assertThat(intvLocal.getCoordInterval(i)).isEqualTo(intvRemote.getCoordInterval(i));
+        assertThat(intvLocal.getCoordinate(i)).isEqualTo(intvRemote.getCoordinate(i));
+      }
+    } else {
+      GridAxisPoint intvLocal = (GridAxisPoint) remote;
+      GridAxisPoint intvRemote = (GridAxisPoint) local;
+      for (int i = 0; i < remote.getNominalSize(); i++) {
+        assertThat(intvLocal.getCoordInterval(i)).isEqualTo(intvRemote.getCoordInterval(i));
+        assertThat(intvLocal.getCoordinate(i)).isEqualTo(intvRemote.getCoordinate(i));
+      }
+    }
+
+    return ok;
+  }
+
+
+  private boolean compareGrid(Grid remote, Grid local) {
+    boolean ok = true;
+
+    assertThat(remote.getName()).isEqualTo(local.getName());
+    assertThat(remote.attributes()).isEqualTo(local.attributes());
+    assertThat(remote.getCoordinateSystem().getName()).isEqualTo(local.getCoordinateSystem().getName());
+    assertThat(remote.getUnits()).isEqualTo(local.getUnits());
+    assertThat(remote.getDescription()).isEqualTo(local.getDescription());
+    assertThat(remote.getArrayType()).isEqualTo(local.getArrayType());
+
+    assertWithMessage(remote.getName())
+        .that(compareGridHorizCoordinateSystem(remote.getHorizCoordinateSystem(), local.getHorizCoordinateSystem()))
+        .isTrue();
+    assertWithMessage(remote.getName())
+        .that(compareGridTimeCoordinateSystem(remote.getTimeCoordinateSystem(), local.getTimeCoordinateSystem()))
+        .isTrue();
+
+    return ok;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  private static boolean doRunTime(Grid remote, Grid local, GridSubset subset) throws Exception {
+    boolean ok = true;
+    GridTimeCoordinateSystem tcs = remote.getCoordinateSystem().getTimeCoordinateSystem();
     if (tcs == null) {
-      ok &= doVert(local, remote, subset);
+      ok &= doVert(remote, local, subset);
     } else {
       GridAxisPoint runtimeAxis = tcs.getRunTimeAxis();
       if (runtimeAxis == null) {
-        ok &= doTime(local, remote, subset, 0);
+        ok &= doTime(remote, local, subset, 0);
       } else {
         for (int runIdx = 0; runIdx < runtimeAxis.getNominalSize(); runIdx++) {
           subset.setRunTime(tcs.getRuntimeDate(runIdx));
-          ok &= doTime(local, remote, subset, runIdx);
+          ok &= doTime(remote, local, subset, runIdx);
         }
       }
     }
     return ok;
   }
 
-  private static boolean doTime(Grid local, Grid remote, GridSubset subset, int runIdx) throws Exception {
+  private static boolean doTime(Grid remote, Grid local, GridSubset subset, int runIdx) throws Exception {
     boolean ok = true;
-    GridTimeCoordinateSystem tcs = local.getCoordinateSystem().getTimeCoordinateSystem();
+    GridTimeCoordinateSystem tcs = remote.getCoordinateSystem().getTimeCoordinateSystem();
     assertThat(tcs).isNotNull();
     GridAxis<?> timeAxis = tcs.getTimeOffsetAxis(runIdx);
     if (timeAxis == null) {
-      ok &= doVert(local, remote, subset);
+      ok &= doVert(remote, local, subset);
     } else {
       for (Object coord : timeAxis) {
         subset.setTimeOffsetCoord(coord);
-        ok &= doVert(local, remote, subset);
+        ok &= doVert(remote, local, subset);
       }
     }
     return ok;
   }
 
-  private static boolean doVert(Grid local, Grid remote, GridSubset subset) throws Exception {
+  private static boolean doVert(Grid remote, Grid local, GridSubset subset) throws Exception {
     boolean ok = true;
-    GridAxis<?> vertAxis = local.getCoordinateSystem().getVerticalAxis();
+    GridAxis<?> vertAxis = remote.getCoordinateSystem().getVerticalAxis();
     if (vertAxis == null) {
-      ok &= doSubset(local, remote, subset);
+      ok &= doSubset(remote, local, subset);
     } else {
       for (Object vertCoord : vertAxis) {
         subset.setVertCoord(vertCoord);
-        ok &= doSubset(local, remote, subset);
+        ok &= doSubset(remote, local, subset);
       }
     }
     return ok;
   }
 
-  private static boolean doSubset(Grid local, Grid remote, GridSubset subset)
+  private static boolean doSubset(Grid remote, Grid local, GridSubset subset)
       throws IOException, InvalidRangeException {
-    System.out.printf(" Grid %s subset %s %n", local.getName(), subset);
-    GridReferencedArray localArray = local.getReader().read();
-    GridReferencedArray remoteArray = remote.getReader().read();
+    System.out.printf(" Grid %s subset %s %n", remote.getName(), subset);
+    GridReferencedArray localArray = remote.getReader().read();
+    GridReferencedArray remoteArray = local.getReader().read();
     Formatter f = new Formatter();
     boolean ok1 =
-        CompareArrayToArray.compareData(f, local.getName(), localArray.data(), remoteArray.data(), true, true);
+        CompareArrayToArray.compareData(f, remote.getName(), localArray.data(), remoteArray.data(), true, true);
     if (!ok1) {
       System.out.printf("  FAIL %s%n", f);
     }

--- a/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDataset.java
+++ b/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDataset.java
@@ -5,6 +5,7 @@
 package ucar.gcdm;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import ucar.array.InvalidRangeException;
@@ -13,6 +14,7 @@ import ucar.gcdm.client.GcdmNetcdfFile;
 import ucar.nc2.grid.*;
 import ucar.nc2.internal.util.CompareArrayToArray;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -26,6 +28,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 /** Test {@link GcdmNetcdfFile} */
 @RunWith(Parameterized.class)
+@Category(NeedsCdmUnitTest.class)
 public class TestGcdmGridDataset {
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {

--- a/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDatasetProblems.java
+++ b/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDatasetProblems.java
@@ -21,14 +21,27 @@ import java.nio.file.Paths;
 import static com.google.common.truth.Truth.assertThat;
 
 /** Test {@link GcdmNetcdfFile} */
-public class TestGcdmGridProblem {
+public class TestGcdmGridDatasetProblems {
+
+  @Test
+  public void testCurvilinear() throws Exception {
+    String filename = TestDir.cdmUnitTestDir + "ft/grid/stag/bora_feb.nc";
+    new TestGcdmGridDataset(filename).doOne();
+  }
+
+  @Test
+  public void testVerticalTransform() throws Exception {
+    String filename = TestDir.cdmUnitTestDir + "ft/grid/testCFwriter.nc";
+    new TestGcdmGridDataset(filename).doOne();
+  }
 
   @Test
   @Category(NeedsCdmUnitTest.class)
-  public void testCsysShapeFailing() throws Exception {
+  public void testSanityCheck() throws Exception {
     String filename = TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/gfs_2p5deg.ncx4";
     Path path = Paths.get(filename);
     TestGcdmGridConverter.roundtrip(path);
+    new TestGcdmGridDataset(filename).doOne();
   }
 
 }

--- a/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDatasetProblems.java
+++ b/gcdm/src/test/java/ucar/gcdm/TestGcdmGridDatasetProblems.java
@@ -21,6 +21,7 @@ import java.nio.file.Paths;
 import static com.google.common.truth.Truth.assertThat;
 
 /** Test {@link GcdmNetcdfFile} */
+@Category(NeedsCdmUnitTest.class)
 public class TestGcdmGridDatasetProblems {
 
   @Test

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionImmutable.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionImmutable.java
@@ -239,7 +239,7 @@ public abstract class GribCollectionImmutable implements Closeable, FileCacheabl
     result.addAttribute(new Attribute(CDM.HISTORY, "Read using CDM IOSP GribCollection v3"));
     result.addAttribute(new Attribute(CF.FEATURE_TYPE, FeatureType.GRID.name()));
 
-    return result;
+    return result.toImmutable();
   }
 
   public abstract void addGlobalAttributes(AttributeContainerMutable result);

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridAxis.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridAxis.java
@@ -340,6 +340,9 @@ public class GribGridAxis {
         if (built)
           throw new IllegalStateException("already built");
         built = true;
+        if (this.resolution == 0 && this.spacing == GridAxisSpacing.contiguousInterval && this.values.length > 1) {
+          this.resolution = (this.values[this.values.length - 1] - this.values[0]) / (this.values.length - 1);
+        }
         return new GribGridAxis.Interval(this);
       }
     }


### PR DESCRIPTION
Tweaks to gcdmGrid proto, I assume this isnt used anywhere else.
VerticalTranforms are implemented by calling back into the host GridDataset on the server.
GridNetcdfDataset: add name to global attributes.
GribGridAxis sets resolution on contiguous intervals if needed.
Fix gcdm problems, add tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/859)
<!-- Reviewable:end -->
