### PR TITLE
Improve ucar.array.Index, NetcdfFormatWriter.

### DIFF
--- a/cdm-core/src/main/java/ucar/array/Array.java
+++ b/cdm-core/src/main/java/ucar/array/Array.java
@@ -52,7 +52,7 @@ public abstract class Array<T> implements Iterable<T> {
 
   /** An Index that can be used instead of int[], with the same rank as this Array. */
   public Index getIndex() {
-    return new Index(new int[this.rank], this.indexFn);
+    return Index.ofRank(rank);
   }
 
   /** Get the number of dimensions of the array. */

--- a/cdm-core/src/main/java/ucar/array/ArrayByte.java
+++ b/cdm-core/src/main/java/ucar/array/ArrayByte.java
@@ -4,10 +4,10 @@
  */
 package ucar.array;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import javax.annotation.concurrent.Immutable;
 
@@ -117,7 +117,7 @@ final class ArrayByte extends Array<Byte> {
       }
       carr[idx++] = c;
     }
-    return new String(carr, Charsets.UTF_8);
+    return new String(carr, StandardCharsets.UTF_8);
   }
 
   /**
@@ -147,13 +147,13 @@ final class ArrayByte extends Array<Byte> {
       int idx = sidx * innerLength + cidx;
       byte c = get(indexFn.odometer(idx));
       if (c == 0) {
-        result[sidx++] = new String(carr, 0, cidx, Charsets.UTF_8);
+        result[sidx++] = new String(carr, 0, cidx, StandardCharsets.UTF_8);
         cidx = 0;
         continue;
       }
       carr[cidx++] = c;
       if (cidx == innerLength) {
-        result[sidx++] = new String(carr, Charsets.UTF_8);
+        result[sidx++] = new String(carr, StandardCharsets.UTF_8);
         cidx = 0;
       }
     }

--- a/cdm-core/src/main/java/ucar/array/ArrayByte.java
+++ b/cdm-core/src/main/java/ucar/array/ArrayByte.java
@@ -102,7 +102,6 @@ final class ArrayByte extends Array<Byte> {
    * The null is not returned as part of the String.
    */
   String makeStringFromChar() {
-    // LOOK Preconditions.checkArgument(getRank() < 2);
     int count = 0;
     for (byte c : this) {
       if (c == 0) {
@@ -143,10 +142,10 @@ final class ArrayByte extends Array<Byte> {
     int cidx = 0;
     int sidx = 0;
 
-    Index index = getIndex(); // have to do this because maybe its a view
+    IndexFn indexFn = IndexFn.builder(getShape()).build();
     while (sidx < outerLength) {
       int idx = sidx * innerLength + cidx;
-      byte c = get(index.setElem(idx));
+      byte c = get(indexFn.odometer(idx));
       if (c == 0) {
         result[sidx++] = new String(carr, 0, cidx, Charsets.UTF_8);
         cidx = 0;

--- a/cdm-core/src/main/java/ucar/array/Index.java
+++ b/cdm-core/src/main/java/ucar/array/Index.java
@@ -13,27 +13,24 @@ import com.google.common.base.Preconditions;
  */
 public class Index {
   public static Index ofRank(int rank) {
-    return new Index(new int[rank], IndexFn.builder(rank).build());
+    return new Index(new int[rank]);
   }
 
   public static Index of(int[] index) {
-    return new Index(index, IndexFn.builder(index.length).build());
+    return new Index(index);
   }
 
   /////////////////////////////////////////////////////
   private int[] current; // current element's index
-  private final IndexFn indexFn;
 
-  Index(int[] index, IndexFn indexFn) {
+  Index(int[] index) {
     this.current = index;
-    this.indexFn = indexFn;
   }
 
   // Copy constructor.
   public Index(Index from) {
     this.current = new int[from.current.length];
     System.arraycopy(from.current, 0, this.current, 0, from.current.length);
-    this.indexFn = from.indexFn; // Immutable
   }
 
   /**
@@ -51,12 +48,6 @@ public class Index {
   /** Get the current index as int[] . */
   public int[] getCurrentIndex() {
     return current;
-  }
-
-  /** Set the current multidim index using 1-d element index. */
-  public Index setElem(long elem) {
-    this.current = indexFn.odometer(elem);
-    return this;
   }
 
   /**

--- a/cdm-core/src/main/java/ucar/array/IndexFn.java
+++ b/cdm-core/src/main/java/ucar/array/IndexFn.java
@@ -13,7 +13,7 @@ import javax.annotation.concurrent.Immutable;
 
 /** Translate between multidimensional index and 1-d arrays. */
 @Immutable
-final class IndexFn implements Iterable<Integer> {
+public final class IndexFn implements Iterable<Integer> {
 
   /**
    * Get the 1-d index indicated by the list of multidimensional indices.
@@ -303,7 +303,7 @@ final class IndexFn implements Iterable<Integer> {
     return newIndex.build();
   }
 
-  public static Builder builder(int rank) {
+  private static Builder builder(int rank) {
     return new Builder(rank);
   }
 
@@ -417,7 +417,7 @@ final class IndexFn implements Iterable<Integer> {
   }
 
   /** what is the odometer (n-dim index) for element (1-d index)? */
-  int[] odometer(long element) {
+  public int[] odometer(long element) {
     int[] odometer = new int[rank];
     for (int dim = 0; dim < rank; dim++) {
       odometer[dim] = (int) (element / stride[dim]);

--- a/cdm-core/src/main/java/ucar/nc2/constants/CDM.java
+++ b/cdm-core/src/main/java/ucar/nc2/constants/CDM.java
@@ -6,13 +6,10 @@ package ucar.nc2.constants;
 
 import com.google.common.collect.ImmutableList;
 
-/**
- * CDM constants.
- *
- * @author caron
- * @since 12/20/11
- */
+/** CDM constants. */
 public class CDM {
+  /** @deprecated use StandardCharsets.UTF_8 */
+  @Deprecated
   public static final String UTF8 = "UTF-8";
 
   // structural

--- a/cdm-core/src/main/java/ucar/nc2/write/NcdumpArray.java
+++ b/cdm-core/src/main/java/ucar/nc2/write/NcdumpArray.java
@@ -413,10 +413,11 @@ public class NcdumpArray {
     int last = dims[0];
 
     out.format("%n%s{", indent);
-    Index ima = ma.getIndex();
+    IndexFn indexFn = IndexFn.builder(ma.getShape()).build();
+
     if ((rank == 1) && (ma.getArrayType() != ArrayType.STRUCTURE)) {
       for (int ii = 0; ii < last; ii++) {
-        Object value = ma.get(ima.setElem(ii)); // LOOK
+        Object value = ma.get(indexFn.odometer(ii));
 
         if (ma.getArrayType().isUnsigned()) {
           assert value instanceof Number : "A data type being unsigned implies that it is numeric.";

--- a/cdm-core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
+++ b/cdm-core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
@@ -4,7 +4,6 @@
  */
 package ucar.nc2.write;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import ucar.array.Array;
 import ucar.array.ArrayType;
@@ -33,6 +32,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static ucar.nc2.NetcdfFile.IOSP_MESSAGE_GET_NETCDF_FILE_FORMAT;
@@ -209,7 +209,7 @@ public class NetcdfFormatWriter implements Closeable {
 
     // previously we truncated chars to bytes.
     // here we are going to use UTF encoded bytes, just as if we were real programmers.
-    byte[] bb = data.getBytes(Charsets.UTF_8);
+    byte[] bb = data.getBytes(StandardCharsets.UTF_8);
     if (bb.length != last) {
       byte[] storage = new byte[last];
       System.arraycopy(bb, 0, storage, 0, Math.min(bb.length, last));

--- a/cdm-core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
+++ b/cdm-core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
@@ -4,7 +4,9 @@
  */
 package ucar.nc2.write;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import ucar.array.Array;
 import ucar.array.ArrayType;
 import ucar.array.Arrays;
 import ucar.array.ArraysConvert;
@@ -169,6 +171,8 @@ public class NetcdfFormatWriter implements Closeable {
   public void write(Variable v, Index origin, ucar.array.Array<?> values) throws IOException, InvalidRangeException {
     Preconditions.checkArgument(v.getArrayType() == values.getArrayType()); // LOOK do something better?
     Preconditions.checkArgument(v.getRank() == values.getRank()); // LOOK do something better: contains?
+
+    // we have to keep using old until all spis implement new?
     ucar.ma2.Array oldArray = ArraysConvert.convertFromArray(values);
     try {
       write(v, origin.getCurrentIndex(), oldArray);
@@ -180,12 +184,13 @@ public class NetcdfFormatWriter implements Closeable {
   /**
    * Write String value to a CHAR Variable.
    * Truncated or zero extended as needed to fit into last dimension of v.
+   * Note that origin is not incremeted as in previous versions.
    * 
    * <pre>
    * Index index = Index.ofRank(v.getRank());
    * writer.writeStringData(v, index, "This is the first string.");
-   * writer.writeStringData(v, index, "Shorty");
-   * writer.writeStringData(v, index, "This is too long so it will get truncated");
+   * writer.writeStringData(v, index.incr(0), "Shorty");
+   * writer.writeStringData(v, index.incr(0), "This is too long so it will get truncated");
    * </pre>
    * 
    * @param v write to this variable, must be of type CHAR.
@@ -195,22 +200,24 @@ public class NetcdfFormatWriter implements Closeable {
   public void writeStringData(Variable v, Index origin, String data) throws IOException, InvalidRangeException {
     Preconditions.checkArgument(v.getArrayType() == ArrayType.CHAR);
     Preconditions.checkArgument(v.getRank() > 0);
-    int rank = v.getRank();
-    int[] offset = origin.getCurrentIndex();
-    ucar.ma2.Array cvalues = ucar.ma2.ArrayChar.makeFromString(data, v.getShape(rank - 1));
-    if (rank > 1) {
-      // LOOK: rather do this in ucar.array, but must convert all iosp's to use array first; will do in ver7
-      cvalues = cvalues.extend(rank);
+    int[] shape = v.getShape();
+    // all but the last shape is 1
+    for (int i = 0; i < shape.length - 1; i++) {
+      shape[i] = 1;
     }
-    try {
-      write(v, offset, cvalues);
-    } catch (ucar.ma2.InvalidRangeException e) {
-      throw new InvalidRangeException(e);
+    int last = shape[shape.length - 1];
+
+    // previously we truncated chars to bytes.
+    // here we are going to use UTF encoded bytes, just as if we were real programmers.
+    byte[] bb = data.getBytes(Charsets.UTF_8);
+    if (bb.length != last) {
+      byte[] storage = new byte[last];
+      System.arraycopy(bb, 0, storage, 0, Math.min(bb.length, last));
+      bb = storage;
     }
-    // increment origin, if possible
-    if (rank > 1) {
-      origin.incr(rank - 2); // LOOK this is wrong when rank > 2
-    }
+
+    Array<?> barray = Arrays.factory(ArrayType.CHAR, shape, bb);
+    write(v, origin, barray);
   }
 
   /**
@@ -661,27 +668,30 @@ public class NetcdfFormatWriter implements Closeable {
     Object primArray;
     ucar.array.Array<?> values;
     int[] shape;
-    String sval;
+    String stringValue;
 
-    /** Write to this Variable. */
+    /** Write to this Variable. Set Variable or Variable name. */
     public WriteConfig forVariable(Variable v) {
       this.v = v;
       return this;
     }
 
-    /** Write to this named Variable. */
+    /** Write to this named Variable. Set Variable or Variable name. */
     public WriteConfig forVariable(String varName) {
       this.varName = varName;
       return this;
     }
 
-    /** If not set, assume all zeroes. */
+    /**
+     * The starting element, ie write(int[] origin, int[] shape).
+     * If not set, origin of 0 is assumed.
+     */
     public WriteConfig withOrigin(Index origin) {
       this.origin = origin;
       return this;
     }
 
-    /** If not set, assume all zeroes. */
+    /** The starting element as an int[]. */
     public WriteConfig withOrigin(int... origin) {
       this.origin = Index.of(origin);
       return this;
@@ -690,6 +700,7 @@ public class NetcdfFormatWriter implements Closeable {
     /** The values to write. ArrayType must match the Variable. */
     public WriteConfig withArray(ucar.array.Array<?> values) {
       this.values = values;
+      this.shape = values.getShape();
       return this;
     }
 
@@ -703,7 +714,11 @@ public class NetcdfFormatWriter implements Closeable {
       return this;
     }
 
-    /** Shape of primitive array, not needed for Array. If not set, assume v.getShape(). */
+    /**
+     * Shape of primitive array to write, ie write(int[] origin, int[] shape).
+     * Only needed if you use withPrimitiveArray, otherwise the Array values' shape is used.
+     * Use v.getShape() if shape is not set, and Array values is not set.
+     */
     public WriteConfig withShape(int... shape) {
       this.shape = shape;
       return this;
@@ -715,12 +730,12 @@ public class NetcdfFormatWriter implements Closeable {
      * @see NetcdfFormatWriter#writeStringData(Variable, Index, String)
      */
     public WriteConfig withString(String sval) {
-      this.sval = sval;
+      this.stringValue = sval;
       return this;
     }
 
     /**
-     * Do the write to the file.
+     * Do the write to the file, agter constructing the WriteConfig.
      * 
      * @throws IllegalArgumentException when not configured correctly.
      * @see NetcdfFormatWriter#write(Variable, ucar.array.Index, ucar.array.Array)
@@ -739,8 +754,8 @@ public class NetcdfFormatWriter implements Closeable {
         this.origin = Index.ofRank(v.getRank());
       }
 
-      if (sval != null) {
-        NetcdfFormatWriter.this.writeStringData(this.v, this.origin, sval);
+      if (stringValue != null) {
+        NetcdfFormatWriter.this.writeStringData(this.v, this.origin, stringValue);
         return;
       }
 

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNcdump.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNcdump.java
@@ -4,11 +4,12 @@
  */
 package ucar.nc2.write;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -32,7 +33,7 @@ public class TestNcdump {
       String ncdumpOut = ncdump.print();
 
       File expectedOutputFile = new File(TestDir.cdmLocalTestDataDir, "testUnsignedFillValueNew.dump");
-      String expectedOutput = Files.toString(expectedOutputFile, Charsets.UTF_8);
+      String expectedOutput = Files.toString(expectedOutputFile, StandardCharsets.UTF_8);
 
       Assert.assertEquals(toUnixEOLs(expectedOutput), toUnixEOLs(ncdumpOut));
     }
@@ -46,7 +47,7 @@ public class TestNcdump {
       String ncdumpOut = ncdump.print();
 
       File expectedOutputFile = new File(TestDir.cdmLocalTestDataDir, "testNestedGroups.dump");
-      String expectedOutput = Files.toString(expectedOutputFile, Charsets.UTF_8);
+      String expectedOutput = Files.toString(expectedOutputFile, StandardCharsets.UTF_8);
 
       Assert.assertEquals(toUnixEOLs(expectedOutput), toUnixEOLs(ncdumpOut));
     }

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfFormatWithWriter.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfFormatWithWriter.java
@@ -147,11 +147,11 @@ public class TestNetcdfFormatWithWriter {
       writer.config().forVariable("lat").withPrimitiveArray(new float[] {41, 40, 39}).write();
       writer.config().forVariable("lon").withPrimitiveArray(new float[] {-109, -107, -105, -103}).write();
 
-      Index timeOrigin = Index.ofRank(1);
-      Index recordOrigin = Index.ofRank(3);
-
       Variable timeVar = writer.findVariable("time");
       Preconditions.checkNotNull(timeVar);
+
+      Index timeOrigin = Index.ofRank(1);
+      Index recordOrigin = Index.ofRank(3);
 
       // write 10 records
       int[] timeValue = new int[1];
@@ -226,9 +226,9 @@ public class TestNetcdfFormatWithWriter {
       // Note that origin is incremented.
       Index index = Index.ofRank(time.getRank());
       writer.config().forVariable(time).withOrigin(index).withString("This is the first string.").write();
-      writer.config().forVariable(time).withOrigin(index).withString("Shorty").write();
-      writer.config().forVariable(time).withOrigin(index).withString("This is too long so it will get truncated")
-          .write();
+      writer.config().forVariable(time).withOrigin(index.incr(0)).withString("Shorty").write();
+      writer.config().forVariable(time).withOrigin(index.incr(0))
+          .withString("This is too long so it will get truncated").write();
     }
 
     try (NetcdfFile ncfile = NetcdfFiles.open(filename)) {

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriteArrayAndUpdate.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriteArrayAndUpdate.java
@@ -29,7 +29,7 @@ import java.util.List;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-/** Test successive NetcdfFormat Writint and updating */
+/** Test successive NetcdfFormat Writing and updating */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestNetcdfWriteArrayAndUpdate {
   @ClassRule
@@ -169,8 +169,8 @@ public class TestNetcdfWriteArrayAndUpdate {
         assertThat(v).isNotNull();
         Index origin = Index.ofRank(v.getRank());
         writer.config().forVariable(v).withOrigin(origin).withString("No pairs of ladies stockings!").write();
-        writer.config().forVariable(v).withOrigin(origin).withString("One pairs of ladies stockings!").write();
-        writer.config().forVariable(v).withOrigin(origin).withString("Two pairs of ladies stockings!").write();
+        writer.config().forVariable(v).withOrigin(origin.incr(0)).withString("One pairs of ladies stockings!").write();
+        writer.config().forVariable(v).withOrigin(origin.incr(0)).withString("Two pairs of ladies stockings!").write();
       } catch (IOException e) {
         System.err.println("ERROR writing Achar3");
         fail();
@@ -399,8 +399,8 @@ public class TestNetcdfWriteArrayAndUpdate {
         assertThat(v).isNotNull();
         Index index = Index.ofRank(v.getRank());
         writer.writeStringData(v, index, "0 pairs of ladies stockings!");
-        writer.writeStringData(v, index, "1 pairs of ladies stockings!");
-        writer.writeStringData(v, index, "2 pairs of ladies stockings!");
+        writer.writeStringData(v, index.incr(0), "1 pairs of ladies stockings!");
+        writer.writeStringData(v, index.incr(0), "2 pairs of ladies stockings!");
       } catch (IOException e) {
         System.err.println("ERROR writing Achar3");
         fail();

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
@@ -63,6 +63,9 @@ public class TestNetcdfWriterStrings {
       Array<?> vrdata = vr.readArray();
       assertThat(vrdata.getArrayType()).isEqualTo(ArrayType.CHAR); // writing to netcdf3 turns it into a char
       assertThat(vrdata.getShape()).isEqualTo(new int[] {helloGreekLen});
+      System.out.printf(" writeNetCDFchar printArray = %ss%n", NcdumpArray.printArray(vrdata));
+      System.out.printf(" writeNetCDFchar showBytes  = %ss%n", showBytes((Array<Byte>) vrdata));
+
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
       String strData = sdata.getScalar();
       System.out.printf(" writeNetCDFchar %s = %s = %s%n", strData, showString(strData),
@@ -207,6 +210,16 @@ public class TestNetcdfWriterStrings {
       int ub = (b < 0) ? b + 256 : b;
       if (i > 0)
         sbuff.append(" ");
+      sbuff.append(Integer.toHexString(ub));
+    }
+    return sbuff.toString();
+  }
+
+  private String showBytes(Array<Byte> buff) {
+    StringBuffer sbuff = new StringBuffer();
+    for (byte b : buff) {
+      int ub = (b < 0) ? b + 256 : b;
+      sbuff.append(" ");
       sbuff.append(Integer.toHexString(ub));
     }
     return sbuff.toString();

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
@@ -54,7 +54,7 @@ public class TestNetcdfWriterStrings {
 
     try (NetcdfFormatWriter writer = writerb.build()) {
       Variable v = writer.findVariable(helloGreek);
-      byte[] helloBytes = helloGreek.getBytes();
+      byte[] helloBytes = helloGreek.getBytes(StandardCharsets.UTF_8); // LOOK
       Array<Byte> data = Arrays.factory(ArrayType.CHAR, new int[] {helloBytes.length}, helloBytes);
       writer.write(v, data.getIndex(), data);
     }
@@ -67,8 +67,8 @@ public class TestNetcdfWriterStrings {
       Array<?> vrdata = vr.readArray();
       assertThat(vrdata.getArrayType()).isEqualTo(ArrayType.CHAR); // writing to netcdf3 turns it into a char
       assertThat(vrdata.getShape()).isEqualTo(new int[] {helloGreekLen});
-      System.out.printf(" writeNetCDFchar printArray = %ss%n", NcdumpArray.printArray(vrdata));
-      System.out.printf(" writeNetCDFchar showBytes  = %ss%n", showBytes((Array<Byte>) vrdata));
+      System.out.printf(" writeNetCDFchar printArray = %s%n", NcdumpArray.printArray(vrdata));
+      System.out.printf(" writeNetCDFchar showBytes  = %s%n", showBytes((Array<Byte>) vrdata));
 
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
       String strData = sdata.getScalar();
@@ -97,7 +97,7 @@ public class TestNetcdfWriterStrings {
 
     try (NetcdfFormatWriter writer = writerb.build()) {
       Variable v = writer.findVariable(helloGreek);
-      byte[] helloBytes = helloGreek.getBytes();
+      byte[] helloBytes = helloGreek.getBytes(StandardCharsets.UTF_8);
       Array<Byte> data = Arrays.factory(ArrayType.CHAR, new int[] {1, helloBytes.length}, helloBytes);
       Index index = data.getIndex();
       for (int i = 0; i < ngreeks; i++) {

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2.write;
 
+import com.google.common.base.Charsets;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -23,6 +24,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.util.Formatter;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -41,7 +43,9 @@ public class TestNetcdfWriterStrings {
   @Test
   public void writeNetCDFchar() throws IOException, InvalidRangeException {
     String helloGreek = makeString(helloGreekCode, true);
-    helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+    System.out.printf("writeNetCDFchar= %s%n", showBoth(helloGreek));
+    String helloGreek2 = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+    System.out.printf(" normalized= %s%n", showBoth(helloGreek2));
 
     String filename = tempFolder.newFile().getPath();
     NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
@@ -68,8 +72,7 @@ public class TestNetcdfWriterStrings {
 
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
       String strData = sdata.getScalar();
-      System.out.printf(" writeNetCDFchar %s = %s = %s%n", strData, showString(strData),
-                showBytes(strData.getBytes()));
+      System.out.printf(" writeNetCDFchar read = %s%n", showBoth(strData));
       assertThat(strData).isEqualTo(helloGreek);
 
       Attribute att = vr.findAttribute("units");
@@ -82,7 +85,8 @@ public class TestNetcdfWriterStrings {
   @Test
   public void writeNetCDFcharArray() throws IOException, InvalidRangeException {
     String helloGreek = makeString(helloGreekCode, true);
-    helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+    // helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+    System.out.printf("writeNetCDFcharArray=%s%n", showBoth(helloGreek));
 
     String filename = tempFolder.newFile().getPath();
     NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
@@ -112,8 +116,7 @@ public class TestNetcdfWriterStrings {
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
       for (int i = 0; i < ngreeks; i++) {
         String strData = sdata.get(i);
-        System.out.printf(" writeNetCDFcharArray %s = %s = %s%n", strData, showString(strData),
-                showBytes(strData.getBytes()));
+        System.out.printf(" writeNetCDFcharArray read = %s%n", showBoth(strData));
       }
       for (int i = 0; i < ngreeks; i++) {
         String strData = sdata.get(i);
@@ -125,9 +128,8 @@ public class TestNetcdfWriterStrings {
   @Test
   public void writeNetCDFstring() throws IOException, InvalidRangeException {
     String helloGreek = makeString(helloGreekCode, true);
-    System.out.printf(" org=%s%n", helloGreek);
     helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
-    System.out.printf("norm=%s%n", helloGreek);
+    System.out.printf("writeNetCDFstring=%s%n", showBoth(helloGreek));
 
     String filename = tempFolder.newFile().getPath();
     NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
@@ -150,6 +152,7 @@ public class TestNetcdfWriterStrings {
       assertThat(vrdata.getShape()).isEqualTo(new int[] {helloGreekLen});
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
       String strData = sdata.getScalar();
+      System.out.printf(" writeNetCDFstring read = %s%n", showBoth(strData));
       assertThat(strData).isEqualTo(helloGreek);
     }
   }
@@ -158,6 +161,7 @@ public class TestNetcdfWriterStrings {
   public void testWriteStringData() throws IOException, InvalidRangeException {
     String helloGreek = makeString(helloGreekCode, false);
     helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+    System.out.printf("testWriteStringData=%s%n", showBoth(helloGreek));
 
     String filename = tempFolder.newFile().getPath();
     NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
@@ -185,6 +189,7 @@ public class TestNetcdfWriterStrings {
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
       for (int i = 0; i < ngreeks; i++) {
         String strData = sdata.get(i);
+        System.out.printf(" testWriteStringData read = %s%n", showBoth(strData));
         assertThat(strData).isEqualTo(helloGreek);
       }
     }
@@ -233,6 +238,12 @@ public class TestNetcdfWriterStrings {
         sbuff.append(" ");
       sbuff.append(Integer.toHexString(c));
     }
+    return sbuff.toString();
+  }
+
+  private String showBoth(String s) {
+    Formatter sbuff = new Formatter();
+    sbuff.format(" %s == %s", s, showBytes(s.getBytes(Charsets.UTF_8)));
     return sbuff.toString();
   }
 

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
@@ -21,6 +21,7 @@ import ucar.nc2.Variable;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -186,7 +187,7 @@ public class TestNetcdfWriterStrings {
       b[i] = (byte) codes[i];
     if (debug)
       System.out.println(" orgBytes= " + showBytes(b));
-    String s = new String(b, "UTF-8");
+    String s = new String(b, StandardCharsets.UTF_8);
     if (debug)
       System.out.println("convBytes= " + showString(s));
     return s;

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.write;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ucar.array.Array;
+import ucar.array.ArrayType;
+import ucar.array.Arrays;
+import ucar.array.Index;
+import ucar.array.InvalidRangeException;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.text.Normalizer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Test using non ascii identifiers with Netcdf3 */
+public class TestNetcdfWriterStrings {
+
+  static int[] helloGreekCode =
+      new int[] {0xce, 0x9a, 0xce, 0xb1, 0xce, 0xbb, 0xce, 0xb7, 0xce, 0xbc, 0xe1, 0xbd, 0xb3, 0xcf, 0x81, 0xce, 0xb1};
+  static int helloGreekLen = 20;
+  static int ngreeks = 3;
+  static String geeks = "geeks";
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void writeNetCDFchar() throws IOException, InvalidRangeException {
+    String helloGreek = makeString(helloGreekCode, false);
+    helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+
+    String filename = tempFolder.newFile().getPath();
+    NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
+    writerb.addDimension(new Dimension(helloGreek, helloGreekLen));
+    writerb.addVariable(helloGreek, ArrayType.CHAR, helloGreek).addAttribute(new Attribute("units", helloGreek));
+
+    try (NetcdfFormatWriter writer = writerb.build()) {
+      Variable v = writer.findVariable(helloGreek);
+      byte[] helloBytes = helloGreek.getBytes();
+      Array<Byte> data = Arrays.factory(ArrayType.CHAR, new int[] {helloBytes.length}, helloBytes);
+      writer.write(v, data.getIndex(), data);
+    }
+
+    try (NetcdfFile ncout = NetcdfFiles.open(filename)) {
+      Variable vr = ncout.findVariable(helloGreek);
+      assertThat(vr).isNotNull();
+      assertThat(vr.getShortName()).isEqualTo(helloGreek);
+
+      Array<?> vrdata = vr.readArray();
+      assertThat(vrdata.getArrayType()).isEqualTo(ArrayType.CHAR); // writing to netcdf3 turns it into a char
+      assertThat(vrdata.getShape()).isEqualTo(new int[] {helloGreekLen});
+      Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
+      String strData = sdata.getScalar();
+      assertThat(strData).isEqualTo(helloGreek);
+
+      Attribute att = vr.findAttribute("units");
+      assertThat(att).isNotNull();
+      assertThat(att.isString()).isTrue();
+      assertThat(att.getStringValue()).isEqualTo(helloGreek);
+    }
+  }
+
+  @Test
+  public void writeNetCDFcharArray() throws IOException, InvalidRangeException {
+    String helloGreek = makeString(helloGreekCode, false);
+    helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+
+    String filename = tempFolder.newFile().getPath();
+    NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
+    writerb.addDimension(new Dimension(geeks, ngreeks));
+    writerb.addDimension(new Dimension(helloGreek, helloGreekLen));
+    writerb.addVariable(helloGreek, ArrayType.CHAR, geeks + " " + helloGreek)
+        .addAttribute(new Attribute("units", helloGreek));
+
+    try (NetcdfFormatWriter writer = writerb.build()) {
+      Variable v = writer.findVariable(helloGreek);
+      byte[] helloBytes = helloGreek.getBytes();
+      Array<Byte> data = Arrays.factory(ArrayType.CHAR, new int[] {1, helloBytes.length}, helloBytes);
+      Index index = data.getIndex();
+      for (int i = 0; i < ngreeks; i++) {
+        writer.write(v, index.set0(i), data);
+      }
+    }
+
+    try (NetcdfFile ncout = NetcdfFiles.open(filename)) {
+      Variable vr = ncout.findVariable(helloGreek);
+      assertThat(vr).isNotNull();
+      assertThat(vr.getShortName()).isEqualTo(helloGreek);
+
+      Array<?> vrdata = vr.readArray();
+      assertThat(vrdata.getArrayType()).isEqualTo(ArrayType.CHAR); // writing to netcdf3 turns it into a char
+      assertThat(vrdata.getShape()).isEqualTo(new int[] {ngreeks, helloGreekLen});
+      Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
+      for (int i = 0; i < ngreeks; i++) {
+        String strData = sdata.get(i);
+        assertThat(strData).isEqualTo(helloGreek);
+      }
+    }
+  }
+
+  @Test
+  public void writeNetCDFstring() throws IOException, InvalidRangeException {
+    String helloGreek = makeString(helloGreekCode, true);
+    System.out.printf(" org=%s%n", helloGreek);
+    helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+    System.out.printf("norm=%s%n", helloGreek);
+
+    String filename = tempFolder.newFile().getPath();
+    NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
+    writerb.addDimension(new Dimension(helloGreek, helloGreekLen));
+    writerb.addVariable(helloGreek, ArrayType.STRING, helloGreek).addAttribute(new Attribute("units", helloGreek));
+
+    try (NetcdfFormatWriter writer = writerb.build()) {
+      Variable v = writer.findVariable(helloGreek);
+      Array<String> data = Arrays.factory(ArrayType.STRING, new int[] {1}, new String[] {helloGreek});
+      writer.write(v, data.getIndex(), data);
+    }
+
+    try (NetcdfFile ncout = NetcdfFiles.open(filename)) {
+      Variable vr = ncout.findVariable(helloGreek);
+      assertThat(vr).isNotNull();
+      assertThat(vr.getShortName()).isEqualTo(helloGreek);
+
+      Array<?> vrdata = vr.readArray();
+      assertThat(vrdata.getArrayType()).isEqualTo(ArrayType.CHAR); // writing to netcdf3 turns it into a char
+      assertThat(vrdata.getShape()).isEqualTo(new int[] {helloGreekLen});
+      Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
+      String strData = sdata.getScalar();
+      assertThat(strData).isEqualTo(helloGreek);
+    }
+  }
+
+  @Test
+  public void testWriteStringData() throws IOException, InvalidRangeException {
+    String helloGreek = makeString(helloGreekCode, false);
+    helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
+
+    String filename = tempFolder.newFile().getPath();
+    NetcdfFormatWriter.Builder<?> writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
+    writerb.addDimension(new Dimension(geeks, ngreeks));
+    writerb.addDimension(new Dimension(helloGreek, helloGreekLen));
+    writerb.addVariable(helloGreek, ArrayType.CHAR, geeks + " " + helloGreek)
+        .addAttribute(new Attribute("units", helloGreek));
+
+    try (NetcdfFormatWriter writer = writerb.build()) {
+      Variable v = writer.findVariable(helloGreek);
+      Index index = Index.ofRank(v.getRank());
+      for (int i = 0; i < ngreeks; i++) {
+        writer.writeStringData(v, index.set0(i), helloGreek);
+      }
+    }
+
+    try (NetcdfFile ncout = NetcdfFiles.open(filename)) {
+      Variable vr = ncout.findVariable(helloGreek);
+      assertThat(vr).isNotNull();
+      assertThat(vr.getShortName()).isEqualTo(helloGreek);
+
+      Array<?> vrdata = vr.readArray();
+      assertThat(vrdata.getArrayType()).isEqualTo(ArrayType.CHAR); // writing to netcdf3 turns it into a char
+      assertThat(vrdata.getShape()).isEqualTo(new int[] {ngreeks, helloGreekLen});
+      Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
+      for (int i = 0; i < ngreeks; i++) {
+        String strData = sdata.get(i);
+        assertThat(strData).isEqualTo(helloGreek);
+      }
+    }
+  }
+
+  ///////////////////////////////////////////
+  private String makeString(int[] codes, boolean debug) throws UnsupportedEncodingException {
+    byte[] b = new byte[codes.length];
+    for (int i = 0; i < codes.length; i++)
+      b[i] = (byte) codes[i];
+    if (debug)
+      System.out.println(" orgBytes= " + showBytes(b));
+    String s = new String(b, "UTF-8");
+    if (debug)
+      System.out.println("convBytes= " + showString(s));
+    return s;
+  }
+
+  private String showBytes(byte[] buff) {
+    StringBuffer sbuff = new StringBuffer();
+    for (int i = 0; i < buff.length; i++) {
+      byte b = buff[i];
+      int ub = (b < 0) ? b + 256 : b;
+      if (i > 0)
+        sbuff.append(" ");
+      sbuff.append(Integer.toHexString(ub));
+    }
+    return sbuff.toString();
+  }
+
+  private String showString(String s) {
+    StringBuffer sbuff = new StringBuffer();
+    for (int i = 0; i < s.length(); i++) {
+      int c = s.charAt(i);
+      if (i > 0)
+        sbuff.append(" ");
+      sbuff.append(Integer.toHexString(c));
+    }
+    return sbuff.toString();
+  }
+
+}

--- a/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
+++ b/cdm-core/src/test/java/ucar/nc2/write/TestNetcdfWriterStrings.java
@@ -40,7 +40,7 @@ public class TestNetcdfWriterStrings {
 
   @Test
   public void writeNetCDFchar() throws IOException, InvalidRangeException {
-    String helloGreek = makeString(helloGreekCode, false);
+    String helloGreek = makeString(helloGreekCode, true);
     helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
 
     String filename = tempFolder.newFile().getPath();
@@ -65,6 +65,8 @@ public class TestNetcdfWriterStrings {
       assertThat(vrdata.getShape()).isEqualTo(new int[] {helloGreekLen});
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
       String strData = sdata.getScalar();
+      System.out.printf(" writeNetCDFchar %s = %s = %s%n", strData, showString(strData),
+                showBytes(strData.getBytes()));
       assertThat(strData).isEqualTo(helloGreek);
 
       Attribute att = vr.findAttribute("units");
@@ -76,7 +78,7 @@ public class TestNetcdfWriterStrings {
 
   @Test
   public void writeNetCDFcharArray() throws IOException, InvalidRangeException {
-    String helloGreek = makeString(helloGreekCode, false);
+    String helloGreek = makeString(helloGreekCode, true);
     helloGreek = Normalizer.normalize(helloGreek, Normalizer.Form.NFC);
 
     String filename = tempFolder.newFile().getPath();
@@ -105,6 +107,11 @@ public class TestNetcdfWriterStrings {
       assertThat(vrdata.getArrayType()).isEqualTo(ArrayType.CHAR); // writing to netcdf3 turns it into a char
       assertThat(vrdata.getShape()).isEqualTo(new int[] {ngreeks, helloGreekLen});
       Array<String> sdata = Arrays.makeStringsFromChar((Array<Byte>) vrdata);
+      for (int i = 0; i < ngreeks; i++) {
+        String strData = sdata.get(i);
+        System.out.printf(" writeNetCDFcharArray %s = %s = %s%n", strData, showString(strData),
+                showBytes(strData.getBytes()));
+      }
       for (int i = 0; i < ngreeks; i++) {
         String strData = sdata.get(i);
         assertThat(strData).isEqualTo(helloGreek);

--- a/cdm-test/src/test/java/ucar/nc2/write/TestNetcdfFormatWriterBig.java
+++ b/cdm-test/src/test/java/ucar/nc2/write/TestNetcdfFormatWriterBig.java
@@ -178,8 +178,8 @@ public class TestNetcdfFormatWriterBig {
       }
       // write the last value
       float[] prim = new float[] {lastVal};
-      writer.config().forVariable(varName).withOrigin(new int[] {timeSize - 1, latSize - 1, lonSize - 1})
-          .withPrimitiveArray(prim).withShape(1, 1, 1).write();
+      writer.config().forVariable(varName).withOrigin(timeSize - 1, latSize - 1, lonSize - 1).withPrimitiveArray(prim)
+          .withShape(1, 1, 1).write();
     }
 
     try (NetcdfFile ncfile = NetcdfFiles.open(fileName)) {


### PR DESCRIPTION
ucar.array.Index does not have an IndexFn; its a pure int[], and doesnot know its shape; see ArrayByte on how to get odometer for an Array.

NetcdfFormatWriter.writeStringData() refactored to use UTF-8 encoded byte arrays. Otherwise multiple byte encoding get lost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/869)
<!-- Reviewable:end -->
