### PR TITLE
Time coordinate values must use Longs, not Integers.

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
 package ucar.nc2.grib;
 
 import org.junit.*;
@@ -248,6 +252,7 @@ public class TestGribIndexCreation {
 
   @Test
   @Category(NeedsCdmUnitTest.class)
+  @Ignore("too slow")
   public void testRdvamds083p2() throws IOException {
     Grib.setDebugFlags(DebugFlags.create("Grib/debugGbxIndexOnly"));
     FeatureCollectionConfig config = new FeatureCollectionConfig("ds083.2_Aggregation", "test/ds083.2",
@@ -428,8 +433,25 @@ public class TestGribIndexCreation {
   public void createGEFSmembers() throws IOException {
     Grib.setDebugFlags(DebugFlags.create("Grib/debugGbxIndexOnly"));
     FeatureCollectionConfig config = new FeatureCollectionConfig("GEFS-Global_1p0deg_Ensemble-members",
-        "test/GEFSmembners", FeatureCollectionType.GRIB2,
+        "test/GEFSmembers", FeatureCollectionType.GRIB2,
         TestDir.cdmUnitTestDir + "ncss/GEFS/Global_1p0deg_Ensemble/member/.*gbx9", null, null, null, "directory", null);
+    System.out.printf("Create %s %s index for = %s%n", config.collectionName, config.ptype, config.spec);
+
+    GribCdmIndex.updateGribCollection(config, always, logger);
+    Grib.setDebugFlags(DebugFlags.create(""));
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void createDewpointTempFromGsdHrrrrConus3surface() throws IOException {
+    Grib.setDebugFlags(DebugFlags.create("Grib/debugGbxIndexOnly"));
+    String dataset = TestDir.cdmUnitTestDir + "gribCollections/hrrr/DewpointTempFromGsdHrrrrConus3surface.grib2";
+
+    // ${cdmUnitTest}/gribCollections/hrrr/DewpointTempFromGsdHrrrrConus3surface.grib2
+    FeatureCollectionConfig config =
+        new FeatureCollectionConfig("DewpointTempFromGsdHrrrrConus3surface", "test/hrrr", FeatureCollectionType.GRIB2,
+            TestDir.cdmUnitTestDir + "gribCollections/hrrr/DewpointTempFromGsdHrrrrConus3surface.grib2", null, null,
+            null, "file", null);
     System.out.printf("Create %s %s index for = %s%n", config.collectionName, config.ptype, config.spec);
 
     GribCdmIndex.updateGribCollection(config, always, logger);

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreationOther.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreationOther.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
 package ucar.nc2.grib;
 
 import org.junit.AfterClass;
@@ -15,8 +19,11 @@ import ucar.nc2.util.DebugFlags;
 import ucar.nc2.internal.cache.FileCache;
 import ucar.nc2.internal.cache.FileCacheIF;
 import ucar.unidata.io.RandomAccessFile;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.category.NeedsRdaData;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.Slow;
+
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Formatter;
@@ -25,7 +32,7 @@ import java.util.Formatter;
  * Test that the CDM Index Creation works on other Grib collections.
  * TODO: add other collections to unit tests as needed.
  */
-@Ignore("too long")
+@Category({NeedsCdmUnitTest.class, Slow.class})
 public class TestGribIndexCreationOther {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribNcepIndexCreation.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribNcepIndexCreation.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
 package ucar.nc2.grib;
 
 import org.junit.AfterClass;

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribNcepVer7IndexCreation.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribNcepVer7IndexCreation.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
 package ucar.nc2.grib;
 
 import org.junit.AfterClass;

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2CollectionBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2CollectionBuilder.java
@@ -289,8 +289,9 @@ class Grib2CollectionBuilder extends GribCollectionBuilder {
         CoordinateTime2D.Builder2 builder2D = new CoordinateTime2D.Builder2(isTimeInterval, cust, vb.timeUnit, code);
         coordNBuilder.addBuilder(builder2D);
 
-        if (vb.first.getPDS().isEnsemble())
+        if (vb.first.getPDS().isEnsemble()) {
           coordNBuilder.addBuilder(new CoordinateEns.Builder2(0));
+        }
 
         VertCoordType vertUnit = cust.getVertUnit(pdsFirst.getLevelType1());
         if (vertUnit.isVerticalCoordinate())
@@ -298,8 +299,9 @@ class Grib2CollectionBuilder extends GribCollectionBuilder {
               new CoordinateVert.Builder2(pdsFirst.getLevelType1(), cust.getVertUnit(pdsFirst.getLevelType1())));
 
         // populate the coordinates with the inventory of data
-        for (Grib2Record gr : vb.atomList)
+        for (Grib2Record gr : vb.atomList) {
           coordNBuilder.addRecord(gr);
+        }
 
         // done, build coordinates and sparse array indicating which records to use
         vb.coordND = coordNBuilder.finish(vb.atomList, info);

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionBuilderFromIndex.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionBuilderFromIndex.java
@@ -377,12 +377,14 @@ abstract class GribCollectionBuilderFromIndex {
         return new CoordinateRuntime(pc.getMsecsList(), cdUnit.getCalendarPeriod());
 
       case time:
-        List<Integer> offs = new ArrayList<>(pc.getValuesCount());
-        for (float val : pc.getValuesList())
-          offs.add((int) val);
+        List<Long> offs = new ArrayList<>(pc.getValuesCount());
+        for (float val : pc.getValuesList()) {
+          offs.add((long) val);
+        }
         CalendarDate refDate = CalendarDate.of(pc.getMsecs(0));
-        if (unit == null)
+        if (unit == null) {
           throw new IllegalStateException("Null units");
+        }
         CalendarPeriod timeUnit = CalendarPeriod.of(unit);
         return new CoordinateTime(code, timeUnit, refDate, offs, readTime2Runtime(pc));
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionWriter.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionWriter.java
@@ -86,13 +86,16 @@ class GribCollectionWriter {
     b.setCode(coord.getCode());
     b.setUnit(coord.getTimeUnit().toString());
     b.addMsecs(coord.getRefDate().getMillisFromEpoch());
-    for (Integer offset : coord.getOffsetSorted())
+    for (Long offset : coord.getOffsetSorted()) {
       b.addValues(offset);
+    }
 
     int[] time2runtime = coord.getTime2runtime();
-    if (time2runtime != null)
-      for (int val : time2runtime)
+    if (time2runtime != null) {
+      for (int val : time2runtime) {
         b.addTime2Runtime(val);
+      }
+    }
 
     return b.build();
   }

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
@@ -559,7 +559,7 @@ class GribIospBuilder {
         for (int runIdx = 0; runIdx < nruns; runIdx++) {
           CoordinateTime coordTime = (CoordinateTime) time2D.getTimeCoordinate(runIdx);
           int timeIdx = 0;
-          for (int val : coordTime.getOffsetSorted()) {
+          for (long val : coordTime.getOffsetSorted()) {
             data[runIdx * ntimes + timeIdx] = timeUnit.getValue() * val + time2D.getOffset(runIdx);
             timeIdx++;
           }
@@ -570,7 +570,7 @@ class GribIospBuilder {
         count = 0;
         for (int runIdx = 0; runIdx < nruns; runIdx++) {
           CoordinateTime coordTime = (CoordinateTime) time2D.getTimeCoordinate(runIdx);
-          for (int val : coordTime.getOffsetSorted()) {
+          for (long val : coordTime.getOffsetSorted()) {
             data[count++] = timeUnit.getValue() * val + time2D.getOffset(runIdx);
           }
         }
@@ -673,7 +673,7 @@ class GribIospBuilder {
     int count = 0;
 
     // coordinate values
-    for (int val : coordTime.getOffsetSorted()) {
+    for (long val : coordTime.getOffsetSorted()) {
       data[count++] = val;
     }
     v.setSourceData(Arrays.factory(ArrayType.DOUBLE, new int[] {ntimes}, data));
@@ -853,8 +853,7 @@ class GribIospBuilder {
     } else {
       int count = 0;
       for (Object val : offsets) {
-        Integer off = (Integer) val;
-        midpoints[count++] = off; // int ??
+        midpoints[count++] = (Long) val;
       }
     }
     v.setSourceData(Arrays.factory(ArrayType.DOUBLE, new int[] {n}, midpoints));
@@ -926,7 +925,7 @@ class GribIospBuilder {
           CoordinateTime timeCoord = (CoordinateTime) time2D.getRegularTimeCoordinateFromMinuteOfDay(minutes);
           // may be uneven number of values for each hour
           int count = offsetidx * noffsets;
-          for (Integer offset : timeCoord.getOffsetSorted()) {
+          for (Long offset : timeCoord.getOffsetSorted()) {
             midpoints[count++] = offset;
           }
           offsetidx++;

--- a/grib/src/main/java/ucar/nc2/grib/collection/PartitionCollectionImmutable.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/PartitionCollectionImmutable.java
@@ -623,7 +623,7 @@ public abstract class PartitionCollectionImmutable extends GribCollectionImmutab
 
           CoordinateTime2D.Time2D wholeVal2D = compCoord2D.isTimeInterval()
               ? new CoordinateTime2D.Time2D(wholeCoord1Dtime.getRefDate(), null, (TimeCoordIntvValue) wholeVal1D)
-              : new CoordinateTime2D.Time2D(wholeCoord1Dtime.getRefDate(), (Integer) wholeVal1D, null);
+              : new CoordinateTime2D.Time2D(wholeCoord1Dtime.getRefDate(), (Long) wholeVal1D, null);
 
           resultIdx = compCoord2D.matchTimeCoordinate(runtimeIdxPart, wholeVal2D);
           // if (resultIdx < 0) resultIdx = compCoord2D.matchTimeCoordinate(runtimeIdxPart, wholeVal,

--- a/grib/src/main/java/ucar/nc2/grib/collection/Time2DLazyCoordinate.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Time2DLazyCoordinate.java
@@ -104,7 +104,7 @@ class Time2DLazyCoordinate {
         for (int runIdx = 0; runIdx < nruns; runIdx++) {
           CoordinateTime coordTime = (CoordinateTime) time2D.getTimeCoordinate(runIdx);
           int timeIdx = 0;
-          for (int val : coordTime.getOffsetSorted()) {
+          for (long val : coordTime.getOffsetSorted()) {
             data[runIdx * ntimes + timeIdx] = timeUnit.getValue() * val + time2D.getOffset(runIdx);
             timeIdx++;
           }
@@ -115,7 +115,7 @@ class Time2DLazyCoordinate {
         count = 0;
         for (int runIdx = 0; runIdx < nruns; runIdx++) {
           CoordinateTime coordTime = (CoordinateTime) time2D.getTimeCoordinate(runIdx);
-          for (int val : coordTime.getOffsetSorted()) {
+          for (long val : coordTime.getOffsetSorted()) {
             data[count++] = timeUnit.getValue() * val + time2D.getOffset(runIdx);
           }
         }

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateBuilderImpl.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateBuilderImpl.java
@@ -4,6 +4,8 @@
  */
 package ucar.nc2.grib.coord;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.*;
 
 /**
@@ -21,21 +23,37 @@ public abstract class CoordinateBuilderImpl<T> implements CoordinateBuilder<T> {
   @Override
   public void addRecord(T gr) {
     Object val = extract(gr);
+    testCoord(ImmutableList.of(val));
     valSet.add(val);
   }
 
   @Override
   public void addAll(Coordinate coord) {
+    testCoord(coord.getValues());
     valSet.addAll(coord.getValues());
   }
 
   public void add(Object val) {
+    testCoord(ImmutableList.of(val));
     valSet.add(val);
   }
 
   @Override
   public void addAll(List<Object> coords) {
+    testCoord(coords);
     valSet.addAll(coords);
+  }
+
+  private boolean testCoord(List<?> vals) {
+    boolean ok = true;
+    for (Object val : vals) {
+      if (!(val instanceof Long) && !(val instanceof TimeCoordIntvValue) && !(val instanceof CoordinateTime2D.Time2D)
+          && !(val instanceof VertCoordValue) && !(val instanceof EnsCoordValue)) {
+        System.out.printf("HEY");
+        throw new IllegalArgumentException();
+      }
+    }
+    return ok;
   }
 
   @Override

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateRuntime.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.grib.coord;
@@ -308,8 +308,9 @@ public class CoordinateRuntime implements Coordinate {
     @Override
     public Coordinate makeCoordinate(List<Object> values) {
       List<Long> runtimeSorted = new ArrayList<>(values.size());
-      for (Object val : values)
+      for (Object val : values) {
         runtimeSorted.add((Long) val);
+      }
       Collections.sort(runtimeSorted);
       return new CoordinateRuntime(runtimeSorted, timeUnit);
     }

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.grib.coord;
@@ -37,9 +37,9 @@ import java.util.List;
 public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate {
   private static final Logger logger = LoggerFactory.getLogger(CoordinateTime.class);
 
-  private final List<Integer> offsetSorted;
+  private final List<Long> offsetSorted;
 
-  public CoordinateTime(int code, CalendarPeriod timeUnit, CalendarDate refDate, List<Integer> offsetSorted,
+  public CoordinateTime(int code, CalendarPeriod timeUnit, CalendarDate refDate, List<Long> offsetSorted,
       int[] time2runtime) {
     super(code, timeUnit, refDate, time2runtime);
     this.offsetSorted = Collections.unmodifiableList(offsetSorted);
@@ -50,7 +50,7 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
     this.offsetSorted = org.getOffsetSorted();
   }
 
-  public List<Integer> getOffsetSorted() {
+  public List<Long> getOffsetSorted() {
     return offsetSorted;
   }
 
@@ -61,7 +61,7 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
 
   @Override
   public int getIndex(Object val) {
-    return Collections.binarySearch(offsetSorted, (Integer) val);
+    return Collections.binarySearch(offsetSorted, (Long) val);
   }
 
   @Override
@@ -95,18 +95,21 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
   @Override
   public void showInfo(Formatter info, Indent indent) {
     info.format("%s%s:", indent, getType());
-    for (Integer cd : offsetSorted)
+    for (Long cd : offsetSorted) {
       info.format(" %3d,", cd);
+    }
     info.format(" (%d) %n", offsetSorted.size());
-    if (time2runtime != null)
+    if (time2runtime != null) {
       info.format("%stime2runtime: %s", indent, Arrays.toString(time2runtime));
+    }
   }
 
   @Override
   public void showCoords(Formatter info) {
     info.format("Time offsets: (%s) ref=%s %n", getTimeUnit(), getRefDate());
-    for (Integer cd : offsetSorted)
+    for (Long cd : offsetSorted) {
       info.format("   %3d%n", cd);
+    }
   }
 
   @Override
@@ -114,9 +117,9 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
     Counters counters = new Counters();
     counters.add("resol");
 
-    List<Integer> offsets = getOffsetSorted();
+    List<Long> offsets = getOffsetSorted();
     for (int i = 0; i < offsets.size() - 1; i++) {
-      int diff = offsets.get(i + 1) - offsets.get(i);
+      long diff = offsets.get(i + 1) - offsets.get(i);
       counters.count("resol", diff);
     }
 
@@ -125,17 +128,18 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
+    if (this == o) {
       return true;
-    if (o == null || getClass() != o.getClass())
+    }
+    if (o == null || getClass() != o.getClass()) {
       return false;
+    }
 
     CoordinateTime that = (CoordinateTime) o;
-
-    if (code != that.code)
+    if (code != that.code) {
       return false;
+    }
     return offsetSorted.equals(that.offsetSorted);
-
   }
 
   @Override
@@ -146,7 +150,7 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
   }
 
   protected CoordinateTimeAbstract makeBestFromComplete(int[] best, int n) {
-    List<Integer> offsetSortedBest = new ArrayList<>(offsetSorted.size());
+    List<Long> offsetSortedBest = new ArrayList<>(offsetSorted.size());
     int[] time2runtimeBest = new int[n];
     int count = 0;
     for (int i = 0; i < best.length; i++) {
@@ -157,7 +161,6 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
         count++;
       }
     }
-
     return new CoordinateTime(code, timeUnit, refDate, offsetSortedBest, time2runtimeBest);
   }
 
@@ -186,13 +189,12 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
       int offset = pds.getForecastTime();
       int tuInRecord = pds.getTimeUnit();
       if (tuInRecord == code) {
-        return offset;
-
+        return (long) offset;
       } else {
         CalendarPeriod period = Grib2Utils.getCalendarPeriod(tuInRecord);
         if (period == null) {
           logger.warn("Cant find period for time unit=" + tuInRecord);
-          return offset;
+          return (long) offset;
         }
         CalendarDate validDate = refDate.add(offset, period);
         // timeUnit.getOffset(refDate, validDate);
@@ -202,9 +204,9 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
 
     @Override
     public Coordinate makeCoordinate(List<Object> values) {
-      List<Integer> offsetSorted = new ArrayList<>(values.size());
+      List<Long> offsetSorted = new ArrayList<>(values.size());
       for (Object val : values) {
-        offsetSorted.add((Integer) val);
+        offsetSorted.add((Long) val);
       }
       Collections.sort(offsetSorted);
       return new CoordinateTime(code, timeUnit, refDate, offsetSorted, null);
@@ -232,25 +234,23 @@ public class CoordinateTime extends CoordinateTimeAbstract implements Coordinate
       int offset = ptime.getForecastTime();
       int tuInRecord = pds.getTimeUnit();
       if (tuInRecord == code) {
-        return offset;
-
+        return (long) offset;
       } else {
         CalendarDate validDate = GribUtils.getValidTime(refDate, tuInRecord, offset);
         // timeUnit.getOffset(refDate, validDate);
         return validDate.since(refDate, timeUnit);
       }
-
     }
 
     @Override
     public Coordinate makeCoordinate(List<Object> values) {
-      List<Integer> offsetSorted = new ArrayList<>(values.size());
-      for (Object val : values)
-        offsetSorted.add((Integer) val);
+      List<Long> offsetSorted = new ArrayList<>(values.size());
+      for (Object val : values) {
+        offsetSorted.add((Long) val);
+      }
       Collections.sort(offsetSorted);
       return new CoordinateTime(code, timeUnit, refDate, offsetSorted, null);
     }
   }
-
 
 }

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime2D.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime2D.java
@@ -1,8 +1,7 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
-
 package ucar.nc2.grib.coord;
 
 import javax.annotation.Nonnull;
@@ -53,7 +52,7 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
   private final CoordinateTimeAbstract otime; // orthogonal time coordinates - only when isOrthogonal
   // only when isRegular: <minute of day, time coordinate>
   private final SortedMap<Integer, CoordinateTimeAbstract> regTimes;
-  private final int[] offset; // list all offsets from the base/first runtime, length nruns, units ?
+  private final long[] offset; // list all offsets from the base/first runtime, length nruns, units ?
 
   private final boolean isRegular; // offsets are the same for each "runtime minute of day"
   private final boolean isOrthogonal; // offsets same for all runtimes, so 2d time array is (runtime X otime)
@@ -85,8 +84,9 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
     this.isTimeInterval = times.get(0) instanceof CoordinateTimeIntv;
 
     int nmax = 0;
-    for (Coordinate time : times)
+    for (Coordinate time : times) {
       nmax = Math.max(nmax, time.getSize());
+    }
     this.ntimes = nmax;
     this.nruns = runtime.getSize();
     assert nruns == times.size();
@@ -154,8 +154,9 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
     // regList may have different lengths
     int nmax = 0;
-    for (Coordinate time : regList)
+    for (Coordinate time : regList) {
       nmax = Math.max(nmax, time.getSize());
+    }
     this.ntimes = nmax;
 
     // make the offset map
@@ -172,10 +173,9 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
     this.vals = (vals == null) ? null : Collections.unmodifiableList(vals);
   }
 
-  // LOOK do we need long?
-  private int[] makeOffsets(List<Coordinate> orgTimes) {
+  private long[] makeOffsets(List<Coordinate> orgTimes) {
     CalendarDate firstDate = runtime.getFirstDate();
-    int[] offsets = new int[nruns];
+    long[] offsets = new long[nruns];
     for (int idx = 0; idx < nruns; idx++) {
       CoordinateTimeAbstract coordTime = (CoordinateTimeAbstract) orgTimes.get(idx);
       CalendarPeriod period = coordTime.getTimeUnit(); // LOOK are we assuming all have same period ??
@@ -185,12 +185,11 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
     return offsets;
   }
 
-  // LOOK do we need long?
-  private int[] makeOffsets(CalendarPeriod period) {
+  private long[] makeOffsets(CalendarPeriod period) {
     CalendarDate firstDate = runtime.getFirstDate();
-    int[] offsets = new int[nruns];
+    long[] offsets = new long[nruns];
     for (int idx = 0; idx < nruns; idx++) {
-      offsets[idx] = (int) runtime.getRuntimeDate(idx).since(firstDate, period); // LOOK possible loss of precision
+      offsets[idx] = runtime.getRuntimeDate(idx).since(firstDate, period); // LOOK possible loss of precision
       // offsets[idx] = period.getOffset(firstDate, runtime.getRuntimeDate(idx)); // LOOK possible loss of precision
     }
     return offsets;
@@ -199,9 +198,9 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
   @Override
   public CoordinateTimeAbstract setName(String name) {
     super.setName(name);
-    if (isOrthogonal())
+    if (isOrthogonal()) {
       otime.setName(name);
-    else if (isRegular()) {
+    } else if (isRegular()) {
       for (CoordinateTimeAbstract time : regTimes.values()) {
         time.setName(name);
       }
@@ -239,7 +238,7 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
     return nruns;
   }
 
-  public int getOffset(int runIndex) {
+  public long getOffset(int runIndex) {
     return offset[runIndex];
   }
 
@@ -288,23 +287,21 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
   public void showCoords(Formatter info) {
     info.format("%s runtime=%s nruns=%d ntimes=%d isOrthogonal=%s isRegular=%s%n", name, runtime.getName(), nruns,
         ntimes, isOrthogonal, isRegular);
-    // runtime.showCoords(info);
 
-    if (isOrthogonal)
+    if (isOrthogonal) {
       otime.showCoords(info);
-
-    else if (isRegular)
+    } else if (isRegular) {
       for (int minute : regTimes.keySet()) {
         CoordinateTimeAbstract timeCoord = regTimes.get(minute);
         String hourS = String.format("%d:%2d", minute / 60, minute % 60);
         info.format("hour %s: ", hourS);
         timeCoord.showInfo(info, new Indent(0));
       }
-
-    else
+    } else {
       for (Coordinate time : times) {
         time.showCoords(info);
       }
+    }
   }
 
   @Override
@@ -372,26 +369,33 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
+    if (this == o) {
       return true;
-    if (o == null || getClass() != o.getClass())
+    }
+    if (o == null || getClass() != o.getClass()) {
       return false;
+    }
 
     CoordinateTime2D that = (CoordinateTime2D) o;
-    if (isTimeInterval != that.isTimeInterval)
+    if (isTimeInterval != that.isTimeInterval) {
       return false;
-    if (!runtime.equals(that.runtime))
+    }
+    if (!runtime.equals(that.runtime)) {
       return false;
-    if (isOrthogonal != that.isOrthogonal)
+    }
+    if (isOrthogonal != that.isOrthogonal) {
       return false;
-    if (isRegular != that.isRegular)
+    }
+    if (isRegular != that.isRegular) {
       return false;
-    if (!Objects.equals(otime, that.otime))
+    }
+    if (!Objects.equals(otime, that.otime)) {
       return false;
-    if (!Objects.equals(regTimes, that.regTimes))
+    }
+    if (!Objects.equals(regTimes, that.regTimes)) {
       return false;
+    }
     return Objects.equals(times, that.times);
-
   }
 
   @Override
@@ -414,23 +418,26 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
    */
   @Nullable
   public String getTimeIntervalName() {
-    if (!isTimeInterval)
+    if (!isTimeInterval) {
       return null;
+    }
 
-    if (isOrthogonal)
+    if (isOrthogonal) {
       return ((CoordinateTimeIntv) otime).getTimeIntervalName();
+    }
 
     if (isRegular) {
       String firstValue = null;
       for (CoordinateTimeAbstract timeCoord : regTimes.values()) {
         CoordinateTimeIntv timeCoordi = (CoordinateTimeIntv) timeCoord;
         String value = timeCoordi.getTimeIntervalName();
-        if (firstValue == null)
+        if (firstValue == null) {
           firstValue = value;
-        else if (!value.equals(firstValue))
+        } else if (!value.equals(firstValue)) {
           return MIXED_INTERVALS;
-        else if (value.equals(MIXED_INTERVALS))
+        } else if (value.equals(MIXED_INTERVALS)) {
           return MIXED_INTERVALS;
+        }
       }
       return firstValue;
     }
@@ -438,16 +445,18 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
     // are they the same length ?
     String firstValue = null;
     for (Coordinate timeCoord : times) {
-      if (times.isEmpty())
+      if (times.isEmpty()) {
         continue; // skip empties
+      }
       CoordinateTimeIntv timeCoordi = (CoordinateTimeIntv) timeCoord;
       String value = timeCoordi.getTimeIntervalName();
-      if (firstValue == null)
+      if (firstValue == null) {
         firstValue = value;
-      else if (!value.equals(firstValue))
+      } else if (!value.equals(firstValue)) {
         return MIXED_INTERVALS;
-      else if (value.equals(MIXED_INTERVALS))
+      } else if (value.equals(MIXED_INTERVALS)) {
         return MIXED_INTERVALS;
+      }
     }
     return firstValue;
   }
@@ -511,7 +520,7 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
   // For MRUTC, MRUTP
   public CoordinateTimeAbstract getOffsetTimes() {
     // LOOK assumes Point LOOK needs to be seconds, probably cant use this.offset ??
-    List<Integer> offsets = Arrays.stream(this.offset).boxed().collect(Collectors.toList());
+    List<Long> offsets = Arrays.stream(this.offset).boxed().collect(Collectors.toList());
     return new CoordinateTime(this.code, otime.timeUnit, otime.refDate, offsets, otime.time2runtime)
         .setName(this.getName());
   }
@@ -520,7 +529,8 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
   public CoordinateTimeAbstract getMaximalTimes() {
     // Kludge
     if (isRegular()) {
-      return this.regTimes.values().stream().max(Comparator.comparingInt(CoordinateTimeAbstract::getNCoords)).get();
+      return this.regTimes.values().stream().max(Comparator.comparingInt(CoordinateTimeAbstract::getNCoords))
+          .orElseThrow();
     } else {
       return getTimeCoordinate(0); // LOOK can use this for all?
     }
@@ -542,9 +552,10 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
         throw new IllegalArgumentException();
       return new Time2D(runDate, null, valIntv);
     } else {
-      Integer val = (Integer) time.getValue(timeIdx);
-      if (val == null)
+      Long val = (Long) time.getValue(timeIdx);
+      if (val == null) {
         throw new IllegalArgumentException();
+      }
       return new Time2D(runDate, val, null);
     }
   }
@@ -587,9 +598,10 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
       valueWithOffset = value.time + offset;
     }
     int result = time.getIndex(valueWithOffset);
-    if (Grib.debugRead)
+    if (Grib.debugRead) {
       logger.debug(String.format("  matchTimeCoordinate value wanted = (%s) valueWithOffset=%s result=%d %n", value,
           valueWithOffset, result));
+    }
 
     return result;
   }
@@ -618,31 +630,35 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
   private CoordinateTimeAbstract makeBestTime(CoordinateRuntime master) {
     // make complete, unique set of coordinates
-    Set<Integer> values = new HashSet<>(); // complete set of values
-    for (int runIdx = 0; runIdx < nruns; runIdx++) { // use times array, passed into constructor, with original
-                                                     // inventory, if possible
+    Set<Long> values = new HashSet<>(); // complete set of values
+    // use times array, passed into constructor, with original inventory, if possible
+    for (int runIdx = 0; runIdx < nruns; runIdx++) {
       CoordinateTime timeCoord =
           (times == null) ? (CoordinateTime) getTimeCoordinate(runIdx) : (CoordinateTime) times.get(runIdx);
-      for (Integer offset : timeCoord.getOffsetSorted())
+      for (Long offset : timeCoord.getOffsetSorted()) {
         values.add(offset + getOffset(runIdx));
+      }
     }
-    List<Integer> offsetSorted = new ArrayList<>(values.size());
-    for (Object val : values)
-      offsetSorted.add((Integer) val);
+    List<Long> offsetSorted = new ArrayList<>(values.size());
+    for (Object val : values) {
+      offsetSorted.add((Long) val);
+    }
     Collections.sort(offsetSorted); // complete set of values
 
     // fast lookup of offset val in the result CoordinateTime
-    Map<Integer, Integer> map = new HashMap<>();
+    Map<Long, Integer> map = new HashMap<>();
     int count = 0;
-    for (Integer val : offsetSorted)
+    for (Long val : offsetSorted) {
       map.put(val, count++);
+    }
 
     // fast lookup of the run time in the master
     int[] run2master = new int[nruns];
     int masterIdx = 0;
     for (int run2Didx = 0; run2Didx < nruns; run2Didx++) {
-      while (!master.getRuntimeDate(masterIdx).equals(runtime.getRuntimeDate(run2Didx)))
+      while (!master.getRuntimeDate(masterIdx).equals(runtime.getRuntimeDate(run2Didx))) {
         masterIdx++;
+      }
       run2master[run2Didx] = masterIdx;
       masterIdx++;
     }
@@ -654,12 +670,13 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
       CoordinateTime timeCoord =
           (times == null) ? (CoordinateTime) getTimeCoordinate(runIdx) : (CoordinateTime) times.get(runIdx);
       assert timeCoord != null;
-      for (Integer offset : timeCoord.getOffsetSorted()) {
+      for (Long offset : timeCoord.getOffsetSorted()) {
         Integer bestValIdx = map.get(offset + getOffset(runIdx));
-        if (bestValIdx == null)
+        if (bestValIdx == null) {
           throw new IllegalStateException();
-        time2runtime[bestValIdx] = run2master[runIdx] + 1; // uses this runtime; later ones override; one based so 0 =
-                                                           // missing
+        }
+        // uses this runtime; later ones override; one based so 0 = missing
+        time2runtime[bestValIdx] = run2master[runIdx] + 1;
       }
     }
 
@@ -677,22 +694,24 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
             (times == null) ? (CoordinateTimeIntv) getTimeCoordinate(runIdx) : (CoordinateTimeIntv) times.get(runIdx);
         for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals()) {
           TimeCoordIntvValue tinvAbs = tinv.offset(getOffset(runIdx)); // convert to absolute offset
-          if (values.contains(tinvAbs))
+          if (values.contains(tinvAbs)) {
             return false;
+          }
           values.add(tinvAbs);
         }
       }
     } else {
-      Set<Integer> values = new HashSet<>(); // complete set of values
+      Set<Long> values = new HashSet<>(); // complete set of values
       for (int runIdx = 0; runIdx < nruns; runIdx++) { // use times array, passed into constructor, with original
                                                        // inventory, if possible
         CoordinateTime timeCoord =
             (times == null) ? (CoordinateTime) getTimeCoordinate(runIdx) : (CoordinateTime) times.get(runIdx);
         assert timeCoord != null;
-        for (Integer offset : timeCoord.getOffsetSorted()) {
-          int offsetAbs = (offset + getOffset(runIdx)); // convert to absolute offset
-          if (values.contains(offsetAbs))
+        for (Long offset : timeCoord.getOffsetSorted()) {
+          long offsetAbs = (offset + getOffset(runIdx)); // convert to absolute offset
+          if (values.contains(offsetAbs)) {
             return false;
+          }
           values.add(offsetAbs);
         }
       }
@@ -720,7 +739,6 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
       return result;
 
     } else {
-
       int runtime = 0;
       int count = 0;
       for (Coordinate time : times) {
@@ -736,7 +754,6 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
     }
   }
 
-
   private CoordinateTimeAbstract makeBestTimeIntv(CoordinateRuntime master) {
     // make unique set of coordinates
     Set<TimeCoordIntvValue> values = new HashSet<>();
@@ -744,26 +761,30 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
                                                      // inventory, if possible
       CoordinateTimeIntv timeIntv =
           (times == null) ? (CoordinateTimeIntv) getTimeCoordinate(runIdx) : (CoordinateTimeIntv) times.get(runIdx);
-      for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals())
+      for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals()) {
         values.add(tinv.offset(getOffset(runIdx)));
+      }
     }
     List<TimeCoordIntvValue> offsetSorted = new ArrayList<>(values.size());
-    for (Object val : values)
+    for (Object val : values) {
       offsetSorted.add((TimeCoordIntvValue) val);
+    }
     Collections.sort(offsetSorted);
 
     // fast lookup of offset tinv in the result CoordinateTimeIntv
     Map<TimeCoordIntvValue, Integer> map = new HashMap<>(); // lookup coord val to index
     int count = 0;
-    for (TimeCoordIntvValue val : offsetSorted)
+    for (TimeCoordIntvValue val : offsetSorted) {
       map.put(val, count++);
+    }
 
     // fast lookup of the run time in the master
     int[] run2master = new int[nruns];
     int masterIdx = 0;
     for (int run2Didx = 0; run2Didx < nruns; run2Didx++) {
-      while (!master.getRuntimeDate(masterIdx).equals(runtime.getRuntimeDate(run2Didx)))
+      while (!master.getRuntimeDate(masterIdx).equals(runtime.getRuntimeDate(run2Didx))) {
         masterIdx++;
+      }
       run2master[run2Didx] = masterIdx;
       masterIdx++;
     }
@@ -775,8 +796,9 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
           (times == null) ? (CoordinateTimeIntv) getTimeCoordinate(runIdx) : (CoordinateTimeIntv) times.get(runIdx);
       for (TimeCoordIntvValue bestVal : timeIntv.getTimeIntervals()) {
         Integer bestValIdx = map.get(bestVal.offset(getOffset(runIdx)));
-        if (bestValIdx == null)
+        if (bestValIdx == null) {
           throw new IllegalStateException();
+        }
         time2runtime[bestValIdx] = run2master[runIdx] + 1; // uses this runtime; later ones override; one based so 0 =
                                                            // missing
       }
@@ -809,12 +831,14 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
    * @return indx in the time coordinate
    */
   public int findTimeIndexFromVal(int runIdx, Object val) {
-    if (isOrthogonal)
+    if (isOrthogonal) {
       return otime.getIndex(val);
+    }
 
     CoordinateTimeAbstract time = getTimeCoordinate(runIdx);
-    if (time.getNCoords() == 1)
+    if (time.getNCoords() == 1) {
       return 0;
+    }
     return time.getIndex(val); // not sure if its reletive to runtime ??
   }
 
@@ -824,23 +848,26 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
    * @return List<Integer> or List<TimeCoordIntvValue>
    */
   public List<?> getOffsetsSorted() {
-    if (isOrthogonal)
+    if (isOrthogonal) {
       return otime.getValues();
+    }
 
     List<? extends Coordinate> coords = isRegular ? new ArrayList<>(regTimes.values()) : times;
-    if (isTimeInterval)
+    if (isTimeInterval) {
       return getIntervalsSorted(coords);
-    else
-      return getIntegersSorted(coords);
+    } else {
+      return getValuesSorted(coords);
+    }
   }
 
-  private List<Integer> getIntegersSorted(List<? extends Coordinate> coords) {
-    Set<Integer> set = new HashSet<>(100);
+  private List<Long> getValuesSorted(List<? extends Coordinate> coords) {
+    Set<Long> set = new HashSet<>(100);
     for (Coordinate coord : coords) {
-      for (Object val : coord.getValues())
-        set.add((Integer) val);
+      for (Object val : coord.getValues()) {
+        set.add((Long) val);
+      }
     }
-    List<Integer> result = new ArrayList<>(set);
+    List<Long> result = new ArrayList<>(set);
     Collections.sort(result);
     return result;
   }
@@ -848,8 +875,9 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
   private List<TimeCoordIntvValue> getIntervalsSorted(List<? extends Coordinate> coords) {
     Set<TimeCoordIntvValue> set = new HashSet<>(100);
     for (Coordinate coord : coords) {
-      for (Object val : coord.getValues())
+      for (Object val : coord.getValues()) {
         set.add((TimeCoordIntvValue) val);
+      }
     }
     List<TimeCoordIntvValue> result = new ArrayList<>(set);
     Collections.sort(result);
@@ -860,16 +888,16 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
   public static class Time2D implements Comparable<Time2D> {
     long refDate;
-    Integer time;
+    Long time;
     TimeCoordIntvValue tinv;
 
-    public Time2D(CalendarDate refDate, Integer time, TimeCoordIntvValue tinv) {
+    public Time2D(CalendarDate refDate, Long time, TimeCoordIntvValue tinv) {
       this.refDate = refDate.getMillisFromEpoch();
       this.time = time;
       this.tinv = tinv;
     }
 
-    Time2D(long refDate, Integer time, TimeCoordIntvValue tinv) {
+    Time2D(long refDate, Long time, TimeCoordIntvValue tinv) {
       this.refDate = refDate;
       this.time = time;
       this.tinv = tinv;
@@ -879,11 +907,12 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
       return CalendarDate.of(refDate);
     }
 
-    public int getValue() {
-      if (time != null)
+    public long getValue() {
+      if (time != null) {
         return time;
-      else
+      } else {
         return tinv.getBounds2();
+      }
     }
 
     @Override
@@ -895,12 +924,13 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
       Time2D time2D = (Time2D) o;
 
-      if (refDate != time2D.refDate)
+      if (refDate != time2D.refDate) {
         return false;
-      if (!Objects.equals(time, time2D.time))
+      }
+      if (!Objects.equals(time, time2D.time)) {
         return false;
+      }
       return Objects.equals(tinv, time2D.tinv);
-
     }
 
     @Override
@@ -913,20 +943,22 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
 
     @Override
     public String toString() {
-      if (time != null)
+      if (time != null) {
         return time.toString();
-      else
+      } else {
         return tinv.toString();
+      }
     }
 
     @Override
     public int compareTo(@Nonnull Time2D o) {
       int r = Long.compare(refDate, o.refDate);
       if (r == 0) {
-        if (time != null)
+        if (time != null) {
           r = time.compareTo(o.time);
-        else
+        } else {
           r = tinv.compareTo(o.tinv);
+        }
       }
       return r;
     }
@@ -975,10 +1007,8 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
       Object time = timeBuilder.extract(gr);
       if (time instanceof TimeCoordIntvValue) {
         return new Time2D(run, null, (TimeCoordIntvValue) time);
-      } else if (time instanceof Integer) {
-        return new Time2D(run, (Integer) time, null);
       } else if (time instanceof Number) {
-        return new Time2D(run, ((Number) time).intValue(), null);
+        return new Time2D(run, ((Number) time).longValue(), null);
       } else {
         throw new IllegalArgumentException("unsupported coord type = " + time.getClass().getName());
       }
@@ -1077,10 +1107,13 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
         timeBuilders.put(run, timeBuilder);
       }
       Object time = timeBuilder.extract(gr);
-      if (time instanceof Integer)
-        return new Time2D(run, (Integer) time, null);
-      else
+      if (time instanceof TimeCoordIntvValue) {
         return new Time2D(run, null, (TimeCoordIntvValue) time);
+      } else if (time instanceof Number) {
+        return new Time2D(run, ((Number) time).longValue(), null);
+      } else {
+        throw new IllegalArgumentException("unsupported coord type = " + time.getClass().getName());
+      }
     }
 
     @Override
@@ -1095,8 +1128,9 @@ public class CoordinateTime2D extends CoordinateTimeAbstract implements Coordina
       }
 
       List<Time2D> vals = new ArrayList<>(values.size());
-      for (Object val : values)
+      for (Object val : values) {
         vals.add((Time2D) val);
+      }
       Collections.sort(vals);
 
       return new CoordinateTime2D(code, timeUnit, vals, runCoord, times, null);

--- a/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime2DUnionizer.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/CoordinateTime2DUnionizer.java
@@ -89,7 +89,7 @@ class CoordinateTime2DUnionizer<T> extends CoordinateBuilderImpl<T> {
         CalendarDate cd = CalendarDate.of(runtime);
         for (Object timeVal : time.getValues())
           allVals.add(isTimeInterval ? new CoordinateTime2D.Time2D(cd, null, (TimeCoordIntvValue) timeVal)
-              : new CoordinateTime2D.Time2D(cd, (Integer) timeVal, null));
+              : new CoordinateTime2D.Time2D(cd, (Long) timeVal, null));
       }
     }
     Collections.sort(allVals);

--- a/grib/src/main/java/ucar/nc2/grib/grid/GribGridAxis.java
+++ b/grib/src/main/java/ucar/nc2/grib/grid/GribGridAxis.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
-
 package ucar.nc2.grib.grid;
 
 import com.google.common.base.Preconditions;
@@ -224,7 +223,7 @@ public class GribGridAxis {
 
       public T setTimeOffsetCoordinate(CoordinateTime timeCoord) {
         this.gribCoord = timeCoord;
-        List<Number> values = timeCoord.getValues().stream().map(v -> (Integer) v).collect(Collectors.toList());
+        List<Number> values = timeCoord.getValues().stream().map(v -> (Long) v).collect(Collectors.toList());
         RegularValues regular = calcPointIsRegular(values);
         if (regular != null) {
           setRegular(regular.ncoords, regular.start, regular.increment);

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestCoordinate.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestCoordinate.java
@@ -38,9 +38,9 @@ public class TestCoordinate implements Coordinate {
           cd.add(CalendarDate.of(1953, 11, i + 1, 9, i + 1, 0).getMillisFromEpoch());
         return new CoordinateRuntime(cd, period);
       case time:
-        List<Integer> vals = new ArrayList<>(nvals);
+        List<Long> vals = new ArrayList<>(nvals);
         for (int i = 0; i < nvals; i++)
-          vals.add(i);
+          vals.add((long) i);
         return new CoordinateTime(0, period, null, vals, null);
       case vert:
         List<VertCoordValue> vert = new ArrayList<>(nvals);

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestCoordinateTime2DUnionizer.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestCoordinateTime2DUnionizer.java
@@ -2,23 +2,16 @@ package ucar.nc2.grib.coord;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ucar.nc2.grib.grib1.Grib1Record;
 import ucar.nc2.calendar.CalendarDate;
 import ucar.nc2.calendar.CalendarPeriod;
 import ucar.nc2.util.Indent;
-import java.lang.invoke.MethodHandles;
 import java.util.*;
 
 /**
- * Test CoordinateTime2DUnionizer
- *
- * @author caron
- * @since 11/25/2014
+ * Test {@link CoordinateTime2DUnionizer}
  */
 public class TestCoordinateTime2DUnionizer {
-  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   static int code = 0;
   static CalendarPeriod timeUnit = CalendarPeriod.of("1 hour");
@@ -48,9 +41,9 @@ public class TestCoordinateTime2DUnionizer {
   }
 
   private CoordinateTime makeTimeCoordinate(CalendarDate refDate, int size, int spacing) {
-    List<Integer> offsetSorted = new ArrayList<>();
+    List<Long> offsetSorted = new ArrayList<>();
     for (int i = 0; i < size; i++)
-      offsetSorted.add(i * spacing);
+      offsetSorted.add((long) i * spacing);
     return new CoordinateTime(code, timeUnit, refDate, offsetSorted, null);
   }
 
@@ -93,8 +86,9 @@ public class TestCoordinateTime2DUnionizer {
     }
 
     CoordinateTime2DUnionizer unionizer = new CoordinateTime2DUnionizer(false, timeUnit, code, false, null);
-    for (CoordinateTime2D coord2D : coord2Ds)
+    for (CoordinateTime2D coord2D : coord2Ds) {
       unionizer.addAll(coord2D);
+    }
     unionizer.finish();
     CoordinateTime2D result = (CoordinateTime2D) unionizer.getCoordinate();
 
@@ -118,7 +112,7 @@ public class TestCoordinateTime2DUnionizer {
     for (int j = 0; j < nruns; j++) {
       CalendarDate runDate = startDate.add(j, CalendarPeriod.Field.Hour);
       for (int i = 0; i < ntimes; i++) {
-        CoordinateTime2D.Time2D time2D = new CoordinateTime2D.Time2D(runDate, i, null);
+        CoordinateTime2D.Time2D time2D = new CoordinateTime2D.Time2D(runDate, (long) i, null);
         vals.add(time2D);
 
         runBuilder.add(time2D.refDate);

--- a/toolsui/uicdm/src/main/java/ucar/ui/grib/CdmIndexPanel.java
+++ b/toolsui/uicdm/src/main/java/ucar/ui/grib/CdmIndexPanel.java
@@ -846,7 +846,7 @@ public class CdmIndexPanel extends JPanel {
 
       } else if (coord instanceof CoordinateTime) {
         CoordinateTime time = (CoordinateTime) coord;
-        List<Integer> offsets = time.getOffsetSorted();
+        List<Long> offsets = time.getOffsetSorted();
         int n = offsets.size();
         double offsetFromMaster = time.getOffsetInTimeUnits(gc.getMasterFirstDate());
         start = offsets.get(0) + offsetFromMaster;


### PR DESCRIPTION
I think this happened long ago when we were switching to CalendarDate?
But only triggers when regenerating grib ncx4.
So why didnt we see more Jenkins failures??

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/873)
<!-- Reviewable:end -->
