### PR TITLE
Fix bug in hdf5 iosp where we used wrong ByteOrder. 

### DIFF
--- a/cdm-core/src/main/java/ucar/array/StructureDataStorageBB.java
+++ b/cdm-core/src/main/java/ucar/array/StructureDataStorageBB.java
@@ -12,7 +12,6 @@ import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.array.StructureMembers.Member;
-import ucar.nc2.iosp.IospHelper;
 
 /**
  * Storage for StructureDataArray with all data in a single ByteBuffer, using member's offsets and ByteOrder,
@@ -285,8 +284,10 @@ public final class StructureDataStorageBB implements Storage<StructureData> {
 
         case STRING: {
           int heapIdx = bbuffer.getInt(pos);
+          // System.out.printf(" get %s on heap at offset %d heapIdx %d bo %s%n", m.getName(), pos, heapIdx,
+          // m.getByteOrder());
           if (heapIdx < 0 || heapIdx >= heap.size()) {
-            log.warn("getMemberData = {} heapIdx = {} member = {} bo = {}", pos, heapIdx, m.getName(),
+            log.warn("  bad heapIdx pos = {} heapIdx = {} member = {} bo = {}", pos, heapIdx, m.getName(),
                 m.getByteOrder());
           }
           String[] array = (String[]) heap.get(heapIdx);
@@ -295,7 +296,6 @@ public final class StructureDataStorageBB implements Storage<StructureData> {
 
         case SEQUENCE: {
           int heapIdx = bbuffer.getInt(pos);
-          // System.out.printf("getMemberData get seq %s at heap = %d pos = %d%n", m.getName(), heapIdx, pos);
           return (StructureDataArray) heap.get(heapIdx);
         }
 
@@ -317,8 +317,8 @@ public final class StructureDataStorageBB implements Storage<StructureData> {
     }
 
     private Array<?> getMemberVlenData(Member m) {
-      bbuffer.order(m.getByteOrder());
       int pos = offset + recno * members.getStorageSizeBytes() + m.getOffset();
+      bbuffer.order(m.getByteOrder());
       int heapIdx = bbuffer.getInt(pos);
       return (ArrayVlen<?>) heap.get(heapIdx);
     }

--- a/cdm-core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5objects.java
+++ b/cdm-core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5objects.java
@@ -2511,7 +2511,7 @@ public class H5objects {
 
     // the heap id is has already been read into a byte array at given pos
     HeapIdentifier(ByteBuffer bb, int pos) {
-      bb.order(ByteOrder.LITTLE_ENDIAN); // header information is in le byte order
+      bb.order(ByteOrder.LITTLE_ENDIAN); // header information is in LE byte order
       bb.position(pos); // reletive reading
       nelems = bb.getInt();
       heapAddress = header.isOffsetLong ? bb.getLong() : (long) bb.getInt();

--- a/cdm-core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestProblems.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestProblems.java
@@ -5,16 +5,19 @@
 package ucar.nc2.internal.iosp.hdf5;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import ucar.array.ArrayType;
 import ucar.nc2.EnumTypedef;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
 import ucar.nc2.Variable;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import static com.google.common.truth.Truth.assertThat;
 
 /** Test problems in hdf5 / netcdf 4 files. */
+@Category(NeedsCdmUnitTest.class)
 public class TestProblems {
 
   @Test

--- a/cdm-core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestProblems.java
+++ b/cdm-core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestProblems.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.nc2.internal.iosp.hdf5;
+
+import org.junit.Test;
+import ucar.array.ArrayType;
+import ucar.nc2.EnumTypedef;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
+import ucar.unidata.util.test.TestDir;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Test problems in hdf5 / netcdf 4 files. */
+public class TestProblems {
+
+  @Test
+  public void problem() throws Exception {
+    String filename = TestDir.cdmUnitTestDir + "formats/netcdf4/attributeStruct.nc";
+    System.out.printf("TestProblems %s%n", filename);
+    try (NetcdfFile ncfile = NetcdfFiles.open(TestDir.cdmUnitTestDir + "formats/netcdf4/attributeStruct.nc")) {
+      System.out.printf("result = %s%n", ncfile);
+    }
+  }
+
+}


### PR DESCRIPTION
Always use the b…yte order of the member.

Consider how to transport this correctly over gcdm. At the moment we are not sending bo info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/885)
<!-- Reviewable:end -->
