### PR TITLE
[8.x]: Version 8 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 # netCDF-Java
 
-Welcome to the development branch of the netCDF-Java library (currently version _7.x_)!
+Welcome to the development branch of the netCDF-Java library (currently version _8.x_)!
 
-> Looking for the `6.x` line of development?
-See branch [6.x](https://github.com/unidata/netcdf-java/tree/6.x).
+> Looking for the `7.x` line of development?
+See branch [7.x](https://github.com/unidata/netcdf-java/tree/7.x).
+Looking for the `6.x` line of development?
+See branch [6.x](https://github.com/unidata/netcdf-java/tree/6.x)
 Looking for the `5.x` line of development?
 See branch [maint-5.x](https://github.com/unidata/netcdf-java/tree/maint-5.x).
 Version `4.6` is no longer supported outside of the context of the THREDDS Data Server (TDS).

--- a/docs/userguide/src/site/pages/upgrade.md
+++ b/docs/userguide/src/site/pages/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading to netCDF-Java version 8.x
-last_updated: 2021-05-21
+last_updated: 2021-10-12
 sidebar: userguide_sidebar
 toc: false
 permalink: upgrade.html
@@ -16,7 +16,7 @@ permalink: upgrade.html
 
 ## Quick Navigation
 
-* [Summary of changes for v8.0.x](#netcdf-java-api-changes-60x)
+* [Summary of changes for v8.0.x](#netcdf-java-api-changes-80x)
 * [Previous versions](#previous-releases)
 
 ## netCDF-Java API Changes (8.0.x)
@@ -25,5 +25,6 @@ permalink: upgrade.html
 
 ## Previous Releases
 
+* [7.x](https://docs.unidata.ucar.edu/netcdf-java/7.0/userguide/upgrade.html)
 * [6.x](https://docs.unidata.ucar.edu/netcdf-java/6.0/userguide/upgrade.html)
 * [5.x](https://docs.unidata.ucar.edu/netcdf-java/5.4/userguide/upgrade.html)

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -71,7 +71,7 @@ gretty {
 farm {
   jvmArgs = ["-Dlog4j.configurationFile=$rootDir/gradle/gretty/log4j2Config.xml"]
   // :opendap test.
-  webapp 'edu.ucar:dtswar:5.0.0-beta8@war', contextPath: '/dts'
+  webapp 'edu.ucar:dtswar:5.0@war', contextPath: '/dts'
   integrationTestTask = 'test'
 
   // Enable TLS


### PR DESCRIPTION
## Description of Changes

A few easy to miss (and not documented...my bad) changes:
* Update main README
* Upgrade the update doc page
   * make sure all references are for version 8
   * add version 7 to the previous release list
   * update the date of `last_updated` in the jekyll frontmatter

Not related to the updating to version 8, but let's go ahead and update the version of the `dtswar` artifact (DAP2 Test Server war file) to the 5.0 release (was using 5.0.0-beta8). We use this artifact for testing the OPeNDAP client code.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
