### PR TITLE
Port Structures to ucar.array.

### DIFF
--- a/cdm-core/src/main/java/ucar/array/ArrayVlen.java
+++ b/cdm-core/src/main/java/ucar/array/ArrayVlen.java
@@ -171,7 +171,7 @@ public final class ArrayVlen<T> extends Array<Array<T>> {
    * Set the ith value. Do not use after construction.
    * 
    * @param index 1d index
-   * @param value must be primitive array of T, eg double[] of any length.
+   * @param value a primitive array of T, eg double[] of any length, or an Array of T.
    */
   public void set(int index, Object value) {
     storage.set(index, value);

--- a/cdm-core/src/main/java/ucar/array/StructureDataStorageBB.java
+++ b/cdm-core/src/main/java/ucar/array/StructureDataStorageBB.java
@@ -320,7 +320,7 @@ public final class StructureDataStorageBB implements Storage<StructureData> {
       int pos = offset + recno * members.getStorageSizeBytes() + m.getOffset();
       bbuffer.order(m.getByteOrder());
       int heapIdx = bbuffer.getInt(pos);
-      return (ArrayVlen<?>) heap.get(heapIdx);
+      return (Array<?>) heap.get(heapIdx);
     }
 
   }

--- a/cdm-core/src/main/java/ucar/array/StructureMembers.java
+++ b/cdm-core/src/main/java/ucar/array/StructureMembers.java
@@ -124,6 +124,9 @@ public final class StructureMembers implements Iterable<StructureMembers.Member>
       this.members = builder.members != null ? builder.members.build() : null;
       this.byteOrder = builder.byteOrder;
       this.offset = builder.offset;
+      if (builder.offset < 0) {
+        throw new IllegalArgumentException("member offset not set");
+      }
 
       // calculated
       this.length = (int) ucar.ma2.Index.computeSize(shape);

--- a/cdm-core/src/main/java/ucar/nc2/Dimensions.java
+++ b/cdm-core/src/main/java/ucar/nc2/Dimensions.java
@@ -45,33 +45,6 @@ public class Dimensions {
     }
   }
 
-  /**
-   * Make a ucar.ma2.Section.Builder from an ordered set of Dimension objects.
-   * 
-   * @deprecated use makeArraySectionFromDimensions
-   */
-  @Deprecated
-  public static ucar.ma2.Section.Builder makeSectionFromDimensions(Iterable<Dimension> dimensions) {
-    try {
-      ucar.ma2.Section.Builder builder = ucar.ma2.Section.builder();
-      for (Dimension d : dimensions) {
-        int len = d.getLength();
-        if (len > 0)
-          builder.appendRange(new ucar.ma2.Range(d.getShortName(), 0, len - 1));
-        else if (len == 0)
-          builder.appendRange(ucar.ma2.Range.EMPTY); // LOOK empty not named
-        else {
-          assert d.isVariableLength();
-          builder.appendRange(ucar.ma2.Range.VLEN); // LOOK vlen not named
-        }
-      }
-      return builder;
-
-    } catch (ucar.ma2.InvalidRangeException e) {
-      throw new IllegalStateException(e.getMessage());
-    }
-  }
-
   /** Get the total number of elements the dimensions represent. */
   public static long getSize(Iterable<Dimension> dimensions) {
     long size = 1;

--- a/cdm-core/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm-core/src/main/java/ucar/nc2/NetcdfFile.java
@@ -531,20 +531,6 @@ public class NetcdfFile implements FileCacheable, Closeable {
   }
 
   /**
-   * Do not call this directly, use Variable.read() !!
-   * Ranges must be filled (no nulls)
-   * 
-   * @deprecated use readArrayData()
-   */
-  @Deprecated
-  protected Array readData(Variable v, ucar.ma2.Section ranges) throws IOException, ucar.ma2.InvalidRangeException {
-    if (iosp == null) {
-      throw new IOException("iosp is null, perhaps file has been closed. Trying to read variable " + v.getFullName());
-    }
-    return iosp.readData(v, ranges);
-  }
-
-  /**
    * Do not call this directly, use Variable.readArray() !!
    * Ranges must be filled (no nulls)
    */

--- a/cdm-core/src/main/java/ucar/nc2/Sequence.java
+++ b/cdm-core/src/main/java/ucar/nc2/Sequence.java
@@ -10,7 +10,10 @@ import javax.annotation.concurrent.Immutable;
 
 import ucar.array.ArrayType;
 import ucar.array.ArraysConvert;
-import ucar.ma2.*;
+import ucar.array.InvalidRangeException;
+import ucar.array.Section;
+import ucar.array.StructureData;
+
 import java.util.List;
 
 /**
@@ -22,13 +25,13 @@ public class Sequence extends Structure implements Iterable<ucar.array.Structure
 
   /** @deprecated use iterator() */
   @Deprecated
-  public StructureDataIterator getStructureIterator(int bufferSize) throws java.io.IOException {
+  public ucar.ma2.StructureDataIterator getStructureIterator(int bufferSize) throws java.io.IOException {
     if (cache.getData() != null) {
       ucar.array.Array<?> array = cache.getData();
       if (array instanceof ucar.array.StructureDataArray) {
         ucar.ma2.Array ma2 = ArraysConvert.convertFromArray(array);
-        if (ma2 instanceof ArrayStructure) {
-          return ((ArrayStructure) ma2).getStructureDataIterator();
+        if (ma2 instanceof ucar.ma2.ArrayStructure) {
+          return ((ucar.ma2.ArrayStructure) ma2).getStructureDataIterator();
         }
       }
     }
@@ -57,42 +60,28 @@ public class Sequence extends Structure implements Iterable<ucar.array.Structure
   /** Same as read() */
   @Override
   @Deprecated
-  public Array read(ucar.ma2.Section section) throws java.io.IOException {
+  public ucar.ma2.Array read(ucar.ma2.Section section) throws java.io.IOException {
     return read();
   }
 
   /** @throws UnsupportedOperationException always */
   @Override
   @Deprecated
-  public Array read(int[] origin, int[] shape) {
+  public ucar.ma2.Array read(int[] origin, int[] shape) {
     throw new UnsupportedOperationException();
   }
 
   /** @throws UnsupportedOperationException always */
   @Override
   @Deprecated
-  public Array read(String sectionSpec) {
+  public ucar.ma2.Array read(String sectionSpec) {
     throw new UnsupportedOperationException();
   }
 
   /** @throws UnsupportedOperationException always */
   @Override
   @Deprecated
-  public Array read(List<Range> ranges) {
-    throw new UnsupportedOperationException();
-  }
-
-  /** @throws UnsupportedOperationException always */
-  @Override
-  @Deprecated
-  public StructureData readStructure(int index) {
-    throw new UnsupportedOperationException();
-  }
-
-  /** @throws UnsupportedOperationException always */
-  @Override
-  @Deprecated
-  public ArrayStructure readStructure(int start, int count) {
+  public ucar.ma2.Array read(List<ucar.ma2.Range> ranges) {
     throw new UnsupportedOperationException();
   }
 
@@ -104,7 +93,19 @@ public class Sequence extends Structure implements Iterable<ucar.array.Structure
 
   /** @throws UnsupportedOperationException always */
   @Override
+  public Variable section(ucar.ma2.Section subsection) {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @throws UnsupportedOperationException always */
+  @Override
   public Variable section(Section subsection) {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @throws UnsupportedOperationException always */
+  @Override
+  public StructureData readRecord(int recno) throws IOException, InvalidRangeException {
     throw new UnsupportedOperationException();
   }
 

--- a/cdm-core/src/main/java/ucar/nc2/Structure.java
+++ b/cdm-core/src/main/java/ucar/nc2/Structure.java
@@ -6,6 +6,7 @@ package ucar.nc2;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Formatter;
@@ -15,18 +16,12 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import ucar.array.Array;
 import ucar.array.ArrayType;
-import ucar.ma2.Array;
-import ucar.ma2.ArrayObject;
-import ucar.ma2.ArrayStructure;
-import ucar.ma2.DataType;
-import ucar.ma2.Index;
-import ucar.ma2.InvalidRangeException;
-import ucar.ma2.Range;
-import ucar.ma2.Section;
-import ucar.ma2.StructureData;
-import ucar.ma2.StructureDataIterator;
-import ucar.ma2.StructureMembers;
+import ucar.array.InvalidRangeException;
+import ucar.array.Range;
+import ucar.array.Section;
+import ucar.array.StructureData;
 import ucar.nc2.util.Indent;
 
 /**
@@ -46,9 +41,6 @@ import ucar.nc2.util.Indent;
  */
 @Immutable
 public class Structure extends Variable {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Structure.class);
-  private static final int defaultBufferSize = 500 * 1000; // 500K bytes
-
 
   /** Find the Variable member with the specified (short) name, or null if not found. */
   @Nullable
@@ -93,11 +85,11 @@ public class Structure extends Variable {
    * @deprecated use makeStructureMembersBuilder()
    */
   @Deprecated
-  public StructureMembers makeStructureMembers() {
-    StructureMembers.Builder builder = StructureMembers.builder().setName(getShortName());
+  public ucar.ma2.StructureMembers makeStructureMembers() {
+    ucar.ma2.StructureMembers.Builder builder = ucar.ma2.StructureMembers.builder().setName(getShortName());
     for (Variable v2 : this.getVariables()) {
-      StructureMembers.MemberBuilder m = builder.addMember(v2.getShortName(), v2.getDescription(), v2.getUnitsString(),
-          v2.getDataType(), v2.getShape());
+      ucar.ma2.StructureMembers.MemberBuilder m = builder.addMember(v2.getShortName(), v2.getDescription(),
+          v2.getUnitsString(), v2.getDataType(), v2.getShape());
       if (v2 instanceof Structure) {
         m.setStructureMembers(((Structure) v2).makeStructureMembers());
       }
@@ -149,254 +141,10 @@ public class Structure extends Variable {
     return select(ImmutableList.of(varName));
   }
 
-  ///////////////////////////////////////////////////////////////////////////////////////////////////
-
   /** Calculation of size of one element of this structure - equals the sum of sizes of its members. */
   private int calcElementSize() {
     return makeStructureMembersBuilder().getStorageSizeBytes(false);
   }
-
-  //////////////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * Use this when this is a scalar or one dimensional array of Structures, or you are doing the index calculation
-   * yourself for a multidimensional array. This will read only the ith structure, and return a StructureData.
-   * 
-   * @param index linear index into the array
-   * @return ith StructureData
-   * @throws java.io.IOException on read error
-   * @throws ucar.ma2.InvalidRangeException if index out of range
-   * @deprecated use readArray(Section)
-   */
-  @Deprecated
-  public StructureData readStructure(int index) throws IOException, ucar.ma2.InvalidRangeException {
-    Section.Builder sb = Section.builder();
-
-    if (getRank() == 1) {
-      sb.appendRange(index, index);
-
-    } else if (getRank() > 1) {
-      Index ii = Index.factory(shape); // convert to nD index
-      ii.setCurrentCounter(index);
-      int[] origin = ii.getCurrentCounter();
-      for (int anOrigin : origin) {
-        sb.appendRange(anOrigin, anOrigin);
-      }
-    }
-
-    Array dataArray = read(sb.build());
-    if (dataArray instanceof ArrayStructure) {
-      ArrayStructure data = (ArrayStructure) dataArray;
-      return data.getStructureData(0);
-    } else if (dataArray instanceof ArrayObject) {
-      return (StructureData) dataArray.getObject(0);
-    }
-    throw new RuntimeException("Unknown structure array class " + dataArray.getClass().getName());
-  }
-
-  /**
-   * For rank 0 or 1 array of Structures, read count Structures and return the data as an ArrayStructure.
-   * Use only when this is a one dimensional array of Structures.
-   * 
-   * @param start start at this index
-   * @param count return this many StructureData
-   * @return the StructureData recordsfrom start to start+count-1
-   * @throws java.io.IOException on read error
-   * @throws ucar.ma2.InvalidRangeException if start, count out of range
-   * @deprecated use readArray(Section)
-   */
-  @Deprecated
-  public ArrayStructure readStructure(int start, int count) throws IOException, ucar.ma2.InvalidRangeException {
-    Preconditions.checkArgument(getRank() <= 1, "not a vector structure");
-    int[] origin = {start};
-    int[] shape = {count};
-    return (ArrayStructure) read(origin, shape);
-  }
-
-  /**
-   * Iterator over all the data in a Structure.
-   * 
-   * <pre>
-   * StructureDataIterator ii = structVariable.getStructureIterator();
-   * while (ii.hasNext()) {
-   *   StructureData sdata = ii.next();
-   * }
-   * </pre>
-   * 
-   * @return StructureDataIterator over type StructureData
-   * @throws java.io.IOException on read error
-   * @see #getStructureIterator(int bufferSize)
-   * @deprecated use readArray().iterator()
-   */
-  @Deprecated
-  public StructureDataIterator getStructureIterator() throws java.io.IOException {
-    return getStructureIterator(defaultBufferSize);
-  }
-
-  /**
-   * Get an efficient iterator over all the data in the Structure.
-   *
-   * This is the efficient way to get all the data, it can be much faster than reading one record at a time,
-   * and is optimized for large datasets.
-   * This is accomplished by buffering bufferSize amount of data at once.
-   *
-   * <pre>
-   * Example:
-   *
-   *  StructureDataIterator ii = structVariable.getStructureIterator(100 * 1000);
-   *  while (ii.hasNext()) {
-   *    StructureData sdata = ii.next();
-   *  }
-   * </pre>
-   * 
-   * @param bufferSize size in bytes to buffer, set < 0 to use default size
-   * @return StructureDataIterator over type StructureData
-   * @throws java.io.IOException on read error
-   * @deprecated use readArray().iterator()
-   */
-  @Deprecated
-  public StructureDataIterator getStructureIterator(int bufferSize) throws java.io.IOException {
-    return (getRank() < 2) ? new Structure.IteratorRank1(bufferSize) : new IteratorRankAny();
-  }
-
-  /** Iterator over type StructureData, rank 1 (common) case */
-  private class IteratorRank1 implements StructureDataIterator {
-    private int count;
-    private final int recnum = (int) getSize();
-    private int readStart;
-    private int readCount;
-    private int readAtaTime;
-    private ArrayStructure as;
-
-    IteratorRank1(int bufferSize) {
-      setBufferSize(bufferSize);
-    }
-
-    @Override
-    public boolean hasNext() {
-      return count < recnum;
-    }
-
-    @Override
-    public StructureDataIterator reset() {
-      count = 0;
-      readStart = 0;
-      readCount = 0;
-      return this;
-    }
-
-    @Override
-    public StructureData next() throws IOException {
-      if (count >= readStart) {
-        readNext();
-      }
-
-      count++;
-      return as.getStructureData(readCount++);
-    }
-
-    @Override
-    public int getCurrentRecno() {
-      return count - 1;
-    }
-
-    private void readNext() throws IOException {
-      int left = Math.min(recnum, readStart + readAtaTime); // dont go over recnum
-      int need = left - readStart; // how many to read this time
-      try {
-        as = readStructure(readStart, need);
-        if (NetcdfFile.debugStructureIterator)
-          System.out.println("readNext " + count + " " + readStart);
-
-      } catch (InvalidRangeException e) {
-        log.error("Structure.IteratorRank1.readNext() ", e);
-        throw new IllegalStateException("Structure.Iterator.readNext() ", e);
-      } // cant happen
-      readStart += need;
-      readCount = 0;
-    }
-
-    @Override
-    public void setBufferSize(int bytes) {
-      if (count > 0)
-        return; // too late
-      int structureSize = getElementSize();
-      if (structureSize <= 0)
-        structureSize = 1; // no members in the psuedo-structure LOOK is this ok?
-      if (bytes <= 0)
-        bytes = defaultBufferSize;
-      readAtaTime = Math.max(10, bytes / structureSize);
-      if (NetcdfFile.debugStructureIterator)
-        System.out.println("Iterator structureSize= " + structureSize + " readAtaTime= " + readAtaTime);
-    }
-
-  }
-
-  /** Iterator over type StructureData, general case */
-  private class IteratorRankAny implements StructureDataIterator {
-    private int count; // done so far
-    private int total = (int) getSize();
-    private int readStart; // current buffer starts at
-    private int readCount; // count within the current buffer [0,readAtaTime)
-    private int outerCount; // over the outer Dimension
-    private ArrayStructure as;
-
-    @Override
-    public boolean hasNext() {
-      return count < total;
-    }
-
-    @Override
-    public StructureDataIterator reset() {
-      count = 0;
-      total = (int) getSize();
-      readStart = 0;
-      readCount = 0;
-      outerCount = 0;
-      return this;
-    }
-
-    @Override
-    public int getCurrentRecno() {
-      return count - 1;
-    }
-
-    @Override
-    public StructureData next() throws IOException {
-      if (count >= readStart) {
-        readNextGeneralRank();
-      }
-
-      count++;
-      return as.getStructureData(readCount++);
-    }
-
-    private void readNextGeneralRank() throws IOException {
-
-      try {
-        Section.Builder sb = Section.builder().appendRanges(shape);
-        sb.setRange(0, new Range(outerCount, outerCount));
-
-        as = (ArrayStructure) read(sb.build());
-
-        if (NetcdfFile.debugStructureIterator) {
-          System.out.println("readNext inner=" + outerCount + " total=" + outerCount);
-        }
-
-        outerCount++;
-
-      } catch (InvalidRangeException e) {
-        log.error("Structure.Iterator.readNext() ", e);
-        throw new IllegalStateException("Structure.Iterator.readNext() ", e);
-      } // cant happen
-
-      readStart += as.getSize();
-      readCount = 0;
-    }
-
-  }
-
-  ////////////////////////////////////////////
 
   /** Get String with name and attributes. Used in short descriptions like tooltips. */
   public String getNameAndAttributes() {
@@ -432,6 +180,17 @@ public class Structure extends Variable {
       buf.format("%n");
     }
     buf.format("%n");
+  }
+
+  /**
+   * Read one StructureData at index recno.
+   * For rank 0 or 1 Structure, eg netcdf3 record variables.
+   * 
+   * @param recno start at this index
+   */
+  public StructureData readRecord(int recno) throws IOException, InvalidRangeException {
+    Array<?> arr = readArray(Section.builder().appendRange(new Range(recno, recno)).build());
+    return (StructureData) arr.get(0);
   }
 
   ////////////////////////////////////////////////////////
@@ -492,15 +251,6 @@ public class Structure extends Variable {
 
     public T addMemberVariables(List<Variable.Builder<?>> vars) {
       vbuilders.addAll(vars);
-      return self();
-    }
-
-    /** @deprecated use addMemberVariable(String, ArrayType, String) */
-    @Deprecated
-    public T addMemberVariable(String shortName, DataType dataType, String dimString) {
-      Variable.Builder<?> vb = Variable.builder().setName(shortName).setDataType(dataType)
-          .setParentGroupBuilder(this.parentBuilder).setDimensionsByName(dimString);
-      addMemberVariable(vb);
       return self();
     }
 

--- a/cdm-core/src/main/java/ucar/nc2/dataset/SequenceDS.java
+++ b/cdm-core/src/main/java/ucar/nc2/dataset/SequenceDS.java
@@ -11,7 +11,6 @@ import ucar.array.ArrayType;
 import ucar.array.StructureData;
 import ucar.ma2.ArrayStructure;
 import ucar.nc2.Group;
-import ucar.ma2.StructureDataIterator;
 import ucar.ma2.Array;
 import java.io.IOException;
 import ucar.nc2.Sequence;
@@ -28,7 +27,7 @@ public class SequenceDS extends Sequence implements StructureEnhanced {
 
   @Override
   @Deprecated
-  public StructureDataIterator getStructureIterator(int bufferSize) throws java.io.IOException {
+  public ucar.ma2.StructureDataIterator getStructureIterator(int bufferSize) throws java.io.IOException {
     return new StructureDataIteratorEnhanced(this, orgSeq.getStructureIterator(bufferSize));
   }
 

--- a/cdm-core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
+++ b/cdm-core/src/main/java/ucar/nc2/write/NetcdfFormatWriter.java
@@ -252,13 +252,7 @@ public class NetcdfFormatWriter implements Closeable {
   // TODO does this work?
   public int appendStructureData(Structure s, ucar.array.StructureData sdata)
       throws IOException, InvalidRangeException {
-    ucar.ma2.StructureMembers membersMa2 = s.makeStructureMembers(); // ??
-    ucar.ma2.StructureData oldStructure = ArraysConvert.convertStructureData(membersMa2, sdata);
-    try {
-      return appendStructureData(s, oldStructure);
-    } catch (ucar.ma2.InvalidRangeException e) {
-      throw new InvalidRangeException(e);
-    }
+    return spiw.appendStructureData(s, sdata);
   }
 
   ////////////////////////////////////////////
@@ -368,15 +362,6 @@ public class NetcdfFormatWriter implements Closeable {
     System.arraycopy(origin, 0, corigin, 0, rank - 1);
 
     write(v, corigin, cvalues);
-  }
-
-  /**
-   * @deprecated use {@link NetcdfFormatWriter#appendStructureData(Structure, ucar.array.StructureData)}
-   */
-  @Deprecated
-  public int appendStructureData(Structure s, ucar.ma2.StructureData sdata)
-      throws IOException, ucar.ma2.InvalidRangeException {
-    return spiw.appendStructureData(s, sdata);
   }
 
   /**

--- a/cdm-core/src/test/java/ucar/array/TestStructureDataArray.java
+++ b/cdm-core/src/test/java/ucar/array/TestStructureDataArray.java
@@ -22,7 +22,7 @@ public class TestStructureDataArray {
     builder.setName("name");
     builder.addMember("mname1", "mdesc1", "munits1", ArrayType.BYTE, new int[] {11, 11});
     builder.addMember("mname2", "mdesc2", "munits1", ArrayType.FLOAT, new int[] {});
-    StructureMembers members = builder.build();
+    StructureMembers members = builder.setStandardOffsets(false).build();
 
     StructureData[] parr = new StructureData[2];
     parr[0] = new StructureDataRow(members);

--- a/cdm-core/src/test/java/ucar/array/TestStructureMembers.java
+++ b/cdm-core/src/test/java/ucar/array/TestStructureMembers.java
@@ -31,7 +31,7 @@ public class TestStructureMembers {
     assertThat(builder.hasMember("nope")).isFalse();
     assertThat(builder.hasMember("mname2")).isTrue();
 
-    StructureMembers sm = builder.build();
+    StructureMembers sm = builder.setStandardOffsets(false).build();
     assertThat(sm.getName()).isEqualTo("name");
     assertThat(sm.getMember(0).getName()).isEqualTo("mname1");
     assertThat(sm.getMember(1).getName()).isEqualTo("mname3");
@@ -94,7 +94,7 @@ public class TestStructureMembers {
         .setArrayType(ArrayType.STRUCTURE);
     topbuilder.addMember(nbuilder);
 
-    StructureMembers sm = topbuilder.build();
+    StructureMembers sm = topbuilder.setStandardOffsets(false).build();
     assertThat(sm.findMember("mname2")).isNull();
     assertThat(sm.findMember("nname2")).isNotNull();
     assertThat(sm.getStorageSizeBytes()).isEqualTo(88 + 108 + 198);

--- a/cdm-core/src/test/java/ucar/nc2/TestLongOffset.java
+++ b/cdm-core/src/test/java/ucar/nc2/TestLongOffset.java
@@ -7,7 +7,7 @@ package ucar.nc2;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.nc2.write.Ncdump;
+import ucar.nc2.write.NcdumpArray;
 import ucar.unidata.util.test.TestDir;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -39,7 +39,7 @@ public class TestLongOffset {
         NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE)) {
 
       StringWriter sw = new StringWriter();
-      Ncdump.ncdump(ncfile, "-vall", sw, null);
+      NcdumpArray.ncdump(ncfile, "-vall", sw, null);
       logger.debug(sw.toString());
     }
   }
@@ -48,7 +48,7 @@ public class TestLongOffset {
   public void testReadLongOffsetV3mode() throws IOException {
     try (NetcdfFile ncfile = TestDir.openFileLocal("longOffset.nc")) {
       StringWriter sw = new StringWriter();
-      Ncdump.ncdump(ncfile, "-vall", sw, null);
+      NcdumpArray.ncdump(ncfile, "-vall", sw, null);
       logger.debug(sw.toString());
     }
   }

--- a/cdm-core/src/test/java/ucar/nc2/TestStructure.java
+++ b/cdm-core/src/test/java/ucar/nc2/TestStructure.java
@@ -86,11 +86,11 @@ public class TestStructure {
     assertThat(nested.getNumberOfMemberVariables()).isEqualTo(1);
     assertThat(struct.findVariable(null)).isNull();
 
-    StructureMembers sm = struct.makeStructureMembersBuilder().build();
+    StructureMembers sm = struct.makeStructureMembersBuilder().setStandardOffsets(false).build();
     assertThat(sm.findMember("var1")).isNotNull();
     assertThat(sm.findMember("nested")).isNotNull();
 
-    StructureMembers smNested = nested.makeStructureMembersBuilder().build();
+    StructureMembers smNested = nested.makeStructureMembersBuilder().setStandardOffsets(false).build();
     assertThat(smNested.findMember("var1")).isNull();
     assertThat(smNested.findMember("var2")).isNotNull();
   }

--- a/cdm-core/src/test/java/ucar/nc2/TestStructure.java
+++ b/cdm-core/src/test/java/ucar/nc2/TestStructure.java
@@ -5,25 +5,24 @@ import static ucar.nc2.TestUtils.makeDummyGroup;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import ucar.array.ArrayType;
-import ucar.ma2.DataType;
-import ucar.ma2.StructureMembers;
+import ucar.array.StructureMembers;
 
 /** Test {@link ucar.nc2.Structure} */
 public class TestStructure {
 
   @Test
   public void testBuilder() {
-    Variable.Builder<?> var = Variable.builder().setName("member").setDataType(DataType.FLOAT);
+    Variable.Builder<?> var = Variable.builder().setName("member").setArrayType(ArrayType.FLOAT);
     Structure struct = Structure.builder().setName("name").addMemberVariable(var)
         .addAttribute(new Attribute("att", "value")).build(makeDummyGroup());
-    assertThat(struct.getDataType()).isEqualTo(DataType.STRUCTURE);
+    assertThat(struct.getArrayType()).isEqualTo(ArrayType.STRUCTURE);
     assertThat(struct.getShortName()).isEqualTo("name");
     assertThat(struct.isScalar()).isTrue();
     assertThat(struct.getVariableNames()).hasSize(1);
     assertThat(struct.getVariableNames().get(0)).isEqualTo("member");
     assertThat(struct.getVariables()).hasSize(1);
     assertThat(struct.getVariables().get(0).getShortName()).isEqualTo("member");
-    assertThat(struct.getVariables().get(0).getDataType()).isEqualTo(DataType.FLOAT);
+    assertThat(struct.getVariables().get(0).getArrayType()).isEqualTo(ArrayType.FLOAT);
 
     assertThat(struct.getElementSize()).isEqualTo(4);
     assertThat(struct.isSubset()).isFalse();
@@ -37,7 +36,7 @@ public class TestStructure {
   public void testBuilderChain() {
     Structure struct =
         Structure.builder().setName("struct").addMemberVariables(ImmutableList.of()).build(makeDummyGroup());
-    assertThat(struct.getDataType()).isEqualTo(DataType.STRUCTURE);
+    assertThat(struct.getArrayType()).isEqualTo(ArrayType.STRUCTURE);
     assertThat(struct.getShortName()).isEqualTo("struct");
     assertThat(struct.getVariableNames()).hasSize(0);
     assertThat(struct.getVariables()).hasSize(0);
@@ -45,17 +44,17 @@ public class TestStructure {
 
   @Test
   public void testToBuilderChain() {
-    Variable.Builder<?> var = Variable.builder().setName("member").setDataType(DataType.FLOAT);
+    Variable.Builder<?> var = Variable.builder().setName("member").setArrayType(ArrayType.FLOAT);
     Structure struct = Structure.builder().setName("name").addMemberVariable(var).build(makeDummyGroup());
     Structure struct2 = struct.toBuilder().setName("s2").build(makeDummyGroup());
-    assertThat(struct2.getDataType()).isEqualTo(DataType.STRUCTURE);
+    assertThat(struct2.getArrayType()).isEqualTo(ArrayType.STRUCTURE);
     assertThat(struct2.getShortName()).isEqualTo("s2");
 
     assertThat(struct.getVariableNames()).hasSize(1);
     assertThat(struct.getVariableNames().get(0)).isEqualTo("member");
     assertThat(struct.getVariables()).hasSize(1);
     assertThat(struct.getVariables().get(0).getShortName()).isEqualTo("member");
-    assertThat(struct.getVariables().get(0).getDataType()).isEqualTo(DataType.FLOAT);
+    assertThat(struct.getVariables().get(0).getArrayType()).isEqualTo(ArrayType.FLOAT);
 
     assertThat(struct2.getElementSize()).isEqualTo(4);
     assertThat(struct2.isSubset()).isFalse();
@@ -63,14 +62,14 @@ public class TestStructure {
 
   @Test
   public void testNestedStructure() {
-    Variable.Builder<?> varb1 = Variable.builder().setName("var1").setDataType(DataType.FLOAT);
+    Variable.Builder<?> varb1 = Variable.builder().setName("var1").setArrayType(ArrayType.FLOAT);
     Structure.Builder<?> structb = Structure.builder().setName("top").addMemberVariable(varb1);
-    Variable.Builder<?> varb2 = Variable.builder().setName("var2").setDataType(DataType.FLOAT);
+    Variable.Builder<?> varb2 = Variable.builder().setName("var2").setArrayType(ArrayType.FLOAT);
     Structure.Builder<?> structb2 = Structure.builder().setName("nested").addMemberVariable(varb2);
 
     Structure struct = structb.addMemberVariable(structb2).build(makeDummyGroup());
 
-    assertThat(struct.getDataType()).isEqualTo(DataType.STRUCTURE);
+    assertThat(struct.getArrayType()).isEqualTo(ArrayType.STRUCTURE);
     assertThat(struct.getShortName()).isEqualTo("top");
     assertThat(struct.getElementSize()).isEqualTo(8);
 
@@ -81,25 +80,25 @@ public class TestStructure {
 
     Variable nestedVar = nested.findVariable("var2");
     assertThat(nestedVar).isNotNull();
-    assertThat(nestedVar.getDataType()).isEqualTo(DataType.FLOAT);
+    assertThat(nestedVar.getArrayType()).isEqualTo(ArrayType.FLOAT);
 
     assertThat(struct.getNumberOfMemberVariables()).isEqualTo(2);
     assertThat(nested.getNumberOfMemberVariables()).isEqualTo(1);
     assertThat(struct.findVariable(null)).isNull();
 
-    StructureMembers sm = struct.makeStructureMembers();
+    StructureMembers sm = struct.makeStructureMembersBuilder().build();
     assertThat(sm.findMember("var1")).isNotNull();
     assertThat(sm.findMember("nested")).isNotNull();
 
-    StructureMembers smNested = nested.makeStructureMembers();
+    StructureMembers smNested = nested.makeStructureMembersBuilder().build();
     assertThat(smNested.findMember("var1")).isNull();
     assertThat(smNested.findMember("var2")).isNotNull();
   }
 
   @Test
   public void testSelect() {
-    Variable.Builder<?> varb1 = Variable.builder().setName("var1").setDataType(DataType.FLOAT);
-    Variable.Builder<?> varb2 = Variable.builder().setName("var2").setDataType(DataType.INT);
+    Variable.Builder<?> varb1 = Variable.builder().setName("var1").setArrayType(ArrayType.FLOAT);
+    Variable.Builder<?> varb2 = Variable.builder().setName("var2").setArrayType(ArrayType.INT);
     Structure.Builder<?> structb =
         Structure.builder().setName("top").addMemberVariables(ImmutableList.of(varb1, varb2));
     Structure struct = structb.build(makeDummyGroup());
@@ -118,9 +117,9 @@ public class TestStructure {
   public void testAddMembers() {
     Group.Builder parent = Group.builder();
     Structure.Builder<?> structb = Structure.builder().setName("struct").setParentGroupBuilder(parent)
-        .addMemberVariable("one", DataType.BYTE, "").addMemberVariable("two", DataType.CHAR, "");
+        .addMemberVariable("one", ArrayType.BYTE, "").addMemberVariable("two", ArrayType.CHAR, "");
 
-    Variable.Builder<?> two = Variable.builder().setName("two").setDataType(DataType.FLOAT);
+    Variable.Builder<?> two = Variable.builder().setName("two").setArrayType(ArrayType.FLOAT);
     assertThat(structb.replaceMemberVariable(two)).isTrue();
 
     assertThat(structb.removeMemberVariable("one")).isTrue();

--- a/cdm-core/src/test/java/ucar/nc2/TestVariableSimpleBuilder.java
+++ b/cdm-core/src/test/java/ucar/nc2/TestVariableSimpleBuilder.java
@@ -78,7 +78,7 @@ public class TestVariableSimpleBuilder {
   @Test
   public void testMakeMember() {
     StructureMembers.MemberBuilder mb = StructureMembers.memberBuilder().setName("name").setDesc("desc")
-        .setUnits("units").setArrayType(ArrayType.INT).setShape(new int[] {22, 6});
+        .setUnits("units").setArrayType(ArrayType.INT).setShape(new int[] {22, 6}).setOffset(0);
     VariableSimpleBuilder builder = VariableSimpleBuilder.fromMember(mb.build(0, false));
 
     VariableSimpleIF vs = builder.build();

--- a/cdm-core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingForStructure.java
+++ b/cdm-core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingForStructure.java
@@ -1,119 +1,102 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package ucar.nc2.dataset;
 
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
+import ucar.array.ArrayType;
+import ucar.array.InvalidRangeException;
+import ucar.array.StructureData;
+import ucar.array.StructureMembers;
+import ucar.array.Array;
+import ucar.array.Index;
 import ucar.nc2.*;
 import ucar.unidata.util.test.TestDir;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class TestScaleOffsetMissingForStructure {
-  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
   public void testNetcdfFile() throws IOException, InvalidRangeException {
     DatasetUrl durl = DatasetUrl.findDatasetUrl(TestDir.cdmLocalTestDataDir + "testScaleRecord.nc");
     try (NetcdfFile ncfile = NetcdfDatasets.openFile(durl, -1, null, NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE)) {
       Variable v = ncfile.findVariable("testScale");
-      assert null != v;
-      assert v.getDataType() == DataType.SHORT;
+      assertThat(v).isNotNull();
+      assertThat(v.getArrayType()).isEqualTo(ArrayType.SHORT);
 
-      Array data = v.read();
+      Array<Short> data = (Array<Short>) v.readArray();
       Index ima = data.getIndex();
-      short val = data.getShort(ima);
-      assert val == -999;
+      short val = data.get(ima);
+      assertThat(val).isEqualTo(-999);
 
       Structure s = (Structure) ncfile.findVariable("record");
-      assert (s != null);
+      assertThat(s).isNotNull();
 
       Variable v2 = s.findVariable("testScale");
       Attribute att = v2.findAttribute("units");
       assert att.getStringValue().equals("m");
       assert v2.getUnitsString().equals("m");
 
-      StructureData sdata = s.readStructure(0);
-      StructureMembers.Member m = sdata.findMember("testScale");
-      assert null != m;
+      StructureData sd = s.readRecord(0);
+      StructureMembers.Member m = sd.getStructureMembers().findMember("testScale");
+      assertThat(m).isNotNull();
       assert m.getUnitsString().equals("m");
 
-      double dval = sdata.convertScalarDouble(m.getName());
-      assert dval == -999.0;
+      Array<Number> marr = (Array<Number>) sd.getMemberData(m);
+      double dval = marr.getScalar().doubleValue();
+      assertThat(dval).isEqualTo(-999.0);
 
       int count = 0;
-      try (StructureDataIterator siter = s.getStructureIterator()) {
-        while (siter.hasNext()) {
-          sdata = siter.next();
-          m = sdata.findMember("testScale");
-          assert m != null;
-          assert m.getUnitsString().equals("m");
-          dval = sdata.convertScalarDouble(m.getName());
-          double expect = (count == 0) ? -999.0 : 13.0;
-          assert dval == expect : dval + "!=" + expect;
-          count++;
-        }
+      Array<StructureData> sdarr = (Array<StructureData>) s.readArray();
+      for (StructureData sdata : sdarr) {
+        m = sdata.getStructureMembers().findMember("testScale");
+        assertThat(m).isNotNull();
+        assert m.getUnitsString().equals("m");
+        marr = (Array<Number>) sdata.getMemberData(m);
+        dval = marr.getScalar().doubleValue();
+        double expect = (count == 0) ? -999.0 : 13.0;
+        assertThat(dval).isEqualTo(expect);
+        count++;
       }
     }
   }
 
   @Test
   public void testNetcdfDataset() throws IOException, InvalidRangeException {
-    NetcdfDataset ncfile = NetcdfDatasets.openDataset(TestDir.cdmLocalTestDataDir + "testScaleRecord.nc", true, null,
-        NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
-    System.out.printf("Open %s%n", ncfile.getLocation());
-    VariableDS v = (VariableDS) ncfile.findVariable("testScale");
-    assert null != v;
-    assert v.getDataType() == DataType.FLOAT;
+    try (NetcdfDataset ncfile = NetcdfDatasets.openDataset(TestDir.cdmLocalTestDataDir + "testScaleRecord.nc", true,
+        null, NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE)) {
+      System.out.printf("Open %s%n", ncfile.getLocation());
+      VariableDS v = (VariableDS) ncfile.findVariable("testScale");
+      assertThat(v).isNotNull();
+      assertThat(v.getArrayType()).isEqualTo(ArrayType.FLOAT);
 
-    Array data = v.read();
-    Index ima = data.getIndex();
-    float val = data.getFloat(ima);
-    assert v.isMissing(val);
-    assert Float.isNaN(val) : val;
+      Array<Float> data = (Array<Float>) v.readArray();
+      Index ima = data.getIndex();
+      float val = data.get(ima);
+      assertThat(val).isNaN();
 
-    ncfile.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
-    Structure s = (Structure) ncfile.findVariable("record");
-    assert (s != null);
+      ncfile.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
+      Structure s = (Structure) ncfile.findVariable("record");
+      assertThat(s).isNotNull();
 
-    VariableDS vm = (VariableDS) s.findVariable("testScale");
-    Array vmData = vm.read();
-    if (vmData.hasNext()) {
-      float vmval = vmData.nextFloat();
-      assert vm.isMissing(vmval);
-      assert Float.isNaN(vmval) : vmval;
+      VariableDS vm = (VariableDS) s.findVariable("testScale");
+      Array<Float> vmData = (Array<Float>) vm.readArray();
+      float vmval = vmData.getScalar();
+      assertThat(vm.isMissing(vmval)).isTrue();
+      assertThat(vmval).isNaN();
+
+      StructureData sd = s.readRecord(0);
+      StructureMembers.Member m = sd.getStructureMembers().findMember("testScale");
+      assertThat(m).isNotNull();
+      assert m.getUnitsString().equals("m");
+
+      Array<Number> marr = (Array<Number>) sd.getMemberData(m);
+      double dval = marr.getScalar().doubleValue();
+      assertThat(dval).isNaN();
     }
-
-    StructureData sdata = s.readStructure(0);
-    StructureMembers.Member m = sdata.findMember("testScale");
-    assert null != m;
-
-    /*
-     * LOOK heres the problem where StructureData.getScalarXXX doesnt use enhanced values
-     * float dval = sdata.getScalarFloat( m.getName());
-     * assert Float.isNaN(dval) : dval;
-     * 
-     * int count = 0;
-     * StructureDataIterator siter = s.getStructureIterator();
-     * while (siter.hasNext()) {
-     * sdata = siter.next();
-     * m = sdata.findMember("testScale");
-     * assert null != m;
-     * 
-     * dval = sdata.getScalarFloat( m);
-     * if (count == 0)
-     * assert Float.isNaN(dval) : dval;
-     * else
-     * assert TestAll.nearlyEquals(dval, 1040.8407) : dval;
-     * count++;
-     * }
-     */
-
-    ncfile.close();
   }
 
   @Test
@@ -122,7 +105,7 @@ public class TestScaleOffsetMissingForStructure {
         null, NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE)) {
       VariableDS v = (VariableDS) ncfile.findVariable("testScale");
       assert null != v;
-      assert v.getDataType() == DataType.FLOAT;
+      assert v.getArrayType() == ArrayType.FLOAT;
 
       assert v.getUnitsString().equals("m");
       assert v.attributes().findAttributeString("units", "").equals("m");
@@ -132,22 +115,26 @@ public class TestScaleOffsetMissingForStructure {
 
       Variable v2 = s.findVariable("testScale");
       assert v2.getUnitsString().equals("m");
-      assert v2.getDataType() == DataType.FLOAT;
+      assert v2.getArrayType() == ArrayType.FLOAT;
 
-      StructureData sdata = s.readStructure(0);
-      StructureMembers.Member m = sdata.findMember("testScale");
+      StructureData sd = s.readRecord(0);
+      StructureMembers.Member m = sd.getStructureMembers().findMember("testScale");
       assert null != m;
       assert m.getUnitsString().equals("m") : m.getUnitsString();
-      assert m.getDataType() == DataType.FLOAT;
+      assert m.getArrayType() == ArrayType.FLOAT;
 
-      try (StructureDataIterator siter = s.getStructureIterator()) {
-        while (siter.hasNext()) {
-          sdata = siter.next();
-          m = sdata.findMember("testScale");
-          assert null != m;
-          assert m.getUnitsString().equals("m");
-        }
+      int count = 0;
+      Array<StructureData> sdarr = (Array<StructureData>) s.readArray();
+      for (StructureData sdata : sdarr) {
+        m = sdata.getStructureMembers().findMember("testScale");
+        assertThat(m).isNotNull();
+        assert m.getUnitsString().equals("m");
+        Array<Number> marr = (Array<Number>) sd.getMemberData(m);
+        double dval = marr.getScalar().doubleValue();
+        assertThat(dval).isNaN();
+        count++;
       }
+
     }
   }
 }

--- a/cdm-core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingUnsigned.java
+++ b/cdm-core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingUnsigned.java
@@ -12,13 +12,20 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
+import ucar.array.Array;
+import ucar.array.ArrayType;
+import ucar.array.Arrays;
+import ucar.array.InvalidRangeException;
+import ucar.array.IsMissingEvaluator;
+import ucar.array.MinMax;
+import ucar.array.Section;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.internal.dataset.EnhanceScaleMissingUnsigned;
+import ucar.nc2.internal.util.CompareArrayToArray;
 import ucar.nc2.internal.util.CompareNetcdf2;
 import ucar.nc2.util.Misc;
-import ucar.nc2.write.Ncdump;
+import ucar.nc2.write.NcdumpArray;
 import ucar.nc2.write.NetcdfFormatWriter;
 import ucar.unidata.util.test.Assert2;
 import ucar.nc2.dataset.NetcdfDataset.Enhance;
@@ -27,6 +34,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URISyntaxException;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -40,8 +48,7 @@ public class TestScaleOffsetMissingUnsigned {
   @Test
   public void testWrite() throws Exception {
     String filename = tempFolder.newFile().getAbsolutePath();
-    ArrayDouble unpacked;
-    MAMath.ScaleOffset so;
+    ScaleOffset so;
 
     NetcdfFormatWriter.Builder writerb = NetcdfFormatWriter.createNewNetcdf3(filename);
 
@@ -51,67 +58,69 @@ public class TestScaleOffsetMissingUnsigned {
     int n = lonDim.getLength();
 
     // create an array
-    unpacked = new ArrayDouble.D2(latDim.getLength(), lonDim.getLength());
-    Index ima = unpacked.getIndex();
-
+    double[] parray = new double[latDim.getLength() * lonDim.getLength()];
+    int count = 0;
     for (int i = 0; i < latDim.getLength(); i++) {
       for (int j = 0; j < lonDim.getLength(); j++) {
-        unpacked.setDouble(ima.set(i, j), (i * n + j) + 30.0);
+        parray[count++] = (i * n + j) + 30.0;
       }
     }
+    Array<Number> unpacked =
+        Arrays.factory(ArrayType.DOUBLE, new int[] {latDim.getLength(), lonDim.getLength()}, parray);
+
     double missingValue = -9999;
     int nbits = 16;
 
     // convert to packed form
-    so = MAMath.calcScaleOffsetSkipMissingData(unpacked, missingValue, nbits);
-    writerb.addVariable("unpacked", DataType.DOUBLE, "lat lon");
-    writerb.addVariable("packed", DataType.SHORT, "lat lon")
+    so = calcScaleOffsetSkipMissingData(unpacked, missingValue, nbits);
+    writerb.addVariable("unpacked", ArrayType.DOUBLE, "lat lon");
+    writerb.addVariable("packed", ArrayType.SHORT, "lat lon")
         .addAttribute(new Attribute(CDM.MISSING_VALUE, (short) -9999))
         .addAttribute(new Attribute(CDM.SCALE_FACTOR, so.scale)).addAttribute(new Attribute(CDM.ADD_OFFSET, so.offset));
 
     // create and write to the file
-    Array packed = MAMath.convert2packed(unpacked, missingValue, nbits, DataType.SHORT);
+    Array<Number> packed = convert2packedShort(unpacked, missingValue, nbits);
     try (NetcdfFormatWriter writer = writerb.build()) {
-      writer.write("unpacked", unpacked);
-      writer.write("packed", packed);
+      writer.write(writer.findVariable("unpacked"), unpacked.getIndex(), unpacked);
+      writer.write(writer.findVariable("packed"), packed.getIndex(), packed);
     }
 
     // read the packed form, compare to original
-    Array readPacked;
+    Array<Number> readPacked;
     try (NetcdfFile ncfileRead = NetcdfFiles.open(filename)) {
       Variable v = ncfileRead.findVariable("packed");
       assertThat(v).isNotNull();
-      readPacked = v.read();
+      readPacked = (Array<Number>) v.readArray();
       CompareNetcdf2.compareData("packed", packed, readPacked);
     }
 
-    Array readEnhanced;
+    Array<Number> readEnhanced;
 
     // read the packed form, enhance using scale/offset (but not missing), compare to original
     Set<Enhance> enhance = new HashSet<>(NetcdfDataset.getDefaultEnhanceMode());
     enhance.remove(Enhance.ConvertMissing);
     try (NetcdfDataset ncd = NetcdfDatasets.openDataset(filename, enhance, null)) {
       VariableDS vs = (VariableDS) ncd.findVariable("packed");
-      readEnhanced = vs.read();
+      readEnhanced = (Array<Number>) vs.readArray();
 
       nearlyEquals(packed, unpacked, readEnhanced, 1.0 / so.scale);
     }
 
-    Array convertPacked = MAMath.convert2Unpacked(readPacked, so);
+    Array<Number> convertPacked = convert2Unpacked(readPacked, so);
     nearlyEquals(packed, convertPacked, readEnhanced, 1.0 / so.scale);
 
     doSubset(filename);
   }
 
-  private void nearlyEquals(Array packed, Array data1, Array data2, double close) {
-    IndexIterator iterp = packed.getIndexIterator();
-    IndexIterator iter1 = data1.getIndexIterator();
-    IndexIterator iter2 = data2.getIndexIterator();
+  private void nearlyEquals(Array<Number> packed, Array<Number> data1, Array<Number> data2, double close) {
+    Iterator<Number> iterp = packed.iterator();
+    Iterator<Number> iter1 = data1.iterator();
+    Iterator<Number> iter2 = data2.iterator();
 
-    while (iter1.hasNext()) {
-      double v1 = iter1.getDoubleNext();
-      double v2 = iter2.getDoubleNext();
-      double p = iterp.getDoubleNext();
+    while (iterp.hasNext()) {
+      double p = iterp.next().doubleValue();
+      double v1 = iter1.next().doubleValue();
+      double v2 = iter2.next().doubleValue();
       double diff = Math.abs(v1 - v2);
       assert (diff < close) : v1 + " != " + v2 + " index=" + iter1 + " packed=" + p;
     }
@@ -125,14 +134,13 @@ public class TestScaleOffsetMissingUnsigned {
       assert vs != null;
 
       Section s = Section.builder().appendRange(1, 1).appendRange(1, 1).build();
-      Array readEnhanced = vs.read(s);
-      logger.debug(Ncdump.printArray(readEnhanced));
+      Array readEnhanced = vs.readArray(s);
+      logger.debug(NcdumpArray.printArray(readEnhanced));
 
       Variable sec = vs.section(s);
-      Array readSection = sec.read();
-      logger.debug(Ncdump.printArray(readSection));
-
-      CompareNetcdf2.compareData(vs.getShortName(), readEnhanced, readSection);
+      Array readSection = sec.readArray();
+      logger.debug(NcdumpArray.printArray(readSection));
+      CompareArrayToArray.compareData(vs.getShortName(), readEnhanced, readSection);
     }
   }
 
@@ -199,29 +207,29 @@ public class TestScaleOffsetMissingUnsigned {
       // This assertion failed before the bug was fixed.
       Assert.assertTrue(proxy.isFillValue(-0.01));
 
-      Array fooVals = fooVar.read();
+      Array<Float> fooVals = (Array<Float>) fooVar.readArray();
       Assert.assertEquals(4, fooVals.getSize());
 
       // foo[0] == -1 (raw); Double.NaN (scaled). It is equal to fill value and outside of valid_range.
-      Assert2.assertNearlyEquals(Double.NaN, fooVals.getDouble(0), Misc.defaultMaxRelativeDiffFloat);
+      assertThat(fooVals.get(0)).isNaN();
       Assert.assertTrue(proxy.isFillValue(-0.01));
       Assert.assertTrue(proxy.isMissingValue(-0.01));
       Assert.assertTrue(proxy.isInvalidData(-0.01));
       Assert.assertTrue(proxy.isMissing(-0.01));
 
       // foo[1] == 0 (raw); 0.00 (scaled). It is within valid_range.
-      Assert2.assertNearlyEquals(0.00, fooVals.getDouble(1), Misc.defaultMaxRelativeDiffFloat);
+      Assert2.assertNearlyEquals(0.00, fooVals.get(1), Misc.defaultMaxRelativeDiffFloat);
       Assert.assertFalse(proxy.isInvalidData(0.00));
       Assert.assertFalse(fooVar.isMissing(0.00));
 
       // foo[2] == 100 (raw); 1.00 (scaled). It is within valid_range.
-      Assert2.assertNearlyEquals(1.00, fooVals.getDouble(2), Misc.defaultMaxRelativeDiffFloat);
+      Assert2.assertNearlyEquals(1.00, fooVals.get(2), Misc.defaultMaxRelativeDiffFloat);
       // These assertions failed before the bug was fixed.
       Assert.assertFalse(proxy.isInvalidData(1.00));
       Assert.assertFalse(fooVar.isMissing(1.00));
 
       // foo[3] == 101 (raw); Double.NaN, (scaled). It is outside of valid_range.
-      Assert2.assertNearlyEquals(Double.NaN, fooVals.getDouble(3), Misc.defaultMaxRelativeDiffFloat);
+      Assert2.assertNearlyEquals(Double.NaN, fooVals.get(3), Misc.defaultMaxRelativeDiffFloat);
       Assert.assertTrue(proxy.isMissingValue(1.01));
       Assert.assertTrue(proxy.isInvalidData(1.01));
       Assert.assertTrue(fooVar.isMissing(1.01));
@@ -249,29 +257,29 @@ public class TestScaleOffsetMissingUnsigned {
       // This assertion failed before the bug was fixed.
       Assert.assertTrue(proxy.isFillValue(-0.01));
 
-      Array fooVals = fooVar.read();
+      Array<Float> fooVals = (Array<Float>) fooVar.readArray();
       Assert.assertEquals(4, fooVals.getSize());
 
       // foo[0] == -1 (raw); -0.01 (scaled). It is equal to fill value and outside of valid_range.
-      Assert2.assertNearlyEquals(-0.01, fooVals.getDouble(0), Misc.defaultMaxRelativeDiffFloat);
+      assertThat(fooVals.get(0)).isWithin(Misc.defaultMaxRelativeDiffFloat).of(-0.01f);
       Assert.assertTrue(proxy.isFillValue(-0.01));
       Assert.assertTrue(proxy.isMissingValue(-0.01));
       Assert.assertTrue(proxy.isInvalidData(-0.01));
       Assert.assertTrue(proxy.isMissing(-0.01));
 
       // foo[1] == 0 (raw); 0.00 (scaled). It is within valid_range.
-      Assert2.assertNearlyEquals(0.00, fooVals.getDouble(1), Misc.defaultMaxRelativeDiffFloat);
+      Assert2.assertNearlyEquals(0.00, fooVals.get(1), Misc.defaultMaxRelativeDiffFloat);
       Assert.assertFalse(proxy.isInvalidData(0.00));
       Assert.assertFalse(fooVar.isMissing(0.00));
 
       // foo[2] == 100 (raw); 1.00 (scaled). It is within valid_range.
-      Assert2.assertNearlyEquals(1.00, fooVals.getDouble(2), Misc.defaultMaxRelativeDiffFloat);
+      Assert2.assertNearlyEquals(1.00, fooVals.get(2), Misc.defaultMaxRelativeDiffFloat);
       // These assertions failed before the bug was fixed.
       Assert.assertFalse(proxy.isInvalidData(1.00));
       Assert.assertFalse(fooVar.isMissing(1.00));
 
       // foo[3] == 101 (raw); 1.01 (scaled). It is outside of valid_range.
-      Assert2.assertNearlyEquals(1.01, fooVals.getDouble(3), Misc.defaultMaxRelativeDiffFloat);
+      Assert2.assertNearlyEquals(1.01, fooVals.get(3), Misc.defaultMaxRelativeDiffFloat);
       Assert.assertTrue(proxy.isMissingValue(1.01));
       Assert.assertTrue(proxy.isInvalidData(1.01));
       Assert.assertTrue(fooVar.isMissing(1.01));
@@ -297,7 +305,7 @@ public class TestScaleOffsetMissingUnsigned {
       Assert2.assertNearlyEquals(255, proxy.getMissingValues()[0]);
 
       // "missingUnsigned" was originally UBYTE, but was widened to accommodate unsigned conversion.
-      Assert.assertEquals(DataType.USHORT, var.getDataType());
+      Assert.assertEquals(ArrayType.USHORT, var.getArrayType());
 
       // Packed values are: -107, -106, -6, -5, -1, 80. Interpreting them as unsigned yields:
       short[] expecteds = new short[] {149, 150, 250, 251, 255, 80};
@@ -336,7 +344,7 @@ public class TestScaleOffsetMissingUnsigned {
        * unsigned, then {@link #getScaledOffsetMissingType()} will be unsigned as well.
        * </li>
        */
-      Assert.assertEquals(DataType.UINT, var.getDataType());
+      Assert.assertEquals(ArrayType.UINT, var.getArrayType());
 
       // These vals are the same as ones from "missingUnsigned", but with a scale_factor of 100 and offset of 1 applied.
       int[] expecteds = new int[] {14901, 15001, 25001, 25101, 25501, 8001};
@@ -361,7 +369,7 @@ public class TestScaleOffsetMissingUnsigned {
       Assert.assertEquals(-25501, proxy.getFillValue(), fpTol);
       Assert.assertEquals(-25501, proxy.getMissingValues()[0], fpTol);
       // Because scale and offset are now float (to preserve negative values), var is float
-      Assert.assertEquals(DataType.FLOAT, var.getDataType());
+      Assert.assertEquals(ArrayType.FLOAT, var.getArrayType());
 
       // These vals are the same as ones from "missingUnsigned", but with a scale_factor of -100 and offset of
       // -1 applied.
@@ -382,7 +390,7 @@ public class TestScaleOffsetMissingUnsigned {
       Assert2.assertNearlyEquals(9.9f, (float) proxy.getValidMin());
       Assert2.assertNearlyEquals(10.1f, (float) proxy.getValidMax());
 
-      Assert.assertEquals(DataType.FLOAT, var.getDataType()); // scale_factor is float.
+      Assert.assertEquals(ArrayType.FLOAT, var.getArrayType()); // scale_factor is float.
 
       float[] expecteds = new float[] {Float.NaN, 9.9f, 10.0f, 10.1f, Float.NaN};
       float[] actuals = (float[]) var.read().getStorage();
@@ -410,7 +418,7 @@ public class TestScaleOffsetMissingUnsigned {
       Assert2.assertNearlyEquals(9.9f, (float) proxy.getValidMin());
       Assert2.assertNearlyEquals(10.1f, (float) proxy.getValidMax());
 
-      Assert.assertEquals(DataType.FLOAT, var.getDataType()); // scale_factor is float.
+      Assert.assertEquals(ArrayType.FLOAT, var.getArrayType()); // scale_factor is float.
 
       float[] expecteds = new float[] {9.8f, 9.9f, 10.0f, 10.1f, 10.2f};
       float[] actuals = (float[]) var.read().getStorage();
@@ -427,9 +435,94 @@ public class TestScaleOffsetMissingUnsigned {
       EnhanceScaleMissingUnsigned proxy = var.scaleMissingUnsignedProxy();
 
       Assert.assertEquals(156, proxy.getOffset(), 0);
-      Assert.assertEquals(DataType.BYTE, var.getDataType()); // No change to data type.
+      Assert.assertEquals(ArrayType.BYTE, var.getArrayType()); // No change to data type.
 
       Assert.assertEquals(106, var.read().getByte(0)); // -50 + 156 == 106
+    }
+  }
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  /**
+   * Calculate the scale/offset for an array of numbers.
+   *
+   * <pre>
+   * If signed:
+   *   then
+   *     max value unpacked = 2^(n-1) - 1 packed
+   *     min value unpacked = -(2^(n-1) - 1) packed
+   *   note that -2^(n-1) is unused, and a good place to map missing values
+   *   by solving 2 eq in 2 unknowns, we get:
+   *     scale = (max - min) / (2^n - 2)
+   *     offset = (max + min) / 2
+   * If unsigned then
+   *     max value unpacked = 2^n - 1 packed
+   *     min value unpacked = 0 packed
+   *   and:
+   *     scale = (max - min) / (2^n - 1)
+   *     offset = min
+   *   One could modify this to allow a holder for missing values.
+   * </pre>
+   *
+   * @param a array to convert (not changed)
+   * @param missingValue skip these
+   * @param nbits map into this many bits
+   * @return ScaleOffset, calculated as above.
+   */
+  public static ScaleOffset calcScaleOffsetSkipMissingData(Array<Number> a, double missingValue, int nbits) {
+    MinMax minmax = Arrays.getMinMaxSkipMissingData(a, new IsMissingEvaluator() {
+      public boolean hasMissing() {
+        return true;
+      }
+
+      public boolean isMissing(double val) {
+        return val == missingValue;
+      }
+    });
+
+    if (a.getArrayType().isUnsigned()) {
+      long size = (1L << nbits) - 1;
+      double offset = minmax.min();
+      double scale = (minmax.max() - minmax.min()) / size;
+      return new ScaleOffset(scale, offset);
+
+    } else {
+      long size = (1L << nbits) - 2;
+      double offset = (minmax.max() + minmax.min()) / 2;
+      double scale = (minmax.max() - minmax.min()) / size;
+      return new ScaleOffset(scale, offset);
+    }
+  }
+
+  public static Array<Number> convert2packedShort(Array<Number> unpacked, double missingValue, int nbits) {
+    ScaleOffset scaleOffset = calcScaleOffsetSkipMissingData(unpacked, missingValue, nbits);
+    short[] parray = new short[(int) Arrays.computeSize(unpacked.getShape())];
+    int count = 0;
+    for (Number val : unpacked) {
+      double uv = val.doubleValue();
+      parray[count++] = (short) ((uv - scaleOffset.offset) / scaleOffset.scale);
+    }
+    return Arrays.factory(ArrayType.SHORT, unpacked.getShape(), parray);
+  }
+
+  public static Array<Number> convert2Unpacked(Array<Number> packed, ScaleOffset scaleOffset) {
+    double[] parray = new double[(int) Arrays.computeSize(packed.getShape())];
+    int count = 0;
+    for (Number val : packed) {
+      parray[count++] = val.doubleValue() * scaleOffset.scale + scaleOffset.offset;
+    }
+    return Arrays.factory(ArrayType.DOUBLE, packed.getShape(), parray);
+  }
+
+  /**
+   * Holds a scale and offset.
+   */
+  public static class ScaleOffset {
+    public double scale, offset;
+
+    public ScaleOffset(double scale, double offset) {
+      this.scale = scale;
+      this.offset = offset;
     }
   }
 }

--- a/cdm-test/src/test/java/ucar/nc2/TestStructureIterator.java
+++ b/cdm-test/src/test/java/ucar/nc2/TestStructureIterator.java
@@ -6,21 +6,19 @@ package ucar.nc2;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import ucar.ma2.DataType;
-import ucar.ma2.InvalidRangeException;
-import ucar.ma2.StructureData;
-import ucar.ma2.StructureDataIterator;
+import ucar.array.Array;
+import ucar.array.ArrayType;
+import ucar.array.InvalidRangeException;
+import ucar.array.StructureData;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import ucar.unidata.util.test.TestDir;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /** Test StructureIterator works when opened with IOSP_MESSAGE_ADD_RECORD_STRUCTURE. */
 @Category(NeedsCdmUnitTest.class)
 public class TestStructureIterator {
-  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
   public void testStructureIterator() throws IOException, InvalidRangeException {
@@ -28,17 +26,15 @@ public class TestStructureIterator {
         null, NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE)) {
 
       Structure v = (Structure) ncfile.findVariable("record");
-      assert v != null;
-      assert (v.getDataType() == DataType.STRUCTURE);
+      assertThat(v).isNotNull();
+      assertThat(v.getArrayType()).isEqualTo(ArrayType.STRUCTURE);
+      Array<StructureData> data = (Array<StructureData>) v.readArray();
 
       int count = 0;
-      try (StructureDataIterator si = v.getStructureIterator()) {
-        while (si.hasNext()) {
-          StructureData sd = si.next();
-          count++;
-        }
+      for (StructureData sd : data) {
+        count++;
       }
-      assert count == v.getSize();
+      assertThat(count).isEqualTo(v.getSize());
     }
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/dataset/TestNestedStructuresEnhancement.java
+++ b/cdm-test/src/test/java/ucar/nc2/dataset/TestNestedStructuresEnhancement.java
@@ -8,23 +8,20 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.StructureDataIterator;
+import ucar.array.Array;
 import ucar.nc2.Sequence;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.iosp.bufr.BufrIosp;
-import ucar.ma2.StructureData;
-import ucar.ma2.InvalidRangeException;
-import ucar.ma2.ArrayStructure;
-import ucar.unidata.util.test.Assert2;
+import ucar.array.StructureData;
+import ucar.array.InvalidRangeException;
 import ucar.unidata.util.test.TestDir;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
+import static com.google.common.truth.Truth.assertThat;
+
 /**
  * Test that nested structures get enhanced.
- * 
- * @author caron
- * @since Jul 5, 2008
  */
 public class TestNestedStructuresEnhancement {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -34,22 +31,17 @@ public class TestNestedStructuresEnhancement {
   public void testNestedTable() throws IOException {
     String filename = TestDir.cdmLocalTestDataDir + "dataset/nestedTable.bufr";
     try (NetcdfFile ncfile = ucar.nc2.dataset.NetcdfDatasets.openFile(filename, null)) {
-      logger.debug("Open {}", ncfile.getLocation());
+      System.out.printf("open %s%n", ncfile.getLocation());
       Sequence outer = (Sequence) ncfile.findVariable(BufrIosp.obsRecordName);
-      assert outer != null;
+      assertThat((Object) outer).isNotNull();
 
-      try (StructureDataIterator iter = outer.getStructureIterator()) {
-        StructureData data = null;
-        if (iter.hasNext())
-          data = iter.next();
+      for (StructureData sdata : outer) {
+        assertThat(sdata).isNotNull();
+        assertThat(sdata.getMemberData("Latitude_coarse_accuracy").getScalar()).isEqualTo(32767);
 
-        assert data != null;
-        assert data.getScalarShort("Latitude_coarse_accuracy") == 32767;
-
-        ArrayStructure as = data.getArrayStructure("Geopotential");
-        assert as != null;
-        assert as.getScalarShort(0, as.findMember("Wind_speed")) == 61;
-
+        Array<?> as = sdata.getMemberData("Geopotential");
+        assertThat(as).isNotNull();
+        assertThat((Short) sdata.getMemberData("Wind_speed").getScalar()).isEqualTo(61);
       }
     }
   }
@@ -59,21 +51,17 @@ public class TestNestedStructuresEnhancement {
   public void testNestedTableEnhanced() throws IOException, InvalidRangeException {
     String filename = TestDir.cdmLocalTestDataDir + "dataset/nestedTable.bufr";
     try (NetcdfFile ncfile = ucar.nc2.dataset.NetcdfDatasets.openDataset(filename)) {
-      logger.debug("Open {}", ncfile.getLocation());
+      System.out.printf("open %s%n", ncfile.getLocation());
       SequenceDS outer = (SequenceDS) ncfile.findVariable(BufrIosp.obsRecordName);
-      assert outer != null;
+      assertThat((Object) outer).isNotNull();
 
-      try (StructureDataIterator iter = outer.getStructureIterator()) {
-        StructureData data = null;
-        if (iter.hasNext())
-          data = iter.next();
+      for (StructureData sdata : outer) {
+        assertThat(sdata).isNotNull();
+        assertThat((Double) sdata.getMemberData("Latitude_coarse_accuracy").getScalar()).isNaN();
 
-        assert data != null;
-        assert Double.isNaN(data.getScalarFloat("Latitude_coarse_accuracy"));
-
-        ArrayStructure as = data.getArrayStructure("Geopotential");
-        assert as != null;
-        Assert2.assertNearlyEquals(as.getScalarFloat(0, as.findMember("Wind_speed")), 6.1);
+        Array<?> as = sdata.getMemberData("Geopotential");
+        assertThat(as).isNotNull();
+        assertThat((Float) sdata.getMemberData("Wind_speed").getScalar()).isEqualTo(6.1);
       }
     }
   }

--- a/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5ReadStructure2.java
+++ b/cdm-test/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5ReadStructure2.java
@@ -8,13 +8,20 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.*;
+import ucar.array.Array;
+import ucar.array.ArrayType;
+import ucar.array.Arrays;
+import ucar.array.InvalidRangeException;
+import ucar.array.StructureData;
+import ucar.array.StructureDataArray;
+import ucar.array.StructureMembers;
 import ucar.nc2.*;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
-import ucar.nc2.write.Ncdump;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.lang.invoke.MethodHandles;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Test nc2 read JUnit framework.
@@ -48,7 +55,7 @@ public class TestH5ReadStructure2 {
 
       Variable dset = ncfile.findVariable("CompoundComplex");
       assert (null != dset);
-      assert (dset.getDataType() == DataType.STRUCTURE);
+      assert (dset.getArrayType() == ArrayType.STRUCTURE);
       assert (dset.getRank() == 1);
       assert (dset.getSize() == 6);
 
@@ -57,22 +64,21 @@ public class TestH5ReadStructure2 {
 
       Structure s = (Structure) dset;
 
-      // read all with the iterator
-      StructureDataIterator iter = s.getStructureIterator();
-      while (iter.hasNext()) {
-        StructureData sd = iter.next();
-        assert sd.getScalarInt("a_name") == a_name;
+      Array<StructureData> iter = (Array<StructureData>) s.readArray();
+      for (StructureData sd : iter) {
+        assertThat((Integer) sd.getMemberData("a_name").getScalar()).isEqualTo(a_name);
         a_name++;
-        assert sd.getScalarString("c_name").equals(c_name);
-        String[] results = sd.getJavaArrayString(sd.findMember("b_name"));
-        assert results.length == b_name.length;
+        Array<Byte> carr = (Array<Byte>) sd.getMemberData("c_name");
+        assertThat(Arrays.makeStringFromChar(carr)).isEqualTo(c_name);
+        Array<String> results = (Array<String>) sd.getMemberData("b_name");
+        assertThat(results.length()).isEqualTo(b_name.length);
         int count = 0;
-        for (String r : results)
+        for (String r : results) {
           assert r.equals(b_name[count++]);
+        }
 
-        for (StructureMembers.Member m : sd.getMembers()) {
-          Array data = sd.getArray(m);
-          logger.debug(Ncdump.printArray(data, m.getName(), null));
+        for (StructureMembers.Member m : sd.getStructureMembers()) {
+          Array data = sd.getMemberData(m);
         }
       }
 
@@ -93,7 +99,7 @@ public class TestH5ReadStructure2 {
 
       Variable dset = ncfile.findVariable("CompoundComplex");
       assert (null != dset);
-      assert (dset.getDataType() == DataType.STRUCTURE);
+      assert (dset.getArrayType() == ArrayType.STRUCTURE);
       assert (dset.getRank() == 1);
       assert (dset.getSize() == 6);
 
@@ -103,24 +109,23 @@ public class TestH5ReadStructure2 {
       Structure s = (Structure) dset;
 
       // read all with the iterator
-      StructureDataIterator iter = s.getStructureIterator();
-      while (iter.hasNext()) {
-        StructureData sd = iter.next();
-        assert sd.getScalarInt("a_name") == a_name;
+      Array<StructureData> iter = (Array<StructureData>) s.readArray();
+      for (StructureData sd : iter) {
+        assertThat((Integer) sd.getMemberData("a_name").getScalar()).isEqualTo(a_name);
         a_name++;
-        assert sd.getScalarString("c_name").equals(c_name);
-        String[] results = sd.getJavaArrayString(sd.findMember("b_name"));
-        assert results.length == b_name.length;
+        Array<Byte> carr = (Array<Byte>) sd.getMemberData("c_name");
+        assertThat(Arrays.makeStringFromChar(carr)).isEqualTo(c_name);
+        Array<String> results = (Array<String>) sd.getMemberData("b_name");
+        assertThat(results.length()).isEqualTo(b_name.length);
         int count = 0;
-        for (String r : results)
+        for (String r : results) {
           assert r.equals(b_name[count++]);
+        }
 
-        for (StructureMembers.Member m : sd.getMembers()) {
-          Array data = sd.getArray(m);
-          logger.debug(Ncdump.printArray(data, m.getName(), null));
+        for (StructureMembers.Member m : sd.getStructureMembers()) {
+          Array data = sd.getMemberData(m);
         }
       }
-
     }
     System.out.println("*** testH5StructureDS ok");
 
@@ -149,7 +154,7 @@ public class TestH5ReadStructure2 {
 
       Variable dset = ncfile.findVariable("CompoundNative");
       assert (null != dset);
-      assert (dset.getDataType() == DataType.STRUCTURE);
+      assert (dset.getArrayType() == ArrayType.STRUCTURE);
       assert (dset.getRank() == 1);
       assert (dset.getSize() == 15);
 
@@ -159,13 +164,10 @@ public class TestH5ReadStructure2 {
       Structure s = (Structure) dset;
 
       // read all with the iterator
-      StructureDataIterator iter = s.getStructureIterator();
-      while (iter.hasNext()) {
-        StructureData sd = iter.next();
-
-        for (StructureMembers.Member m : sd.getMembers()) {
-          Array data = sd.getArray(m);
-          logger.debug(Ncdump.printArray(data, m.getName(), null));
+      Array<StructureData> iter = (Array<StructureData>) s.readArray();
+      for (StructureData sd : iter) {
+        for (StructureMembers.Member m : sd.getStructureMembers()) {
+          Array data = sd.getMemberData(m);
         }
       }
 
@@ -187,23 +189,21 @@ public class TestH5ReadStructure2 {
 
       Variable dset = ncfile.findVariable("U-MARF/EPS/IASI_xxx_1C/DATA/IMAGE_LAT_ARRAY");
       assert (null != dset);
-      assert (dset.getDataType() == DataType.STRUCTURE);
+      assert (dset.getArrayType() == ArrayType.STRUCTURE);
       assert (dset.getRank() == 1);
       assert (dset.getSize() == 3600);
 
       Dimension d = dset.getDimension(0);
-      assert (d.getLength() == 3600);
+      assertThat(d.getLength()).isEqualTo(3600);
 
       Structure s = (Structure) dset;
-
-      // read last one - chunked
-      StructureData sd = s.readStructure(3599);
-      assert sd.getScalarInt("LAT[0]") == 70862722;
-      assert sd.getScalarInt("LAT[149]") == 85302263;
+      StructureData sd = s.readRecord(3599);
+      assertThat(sd.getMemberData("LAT[0]").getScalar()).isEqualTo(70862722);
+      assertThat(sd.getMemberData("LAT[149]").getScalar()).isEqualTo(85302263);
 
       // read one at a time
       for (int i = 3590; i < d.getLength(); i++) {
-        s.readStructure(i);
+        s.readRecord(i);
         System.out.println(" read structure " + i);
       }
 
@@ -226,18 +226,19 @@ public class TestH5ReadStructure2 {
 
       Variable dset = ncfile.findVariable("U-MARF/EPS/IASI_xxx_1C/DATA/TIME_DESCR");
       assert (null != dset);
-      assert (dset.getDataType() == DataType.STRUCTURE);
+      assert (dset.getArrayType() == ArrayType.STRUCTURE);
       assert (dset.getRank() == 1);
       assert (dset.getSize() == 60);
 
       Dimension d = dset.getDimension(0);
       assert (d.getLength() == 60);
 
-      ArrayStructure data = (ArrayStructure) dset.read();
+      StructureDataArray data = (StructureDataArray) dset.readArray();
       StructureMembers.Member m = data.getStructureMembers().findMember("EntryName");
       assert m != null;
       for (int i = 0; i < dset.getSize(); i++) {
-        String r = data.getScalarString(i, m);
+        Array<Byte> carr = (Array<Byte>) data.get(i).getMemberData(m);
+        String r = Arrays.makeStringFromChar(carr);
         if (i % 2 == 0)
           assert r.equals("TIME[" + i / 2 + "]-days") : r + " at " + i;
         else

--- a/gcdm/src/main/java/ucar/gcdm/client/GcdmNetcdfFile.java
+++ b/gcdm/src/main/java/ucar/gcdm/client/GcdmNetcdfFile.java
@@ -49,11 +49,6 @@ public class GcdmNetcdfFile extends NetcdfFile {
   }
 
   @Override
-  protected ucar.ma2.Array readData(Variable v, Section sectionWanted) throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   protected StructureDataIterator getStructureIterator(Structure s, int bufferSize) {
     throw new UnsupportedOperationException();
   }

--- a/toolsui/uicdm/src/main/java/ucar/ui/grib/Grib1DataTable.java
+++ b/toolsui/uicdm/src/main/java/ucar/ui/grib/Grib1DataTable.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
-
 package ucar.ui.grib;
 
 import com.google.common.collect.ImmutableList;
@@ -10,14 +9,15 @@ import thredds.featurecollection.FeatureCollectionConfig;
 import thredds.inventory.CollectionAbstract;
 import thredds.inventory.MCollection;
 import thredds.inventory.MFile;
-import ucar.ma2.Array;
-import ucar.ma2.DataType;
+import ucar.array.Array;
+import ucar.array.ArrayType;
+import ucar.array.Arrays;
 import ucar.nc2.grib.GribData;
 import ucar.nc2.grib.collection.Grib1Iosp;
 import ucar.nc2.grib.grib1.*;
 import ucar.nc2.grib.grib1.tables.Grib1Customizer;
 import ucar.nc2.calendar.CalendarDate;
-import ucar.nc2.write.Ncdump;
+import ucar.nc2.write.NcdumpArray;
 import ucar.ui.widget.*;
 import ucar.ui.widget.PopupMenu;
 import ucar.nc2.util.Misc;
@@ -30,8 +30,15 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.*;
 import java.nio.ByteOrder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /** Show Grib1 data. */
 public class Grib1DataTable extends JPanel {
@@ -609,8 +616,8 @@ public class Grib1DataTable extends JPanel {
 
     } else {
       int[] shape = {bean.gdss.getNy(), bean.gdss.getNx()};
-      Array dataA = Array.factory(DataType.FLOAT, shape, data);
-      f.format("%s%n", Ncdump.printArray(dataA));
+      Array dataA = Arrays.factory(ArrayType.FLOAT, shape, data);
+      f.format("%s%n", NcdumpArray.printArray(dataA));
     }
 
     float max = -Float.MAX_VALUE;
@@ -662,7 +669,7 @@ public class Grib1DataTable extends JPanel {
     int count = 0;
     int bits = 0;
     for (byte b : bitmap) {
-      short s = DataType.unsignedByteToShort(b);
+      short s = ArrayType.unsignedByteToShort(b);
       bits += Long.bitCount(s);
       f.format("%8s", Long.toBinaryString(s));
       if (++count % 10 == 0)
@@ -905,7 +912,7 @@ public class Grib1DataTable extends JPanel {
       return info.nPoints;
     }
 
-    public String getDataType() {
+    public String getArrayType() {
       return info.getDataTypeS();
     }
 

--- a/toolsui/uicdm/src/main/java/ucar/ui/grib/Grib2CollectionPanel.java
+++ b/toolsui/uicdm/src/main/java/ucar/ui/grib/Grib2CollectionPanel.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
-
 package ucar.ui.grib;
 
 import com.google.common.collect.ImmutableList;
@@ -13,8 +12,9 @@ import thredds.inventory.CollectionAbstract;
 import thredds.inventory.CollectionUpdateType;
 import thredds.inventory.MCollection;
 import thredds.inventory.MFile;
-import ucar.ma2.Array;
-import ucar.ma2.DataType;
+import ucar.array.Array;
+import ucar.array.Arrays;
+import ucar.array.ArrayType;
 import ucar.nc2.grib.*;
 import ucar.nc2.grib.collection.GribCdmIndex;
 import ucar.nc2.grib.collection.GribCollectionImmutable;
@@ -22,7 +22,7 @@ import ucar.nc2.grib.coord.TimeCoordIntvDateValue;
 import ucar.nc2.grib.grib2.*;
 import ucar.nc2.grib.grib2.table.Grib2Tables;
 import ucar.nc2.calendar.CalendarDate;
-import ucar.nc2.write.Ncdump;
+import ucar.nc2.write.NcdumpArray;
 import ucar.ui.widget.*;
 import ucar.ui.widget.PopupMenu;
 import ucar.nc2.util.Misc;
@@ -37,8 +37,17 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.beans.SimpleBeanInfo;
 import java.io.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * A widget to show collections of GRIB2 files.
@@ -901,8 +910,8 @@ public class Grib2CollectionPanel extends JPanel {
     Grib2Gds gds = bean1.gr.getGDS();
 
     int[] shape = {gds.getNy(), gds.getNx()};
-    Array arr = Array.factory(DataType.FLOAT, shape, data);
-    f.format("%s", Ncdump.printArray(arr));
+    Array arr = Arrays.factory(ArrayType.FLOAT, shape, data);
+    f.format("%s", NcdumpArray.printArray(arr));
   }
 
   /////////////////////////////////////////////////////////
@@ -972,7 +981,7 @@ public class Grib2CollectionPanel extends JPanel {
       byte[] bytes = gds.getRawBytes();
       int count = 1;
       for (byte b : bytes) {
-        short s = DataType.unsignedByteToShort(b);
+        short s = ArrayType.unsignedByteToShort(b);
         f.format(" %d : %d%n", count++, s);
       }
     }
@@ -1214,7 +1223,7 @@ public class Grib2CollectionPanel extends JPanel {
       byte[] bytes = gr.getPDSsection().getRawBytes();
       int count = 1;
       for (byte b : bytes) {
-        short s = DataType.unsignedByteToShort(b);
+        short s = ArrayType.unsignedByteToShort(b);
         f.format(" %d : %d%n", count++, s);
       }
     }


### PR DESCRIPTION
Port ui.Grib1DataTable, ui.Grib2CollectionPanel to ucar.array.
Allow getMemberVlenData to return Vlen or regular Arrays. This may be wrong, since how do you know which?
Check if StructureMembers.Member offset is set.
Remove deprecated methods in Structure, Sequence, Variable where possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/netcdf-java/902)
<!-- Reviewable:end -->
