### PR TITLE
[5.x]: Modify XML Schema and DTD URLs for Unidata hostname switch

### DIFF
--- a/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfig1.0.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfig1.0.xml
@@ -7,7 +7,7 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
   xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v0.5"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
   >
   <dataset name="THREDDS CatalogGen test config file">
     <dataset name="NCEP Eta 80km CONUS model data">

--- a/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfigNew1.0.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/config/test1CatGenConfigNew1.0.xml
@@ -7,8 +7,8 @@
          xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
          xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd
-                      http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v1.0 http://www.unidata.ucar.edu/schemas/thredds/CatalogGenConfig.1.0.xsd"
+         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd
+                      http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v1.0 https://schemas.unidata.ucar.edu/thredds/CatalogGenConfig.1.0.xsd"
   >
   <service name="mlode" serviceType="DODS" base="http://localhost:8080/thredds/cataloggen/"/>
   <dataset name="THREDDS CatalogGen test config file">

--- a/cdm-test/src/test/data/thredds/cataloggen/testCatGen.badAccessPoint.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/testCatGen.badAccessPoint.xml
@@ -3,10 +3,10 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
   xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v0.5"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
 >
 <!--?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE catalog SYSTEM "http://www.unidata.ucar.edu/schemas/thredds/CatalogGenConfig.0.5.dtd"-->
+<!DOCTYPE catalog SYSTEM "https://schemas.unidata.ucar.edu/thredds/CatalogGenConfig.0.5.dtd"-->
   <dataset name="CatGen Test for Bad Access Points">
       <metadata inherited="true">
           <serviceName>testServer</serviceName>

--- a/cdm-test/src/test/data/thredds/cataloggen/testCatGen.uahRadarLevelII.xml
+++ b/cdm-test/src/test/data/thredds/cataloggen/testCatGen.uahRadarLevelII.xml
@@ -3,10 +3,10 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
   xmlns:catGen="http://www.unidata.ucar.edu/namespaces/thredds/CatalogGenConfig/v0.5"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
 >
 <!--?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE catalog SYSTEM "http://www.unidata.ucar.edu/schemas/thredds/CatalogGenConfig.0.5.dtd"-->
+<!DOCTYPE catalog SYSTEM "https://schemas.unidata.ucar.edu/thredds/CatalogGenConfig.0.5.dtd"-->
   <dataset name="UAH/ITSC Data Pool NEXRAD Level 2">
       <metadata inherited="true">
           <serviceName>Data Pool server</serviceName>

--- a/cdm/core/src/main/java/ucar/nc2/ncml/NcMLGWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/ncml/NcMLGWriter.java
@@ -31,7 +31,7 @@ import ucar.unidata.util.Parameter;
 @Deprecated
 public class NcMLGWriter {
   private static Logger logger = LoggerFactory.getLogger(NcMLGWriter.class);
-  protected static final String schemaLocation = "http://www.unidata.ucar.edu/schemas/netcdf-cs.xsd";
+  protected static final String schemaLocation = "https://schemas.unidata.ucar.edu/netcdf-cs.xsd";
 
   /**
    * Write a NetcdfDataset as an NcML-G document to the specified stream.

--- a/cdm/core/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.7.xsd
+++ b/cdm/core/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.7.xsd
@@ -10,8 +10,8 @@
     version="1.0.7">
 
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/core/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
+++ b/cdm/core/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
@@ -10,8 +10,8 @@
     version="1.2">
 
   <!-- import other namespaces -->
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.unidata.ucar.edu/schemas/other/xlink.xsd"/>
-  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
 
   <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
   <!-- Catalog element -->

--- a/cdm/core/src/main/resources/resources/thredds/schemas/queryCapability.0.4.xsd
+++ b/cdm/core/src/main/resources/resources/thredds/schemas/queryCapability.0.4.xsd
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.4"
+  xmlns="http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.4"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:cat="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  elementFormDefault="qualified">
+
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    schemaLocation="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd" />
+
+  <!--
+    The queryCapability element.
+  -->
+  <xsd:element name="queryCapability">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="query"/>
+        <!-- Require a selectService, more allowed because of selector elements. -->
+        <xsd:element ref="selectService"/>
+        <xsd:element ref="selector" minOccurs="1" maxOccurs="unbounded"/>
+        <xsd:element ref="userInterface" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="xsd:token" default="0.4"/>
+      <xsd:attribute name="name" type="xsd:token"/>
+    </xsd:complexType>
+
+    <!-- The id attribute of the selector element must be unique. -->
+    <xsd:unique name="selectorID">
+      <xsd:selector xpath=".//selector"/>
+      <xsd:field xpath="@id"/>
+    </xsd:unique>
+  </xsd:element>
+
+  <!--
+    The query element.
+  -->
+  <xsd:element name="query">
+    <xsd:complexType>
+      <xsd:attribute name="base" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    An abstract base class for all selector elements.
+  -->
+  <xsd:element name="selector" type="selectorType" abstract="true"/>
+  <xsd:complexType name="selectorType">
+    <xsd:sequence>
+      <xsd:element name="description" type="cat:documentationType" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:token" use="required"/>
+    <xsd:attribute name="title" type="xsd:token" use="required"/>
+    <xsd:attribute name="template" type="xsd:token"/>
+    <xsd:attribute name="required" type="xsd:boolean" default="true"/>
+  </xsd:complexType>
+
+  <!--
+    compound selectors.
+  -->
+  <xsd:element name="compound" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="selector"/>
+            <xsd:element name="or"/>
+            <xsd:element ref="selector"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="operator">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="and"/>
+          <xsd:enumeration value="or"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!--
+    The selectList element defines a list of choices from which a user can
+    select one or more entries.
+  -->
+  <!-- When the construct method is set to "template", the
+       template string must contain exactly one replacement string.
+       The template string does not have to be related to the id
+       of the selector, if one is given. No matter the actual
+       replacement string used, it will be replaced with the value
+       of the selection. When the "paramValue" construct method
+       is chosen, the parameter name will be the value of the id
+       or "item" if no id is given, i.e., "<id>=<value>" or
+       "item=<value>".
+    -->
+  <xsd:element name="selectList" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="choice" minOccurs="1" maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="multiple" type="xsd:boolean" default="false"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="choice" type="choiceType"/>
+  <xsd:complexType name="choiceType">
+    <xsd:sequence>
+      <xsd:element name="description" type="cat:documentationType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element ref="selectList" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="value" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!--
+    A selectService element defines the list of serviceTypes available through
+    a query. The user can select the service type(s) they understand and limit the
+    datasets returned to only those service types..
+  -->
+  <xsd:element name="selectService" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element name="serviceType" minOccurs="1" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:simpleContent>
+                  <xsd:extension base="cat:serviceTypes">
+                    <xsd:attribute name="title" type="xsd:token"/>
+                    <xsd:attribute name="dataFormatType" type="cat:dataFormatTypes"/>
+                    <xsd:attribute name="returns" type="xsd:token" use="required"/>
+                    <xsd:attribute name="value" type="xsd:token" use="required"/>
+                  </xsd:extension>
+                </xsd:simpleContent>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="multiple" type="xsd:boolean" default="false"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    A selectStation element defines a list of stations from which a user can select.
+  -->
+  <!-- When the construct method is set to "template", the
+       template string must contain exactly one replacement string.
+       The template string does not have to be related to the id
+       of the selector, if one is given. No matter the actual
+       replacement string used, it will be replaced with the value
+       of the selection. When the "paramValue" construct method
+       is chosen, the parameter name will be the value of the id
+       or "stn" if no id is given, i.e., "<id>=<value>" or
+       "stn=<value>".
+    -->
+  <xsd:element name="selectStation" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="station" minOccurs="1" maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="multiple" type="xsd:boolean" default="false"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="station" substitutionGroup="choice">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="choiceType">
+          <xsd:sequence>
+            <xsd:element ref="location"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="location" type="locationType"/>
+  <xsd:complexType name="locationType">
+    <xsd:attribute name="latitude" type="xsd:float" use="required"/>
+    <xsd:attribute name="longitude" type="xsd:float" use="required"/>
+    <xsd:attribute name="latitude_units" type="xsd:token" default="degrees_north"/>
+    <xsd:attribute name="longitude_units" type="xsd:token" default="degrees_east"/>
+  </xsd:complexType>
+
+  <xsd:element name="location3D" substitutionGroup="location">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="locationType">
+          <xsd:attribute name="elevation" type="xsd:float" use="required"/>
+          <xsd:attribute name="elevation_units" type="xsd:token" default="msl"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    A selectFromRange element defines a range from which a user may select
+    a point or a range.
+
+    To select a point, a single replacement string is required: {point}. To
+    select a range, two replacement strings are required: {min} and {max}.
+  -->
+  <xsd:element name="selectFromRange" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:attribute name="min" type="xsd:decimal" use="required"/>
+          <xsd:attribute name="max" type="xsd:decimal" use="required"/>
+          <xsd:attribute name="units" type="xsd:string"/>
+          <xsd:attribute name="modulo" type="xsd:boolean" default="false"/>
+          <xsd:attribute name="resolution" type="xsd:float" use="required"/>
+          <xsd:attribute name="selectType" type="rangeSelectTypeEnum" default="subrange" />
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Enumeration of allowed types of selections from a range. -->
+  <xsd:simpleType name="rangeSelectTypeEnum">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="point"/>
+      <xsd:enumeration value="subrange"/>
+      <!--xsd:enumeration value="pointOrRange"/-->
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!--
+    A selectFromDateRange element defines a date range from which a user may
+    select a point or a date range.
+
+    To select a point, a single replacement string is required: {point}. To
+    select a range, two replacement strings are required: {min} and {max}.
+  -->
+  <xsd:element name="selectFromDateRange" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:attribute name="start" type="cat:dateType"/>
+          <xsd:attribute name="end" type="cat:dateType"/>
+          <xsd:attribute name="duration" type="cat:duration"/>
+          <xsd:attribute name="resolution" type="cat:duration" use="required"/>
+          <xsd:attribute name="selectType" type="rangeSelectTypeEnum" default="subrange"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+     The selectFromGeoRegion element defines a geographic region from which the
+     user can select a geographic region, currently limited to a bounding box.
+    -->
+  <xsd:element name="selectFromGeoRegion" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="geoBoundingBox"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="geoBoundingBox">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="lowerLeft" type="locationType"/>
+        <xsd:element name="upperRight" type="locationType"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    The userInterface element definition.
+  -->
+  <xsd:element name="userInterface">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/cdm/core/src/test/data/thredds/catalog/DifTest.xml
+++ b/cdm/core/src/test/data/thredds/catalog/DifTest.xml
@@ -2,7 +2,7 @@
 <metadata  xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
   
   <contributor role="Investigator">Mashor Mashnor</contributor>
           

--- a/cdm/core/src/test/data/thredds/catalog/MetadataLink.xml
+++ b/cdm/core/src/test/data/thredds/catalog/MetadataLink.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
     >
  
     <documentation type="summary"> The SAGE III Ozone Loss and Validation Experiment (SOLVE) was a measurement campaign designed to examine the     processes controlling ozone levels at mid- to high latitudes. Measurements were made in the Arctic high-latitude region in winter using the NASA     DC-8 and ER-2 aircraft, as well as balloon platforms and ground-based instruments. The mission also acquired correlative data needed to     validate the Stratospheric Aerosol and Gas Experiment (SAGE) III satellite measurements that will be used to quantitatively assess high-latitude     ozone loss. SOLVE is co-sponsored by the Upper Atmosphere Research Program (UARP), Atmospheric Effects of Aviation Project (AEAP),     Atmospheric Chemistry Modeling and Analysis Program (ACMAP), and Earth Observing System (EOS) of NASA's Earth Science Enterprise     (ESE) as part of the validation program for the SAGE III instrument. 

--- a/cdm/core/src/test/data/thredds/catalog/MissingGCProblem.xml
+++ b/cdm/core/src/test/data/thredds/catalog/MissingGCProblem.xml
@@ -3,7 +3,7 @@
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
   
   <service name="this" serviceType="OpenDAP" base=""/>
   

--- a/cdm/core/src/test/data/thredds/catalog/TestHarvest.xml
+++ b/cdm/core/src/test/data/thredds/catalog/TestHarvest.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
     expires="6 days since 1999-01-01 12:00:02"
   >
  

--- a/cdm/core/src/test/data/thredds/catalog/TestTimeCoverage.xml
+++ b/cdm/core/src/test/data/thredds/catalog/TestTimeCoverage.xml
@@ -2,7 +2,7 @@
 <catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0
-    http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd">
+    https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd">
 
   <service base="http://acd.ucar.edu/models/MOZART/DATA_COMP/datasets_nc/solve1/" serviceType="HTTP" name="disk"/>
 

--- a/cdm/core/src/test/data/thredds/catalog/ZoneMetadata.xml
+++ b/cdm/core/src/test/data/thredds/catalog/ZoneMetadata.xml
@@ -2,7 +2,7 @@
 <metadata  xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
   
 <documentation type="summary"> The SAGE III Ozone Loss and Validation Experiment (SOLVE) was a measurement campaign 
  designed to examine the processes controlling ozone levels at mid- to high latitudes. Measurements 

--- a/cdm/core/src/test/data/thredds/catalog/catalogDev.xml
+++ b/cdm/core/src/test/data/thredds/catalog/catalogDev.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd">
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd">
 
   <service name="this" serviceType="QueryCapability" base=""/>
   

--- a/cdm/core/src/test/data/thredds/catalog/catgen1.0.xml
+++ b/cdm/core/src/test/data/thredds/catalog/catgen1.0.xml
@@ -2,7 +2,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
   >
 
     <service name="latest" serviceType="Resolver"

--- a/cdm/core/src/test/data/thredds/catalog/dif/metar.thredds.xml
+++ b/cdm/core/src/test/data/thredds/catalog/dif/metar.thredds.xml
@@ -3,7 +3,7 @@
 <cat:metadata xmlns:cat="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
   xmlns="http://gcmd.gsfc.nasa.gov/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd
+  xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd
                                         http://gcmd.gsfc.nasa.gov/  file://P:/schemas/other/gcmd/dif.xsd"
   >
 

--- a/cdm/core/src/test/data/thredds/catalog/test2.xml
+++ b/cdm/core/src/test/data/thredds/catalog/test2.xml
@@ -4,7 +4,7 @@
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0                          
-              http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd"
+              https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
     expires="6 days since 1999-01-01 12:00:02"
     >
  

--- a/cdm/core/src/test/data/thredds/catalog/testMetadata.xml
+++ b/cdm/core/src/test/data/thredds/catalog/testMetadata.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" 
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.xsd" 
+    xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0  https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd"
   >
  
   <service base="http://acd.ucar.edu/models/MOZART/DATA_COMP/datasets_nc/solve1/" serviceType="HTTP" name="disk"/>

--- a/docs/src/site/pages/netcdfJava/NcmlOverview.md
+++ b/docs/src/site/pages/netcdfJava/NcmlOverview.md
@@ -64,7 +64,7 @@ A more advanced use is to modify existing NetCDF files, as well as to create "vi
 * [Aggregation](ncml_aggregation.html)
 * [Cookbook Examples](ncml_cookbook.html)
 * [Annotated Schema for Netcdf-Java 4](annotated_ncml_schema.html)
-* [ncml-2.2.xsd](https://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd)
+* [ncml-2.2.xsd](https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd)
 
 ### Acknowledgments and History
 

--- a/legacy/src/main/java/thredds/catalog/XMLEntityResolver.java
+++ b/legacy/src/main/java/thredds/catalog/XMLEntityResolver.java
@@ -160,7 +160,7 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
   public static final String CATALOG_NAMESPACE_10 = "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0";
 
   // dqc namespaces (still referenced in legacy)
-  // static public final String DQC_NAMESPACE_02 = "http://www.unidata.ucar.edu/schemas/thredds/queryCapability";
+  // static public final String DQC_NAMESPACE_02 = "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.2";
   // static public final String DQC_NAMESPACE_03 =
   // "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.3";
   public static final String DQC_NAMESPACE_04 = "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.4";
@@ -210,36 +210,36 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
 
     // catalog 1.0 schema
     initEntity(CATALOG_NAMESPACE_10, "/resources/thredds/schemas/InvCatalog.1.2.xsd",
-        "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd");
+        "https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd");
 
     /*
      * catalog 0.6 schema
      * initEntity( CATALOG_NAMESPACE_06,
      * "/resources/thredds/schemas/InvCatalog.0.6.xsd",
-     * "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.0.6.xsd");
+     * "https://schemas.unidata.ucar.edu/thredds/InvCatalog.0.6.xsd");
      * 
      * // DQC schema 0.2
      * initEntity( DQC_NAMESPACE_02,
      * "/resources/thredds/schemas/queryCapability.0.2.xsd",
-     * "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.2.xsd");
+     * "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.2.xsd");
      * 
      * // DQC schema 0.3
      * initEntity( DQC_NAMESPACE_03,
      * "/resources/thredds/schemas/queryCapability.0.3.xsd",
-     * "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.3.xsd");
+     * "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.3.xsd");
      */
 
     // DQC schema 0.4
     initEntity(DQC_NAMESPACE_04, "/resources/thredds/schemas/queryCapability.0.4.xsd",
-        "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.4.xsd");
+        "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.4.xsd");
 
     // nj22 schema
     initEntity(NJ22_NAMESPACE, "/resources/nj22/schemas/ncml-2.2.xsd",
-        "http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd");
+        "https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd");
 
     // XLink schema
     initEntity(XLINK_NAMESPACE, "/resources/thredds/schemas/xlink.xsd",
-        "http://www.unidata.ucar.edu/schemas/other/xlink.xsd");
+        "https://schemas.unidata.ucar.edu/other/xlink.xsd");
 
     /*
      * catgen 0.5 dtd
@@ -257,15 +257,15 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
   public static String getExternalSchemas() {
     if (externalSchemas == null) {
       externalSchemas = XMLEntityResolver.CATALOG_NAMESPACE_10 + " "
-          + "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd" + " " + XMLEntityResolver.NJ22_NAMESPACE
-          + " " + "http://www.unidata.ucar.edu/schemas/netcdf/ncml-2.2.xsd" + " " + XMLEntityResolver.DQC_NAMESPACE_04
-          + " " + "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.4.xsd" + " "
+          + "https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd" + " " + XMLEntityResolver.NJ22_NAMESPACE
+          + " " + "https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd" + " " + XMLEntityResolver.DQC_NAMESPACE_04
+          + " " + "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.4.xsd" + " "
       /*
        * + XMLEntityResolver.DQC_NAMESPACE_03 + " " +
-       * "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.3.xsd" +" " +
+       * "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.3.xsd" +" " +
        * XMLEntityResolver.DQC_NAMESPACE_02 + " " +
-       * "http://www.unidata.ucar.edu/schemas/thredds/queryCapability.0.2.xsd" +" " +
-       * XMLEntityResolver.CATALOG_NAMESPACE_06 + " " + "http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.0.6.xsd"
+       * "https://schemas.unidata.ucar.edu/thredds/queryCapability.0.2.xsd" +" " +
+       * XMLEntityResolver.CATALOG_NAMESPACE_06 + " " + "https://schemas.unidata.ucar.edu/thredds/InvCatalog.0.6.xsd"
        */;
     }
     return externalSchemas;
@@ -440,7 +440,7 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
     }
 
     if (systemId.contains("InvCatalog.0.6.dtd")) {
-      entity = entityHash.get("http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.0.6.dtd");
+      entity = entityHash.get("https://schemas.unidata.ucar.edu/thredds/InvCatalog.0.6.dtd");
       if (entity != null) {
         logger.debug(" *** resolved2 with local copy");
         return new MyInputSource(entity);

--- a/legacy/src/main/java/thredds/catalog/XMLEntityResolver.java
+++ b/legacy/src/main/java/thredds/catalog/XMLEntityResolver.java
@@ -160,7 +160,8 @@ public class XMLEntityResolver implements org.xml.sax.EntityResolver {
   public static final String CATALOG_NAMESPACE_10 = "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0";
 
   // dqc namespaces (still referenced in legacy)
-  // static public final String DQC_NAMESPACE_02 = "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.2";
+  // static public final String DQC_NAMESPACE_02 =
+  // "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.2";
   // static public final String DQC_NAMESPACE_03 =
   // "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.3";
   public static final String DQC_NAMESPACE_04 = "http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.4";

--- a/legacy/src/main/java/thredds/catalog/dl/DCWriter.java
+++ b/legacy/src/main/java/thredds/catalog/dl/DCWriter.java
@@ -17,7 +17,7 @@ import java.util.*;
 
 public class DCWriter {
   private static final Namespace defNS = Namespace.getNamespace("http://purl.org/dc/elements/1.1/");
-  private static final String schemaLocation = defNS.getURI() + " http://www.unidata.ucar.edu/schemas/other/dc/dc.xsd";
+  private static final String schemaLocation = defNS.getURI() + " https://schemas.unidata.ucar.edu/other/dc/dc.xsd";
   private static final String threddsServerURL = "http://localhost:8080/thredds/subset.html";
 
   private InvCatalog cat;


### PR DESCRIPTION
## Description of Changes

Unidata hosted XML Schema and DTD files are now available from "https://schemas.unidata.ucar.edu/*" (with redirects in place from the old URLs, "http://www.unidata.ucar.edu/schemas/*"). This change updates all occurrences.

## PR Checklist
- [x] Indicate the version associated with this PR in the Title
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
