### PR TITLE
[5.x]: Clean up Unidata XML Namespace URIs mistakenly converted to "https:"

### DIFF
--- a/cdm/core/src/main/java/thredds/client/catalog/Catalog.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/Catalog.java
@@ -30,6 +30,11 @@ public class Catalog extends DatasetNode {
   public static final String CATALOG_NAMESPACE_10 = "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0";
   public static final Namespace defNS = Namespace.getNamespace(CATALOG_NAMESPACE_10);
   public static final String NJ22_NAMESPACE = "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2";
+  // This line (and related code) handles incorrect HTTPS variant of NcML Namespace URI.
+  // NOTE: The HTTPS variant is incorrect (according to recent, Oct 2021, decision).
+  //       It probably appeared when Unidata servers started requiring HTTPS.
+  //       NcML is only place HTTPS namespace variants are handled (and tested in testReadHttps.xml).
+  //       Should probably just be dropped.
   public static final String NJ22_NAMESPACE_HTTPS = "https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2";
   public static final Namespace ncmlNS = Namespace.getNamespace("ncml", NJ22_NAMESPACE);
   public static final Namespace ncmlNSHttps = Namespace.getNamespace("ncml", NJ22_NAMESPACE_HTTPS);

--- a/cdm/core/src/main/java/thredds/client/catalog/Catalog.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/Catalog.java
@@ -30,11 +30,11 @@ public class Catalog extends DatasetNode {
   public static final String CATALOG_NAMESPACE_10 = "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0";
   public static final Namespace defNS = Namespace.getNamespace(CATALOG_NAMESPACE_10);
   public static final String NJ22_NAMESPACE = "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2";
-  // This line (and related code) handles incorrect HTTPS variant of NcML Namespace URI.
+  // The following line (and related code) handles incorrect HTTPS variant of NcML Namespace URI.
   // NOTE: The HTTPS variant is incorrect (according to recent, Oct 2021, decision).
-  //       It probably appeared when Unidata servers started requiring HTTPS.
-  //       NcML is only place HTTPS namespace variants are handled (and tested in testReadHttps.xml).
-  //       Should probably just be dropped.
+  // The variant probably appeared when Unidata servers started requiring HTTPS.
+  // NcML is only place HTTPS namespace variants are handled (and tested in testReadHttps.xml).
+  // Should probably just be dropped.
   public static final String NJ22_NAMESPACE_HTTPS = "https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2";
   public static final Namespace ncmlNS = Namespace.getNamespace("ncml", NJ22_NAMESPACE);
   public static final Namespace ncmlNSHttps = Namespace.getNamespace("ncml", NJ22_NAMESPACE_HTTPS);

--- a/cdm/core/src/main/java/ucar/nc2/ncml/NcMLWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/ncml/NcMLWriter.java
@@ -43,7 +43,7 @@ import java.util.TreeMap;
 @Deprecated
 public class NcMLWriter {
   /**
-   * A default namespace constructed from the NcML URI: {@code https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2}.
+   * A default namespace constructed from the NcML URI: {@code http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2}.
    */
   // A default namespace means that we can use it without having to prepend the "ncml:" prefix to every element name.
   // thredds.client.catalog.Catalog.ncmlNS is *not* default and therefore *does* require the prefix.

--- a/cdm/core/src/main/java/ucar/nc2/write/NcmlWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/write/NcmlWriter.java
@@ -57,7 +57,7 @@ public class NcmlWriter {
   private static final Logger log = LoggerFactory.getLogger(NcmlWriter.class);
 
   /**
-   * A default namespace constructed from the NcML URI: {@code https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2}.
+   * A default namespace constructed from the NcML URI: {@code http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2}.
    */
   // A default namespace means that we can use it without having to prepend the "ncml:" prefix to every element name.
   // thredds.client.catalog.Catalog.ncmlNS is *not* default and therefore *does* require the prefix.

--- a/cdm/core/src/test/data/ncml/testReadHttps.xml
+++ b/cdm/core/src/test/data/ncml/testReadHttps.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- DO NOT Change namespace URI
+   - Used to test handling of alternate/incorrect namespace URI.
+   - (See note in Catalog.java.)
+   -->
 <nc:netcdf xmlns:nc="https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
   location="file:src/test/data/example1.nc">
 

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlRead.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlRead.java
@@ -266,7 +266,8 @@ public class TestNcmlRead extends TestCase {
 
   static public class TestReadHttps extends TestNcmlRead {
 
-    // equivalent dataset using "readMetadata"
+    // Test handling of incorrect https variant of NcML namespace URI.
+    // See note in Catalog.java.
     public TestReadHttps(String name) {
       super(name);
       ncfile = null;


### PR DESCRIPTION
## Description of Changes

Some code and document uses of Unidata XML Namespace URIs were converted from “http:” to “https:” when Unidata servers started requiring HTTPS. This change reverts all uses of Unidata XML Namespace URIs back to “http:” form.

## PR Checklist
- [x] Indicate the version associated with this PR in the Title
- [ ] Link to any issues that the PR addresses
- [ ] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
