### PR TITLE
[5.x]: Ignore failing test on Jenkins

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestRemoteCoverage.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestRemoteCoverage.java
@@ -6,6 +6,7 @@ package ucar.nc2.ft.coverage;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,7 @@ public class TestRemoteCoverage {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
+  @Ignore("Depends on cdmrFeature service being available, which was removed in TDS 5 and never in an official stable release.")
   @Category(NeedsExternalResource.class)
   public void testCdmRemoteCoverage() throws Exception {
     String ds = "https://thredds-test.unidata.ucar.edu/thredds/catalog/grib/NCEP/GFS/Global_0p25deg_ana/latest.xml";


### PR DESCRIPTION
## Description of Changes

The test currently failing on Jenkins relies on a TDS with the cdmrFeature service running, which was removed in TDS 5 and never in an official stable release of the TDS. Already removed in netCDF-Java > 6.x, so no ports needed.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
