### PR TITLE
Buffer java version disparity

### DIFF
--- a/cdm-core/src/main/java/ucar/nc2/util/IO.java
+++ b/cdm-core/src/main/java/ucar/nc2/util/IO.java
@@ -6,6 +6,7 @@ package ucar.nc2.util;
 
 import com.google.common.io.CharStreams;
 
+import java.nio.Buffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessControlException;
@@ -117,7 +118,7 @@ public class IO {
       if (n == -1)
         break;
       totalBytesRead += n;
-      buffer.flip();
+      ((Buffer) buffer).flip();
     }
     return totalBytesRead;
   }


### PR DESCRIPTION
To hopefully address the Buffer typing issue brought up in: 
https://www.unidata.ucar.edu/mailing_lists/archives/netcdf-java/2021/msg00062.html