### PR TITLE
[5.x]: Update docs for deprecated/removed Gradle dependency keywords

### DIFF
--- a/docs/src/site/pages/netcdfJava_tutorial/overview/UsingNetcdfJava.md
+++ b/docs/src/site/pages/netcdfJava_tutorial/overview/UsingNetcdfJava.md
@@ -56,8 +56,8 @@ An example using JDK14 logging:
 ~~~groovy
 // In Gradle
 dependencies {
-  compile "edu.ucar:cdm-core:${netcdfJavaVersion}"
-  runtime "org.slf4j:slf4j-jdk14:${slf4jVersion}"
+  implementation "edu.ucar:cdm-core:${netcdfJavaVersion}"
+  runtimeOnly "org.slf4j:slf4j-jdk14:${slf4jVersion}"
 }
 ~~~
 
@@ -115,12 +115,12 @@ For example, in Maven and Gradle:
 ~~~groovy
 // In Gradle
 dependencies {
-  runtime "edu.ucar:bufr:${netcdfJavaVersion}"
-  runtime "edu.ucar:cdm-image:${netcdfJavaVersion}"
-  runtime "edu.ucar:grib:${netcdfJavaVersion}"
-  runtime "edu.ucar:netcdf4:${netcdfJavaVersion}"
-  runtime "edu.ucar:opendap:${netcdfJavaVersion}"
-  runtime "edu.ucar:cdm-mcidas:${netcdfJavaVersion}"
+  runtimeOnly "edu.ucar:bufr:${netcdfJavaVersion}"
+  runtimeOnly "edu.ucar:cdm-image:${netcdfJavaVersion}"
+  runtimeOnly "edu.ucar:grib:${netcdfJavaVersion}"
+  runtimeOnly "edu.ucar:netcdf4:${netcdfJavaVersion}"
+  runtimeOnly "edu.ucar:opendap:${netcdfJavaVersion}"
+  runtimeOnly "edu.ucar:cdm-mcidas:${netcdfJavaVersion}"
 }
 ~~~
 ## Building with netcdfAll


### PR DESCRIPTION
## Description of Changes

Update Gradle dependency keywords used in "Using netCDF-Java Maven Artifacts" doc. Several of the keywords (including "compile" and "runtime") were deprecated in Gradle 6 and removed in Gradle 7.

Note: Current `build.gradle` files still use the deprecated/removed keywords. Will need to be updated them when project moves to Gradle 7.

## PR Checklist
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
