### PR TITLE
[5.x] address buffer method disparity among java versions

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/util/IO.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/IO.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2.util;
 
+import java.nio.Buffer;
 import java.nio.charset.StandardCharsets;
 import ucar.nc2.constants.CDM;
 import java.io.*;
@@ -147,7 +148,7 @@ public class IO {
       if (n == -1)
         break;
       totalBytesRead += n;
-      buffer.flip();
+      ((Buffer) buffer).flip();
     }
     return totalBytesRead;
   }
@@ -171,7 +172,7 @@ public class IO {
       for (int i = 0; i < buffersize; i++)
         touch += result[i];
 
-      buffer.flip();
+      ((Buffer) buffer).flip();
     }
     return touch;
   }
@@ -397,7 +398,7 @@ public class IO {
    * // The read() call leaves the buffer in "fill mode". To prepare
    * // to write bytes from the bufferwe have to put it in "drain mode"
    * // by flipping it: setting limit to position and position to zero
-   * buffer.flip();
+   * ((Buffer) buffer).flip();
    * 
    * // Now write some or all of the bytes out to the output channel
    * out.write(buffer);

--- a/cdm/misc/src/main/java/ucar/nc2/geotiff/GeoTiff.java
+++ b/cdm/misc/src/main/java/ucar/nc2/geotiff/GeoTiff.java
@@ -320,7 +320,7 @@ public class GeoTiff implements Closeable {
       channel.position(nextOverflowData);
       ByteBuffer vbuffer = ByteBuffer.allocate(size);
       writeValues(vbuffer, ifd);
-      v((Buffer) buffer).flip();
+      ((Buffer) vbuffer).flip();
       channel.write(vbuffer);
       nextOverflowData += size;
     }
@@ -510,7 +510,7 @@ public class GeoTiff implements Closeable {
       ByteBuffer vbuffer = ByteBuffer.allocate(ifd.count * ifd.type.size);
       vbuffer.order(byteOrder);
       assert ifd.count * ifd.type.size == channel.read(vbuffer);
-      v((Buffer) buffer).flip();
+      ((Buffer) vbuffer).flip();
       readValues(vbuffer, ifd);
     }
 

--- a/cdm/misc/src/main/java/ucar/nc2/geotiff/GeoTiff.java
+++ b/cdm/misc/src/main/java/ucar/nc2/geotiff/GeoTiff.java
@@ -10,6 +10,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.io.StringWriter;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
@@ -203,7 +204,7 @@ public class GeoTiff implements Closeable {
     ByteBuffer direct = ByteBuffer.allocateDirect(4 * data.length);
     FloatBuffer buffer = direct.asFloatBuffer();
     buffer.put(data);
-    // buffer.flip();
+    // ((Buffer) buffer).flip();
     channel.write(direct);
 
     if (imageNumber == 1)
@@ -232,7 +233,7 @@ public class GeoTiff implements Closeable {
       if (debugRead)
         System.out.println("position before writing nextIFD= " + channel.position() + " IFD is " + firstIFD);
       buffer.putInt(firstIFD);
-      buffer.flip();
+      ((Buffer) buffer).flip();
       channel.write(buffer);
     }
     writeIFD(channel, firstIFD);
@@ -247,7 +248,7 @@ public class GeoTiff implements Closeable {
     buffer.putShort((short) 42);
     buffer.putInt(firstIFD);
 
-    buffer.flip();
+    ((Buffer) buffer).flip();
     channel.write(buffer);
 
     return firstIFD;
@@ -272,7 +273,7 @@ public class GeoTiff implements Closeable {
     ByteBuffer buffer = ByteBuffer.allocate(2);
     int n = tags.size();
     buffer.putShort((short) n);
-    buffer.flip();
+    ((Buffer) buffer).flip();
     channel.write(buffer);
 
     start += 2;
@@ -291,7 +292,7 @@ public class GeoTiff implements Closeable {
       System.out.println("pos before writing nextIFD= " + channel.position());
     buffer = ByteBuffer.allocate(4);
     buffer.putInt(0);
-    buffer.flip();
+    ((Buffer) buffer).flip();
     channel.write(buffer);
   }
 
@@ -308,18 +309,18 @@ public class GeoTiff implements Closeable {
       int done = writeValues(buffer, ifd);
       for (int k = 0; k < 4 - done; k++) // fill out to 4 bytes
         buffer.put((byte) 0);
-      buffer.flip();
+      ((Buffer) buffer).flip();
       channel.write(buffer);
 
     } else { // write offset
       buffer.putInt(nextOverflowData);
-      buffer.flip();
+      ((Buffer) buffer).flip();
       channel.write(buffer);
       // write data
       channel.position(nextOverflowData);
       ByteBuffer vbuffer = ByteBuffer.allocate(size);
       writeValues(vbuffer, ifd);
-      vbuffer.flip();
+      v((Buffer) buffer).flip();
       channel.write(vbuffer);
       nextOverflowData += size;
     }
@@ -417,7 +418,7 @@ public class GeoTiff implements Closeable {
     ByteBuffer buffer = ByteBuffer.allocate(8);
     int n = channel.read(buffer);
     assert n == 8;
-    buffer.flip();
+    ((Buffer) buffer).flip();
     if (showHeaderBytes) {
       printBytes(System.out, "header", buffer, 4);
       buffer.rewind();
@@ -443,7 +444,7 @@ public class GeoTiff implements Closeable {
 
     int n = channel.read(buffer);
     assert n == 2;
-    buffer.flip();
+    ((Buffer) buffer).flip();
     if (showBytes) {
       printBytes(System.out, "IFD", buffer, 2);
       buffer.rewind();
@@ -468,7 +469,7 @@ public class GeoTiff implements Closeable {
     buffer = ByteBuffer.allocate(4);
     buffer.order(byteOrder);
     assert 4 == channel.read(buffer);
-    buffer.flip();
+    ((Buffer) buffer).flip();
     int nextIFD = buffer.getInt();
     if (debugRead)
       System.out.println(" nextIFD == " + nextIFD);
@@ -484,7 +485,7 @@ public class GeoTiff implements Closeable {
     buffer.order(byteOrder);
     int n = channel.read(buffer);
     assert n == 12;
-    buffer.flip();
+    ((Buffer) buffer).flip();
     if (showBytes)
       printBytes(System.out, "IFDEntry bytes", buffer, 12);
 
@@ -509,7 +510,7 @@ public class GeoTiff implements Closeable {
       ByteBuffer vbuffer = ByteBuffer.allocate(ifd.count * ifd.type.size);
       vbuffer.order(byteOrder);
       assert ifd.count * ifd.type.size == channel.read(vbuffer);
-      vbuffer.flip();
+      v((Buffer) buffer).flip();
       readValues(vbuffer, ifd);
     }
 
@@ -670,7 +671,7 @@ public class GeoTiff implements Closeable {
     ByteBuffer buffer = ByteBuffer.allocate(size);
     buffer.order(byteOrder);
     assert size == channel.read(buffer);
-    buffer.flip();
+    ((Buffer) buffer).flip();
     return buffer;
   }
 }


### PR DESCRIPTION
## Description of Changes

Address buffer method disparity in Java versions.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [ ] Link to any issues that the PR addresses
- [ ] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
