### PR TITLE
[8.x]: Provide option to allow build to continue after test failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           java-vendor: ${{ matrix.java-vendor }}
           java-version: ${{ matrix.java-version }}
           build-tool: 'gradlew'
-          test-command: '--info --stacktrace test'
+          test-command: '-DignoreFailures=true --info --stacktrace test'
       - if: failure()
         uses: actions/upload-artifact@v2
         with:

--- a/buildSrc/src/main/kotlin/cdm.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cdm.java-conventions.gradle.kts
@@ -143,6 +143,7 @@ tasks.withType<Test> {
     systemProperties(
         Pair("jna.library.path", System.getProperty("jna.library.path")),
     )
+    ignoreFailures = System.getProperty("ignoreFailures").toBoolean()
 }
 
 spotless {

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -57,6 +57,18 @@ Very few tests are annotated with this category.
 Don't feel bad about not running them.
 We don't like this restriction either.
 
+By default, the test suite will stop running once a failure occurs in a single project.
+If you would like the tests to keep running until completion, set the `ignoreFailures` property to true.
+For example:
+
+~~~shell
+./gradlew test -DignoreFailures=true
+~~~
+
+This will cause all of the tests tasks in all of the projects to run, regardless of how many of the test fail.
+If one or more tasks fail, the overall gradle process will show as successful. 
+However, CI tools like Jenkins will show that this step Fails due to the tests reporting failures.
+
 ## Common Build Scripts
 
 ### Base Java Build Script


### PR DESCRIPTION
## Description of Changes

Provide option to allow build to continue after test failure. To enable this, run the tests with the `-DignoreFailures=true` option. For example:

~~~shell
./gradlew test -DignoreFailures=true
~~~

Default behavior is to stop the build once a test in a single project fails.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [X] Link to any issues that the PR addresses
- [X] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
