### PR TITLE
[5.x] Mfile write to stream

### DIFF
--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
@@ -114,13 +114,13 @@ public class MFileOS implements MFile {
 
   @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
-    IO.copyFileB(file, outputStream, 60 * 1000);
+    IO.copyFile(file, outputStream);
   }
 
   @Override
   public void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException {
     try (RandomAccessFile randomAccessFile = RandomAccessFile.acquire(file.getPath())) {
-      IO.copyRafB(randomAccessFile, offset, maxBytes, outputStream, new byte[60000]);
+      IO.copyRafB(randomAccessFile, offset, maxBytes, outputStream);
     }
   }
 

--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
@@ -7,6 +7,8 @@ package thredds.filesystem;
 
 import java.io.OutputStream;
 import thredds.inventory.MFile;
+import ucar.nc2.util.IO;
+import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.util.StringUtil2;
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
@@ -117,12 +119,14 @@ public class MFileOS7 implements MFile {
 
   @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
-    throw new IOException("Writing MFileOS7 to stream not implemented. Filename: " + getName());
+    IO.copyFile(path.toFile(), outputStream);
   }
 
   @Override
   public void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException {
-    throw new IOException("Writing MFileOS7 to stream not implemented. Filename: " + getName());
+    try (RandomAccessFile randomAccessFile = RandomAccessFile.acquire(path.toString())) {
+      IO.copyRafB(randomAccessFile, offset, maxBytes, outputStream);
+    }
   }
 
   public Path getNioPath() {

--- a/cdm/core/src/main/java/ucar/nc2/util/IO.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/IO.java
@@ -354,6 +354,17 @@ public class IO {
   }
 
   /**
+   * copy file to output stream
+   *
+   * @param fileIn copy this file
+   * @param out copy here
+   * @throws java.io.IOException on io error
+   */
+  public static void copyFile(File fileIn, OutputStream out) throws IOException {
+    copyFileB(fileIn, out, default_file_buffersize);
+  }
+
+  /**
    * copy file to output stream, specify internal buffer size
    *
    * @param fileIn copy this file
@@ -411,6 +422,21 @@ public class IO {
    * }
    * }
    */
+
+  /**
+   * Copy part of a RandomAccessFile to output stream
+   *
+   * @param raf copy this file
+   * @param offset start here (byte offset)
+   * @param length number of bytes to copy
+   * @param out copy to this stream
+   * @return number of bytes copied
+   * @throws java.io.IOException on io error
+   */
+  public static long copyRafB(ucar.unidata.io.RandomAccessFile raf, long offset, long length, OutputStream out)
+      throws IOException {
+    return copyRafB(raf, offset, length, out, new byte[default_file_buffersize]);
+  }
 
   /**
    * Copy part of a RandomAccessFile to output stream, specify internal buffer size

--- a/cdm/core/src/test/java/thredds/filesystem/TestMFileOS7.java
+++ b/cdm/core/src/test/java/thredds/filesystem/TestMFileOS7.java
@@ -1,0 +1,81 @@
+package thredds.filesystem;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestMFileOS7 {
+
+  @ClassRule
+  public static final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Parameterized.Parameters(name = "{0}")
+  static public List<Integer> getTestParameters() {
+    return Arrays.asList(0, 1, 60000, 100000);
+  }
+
+  @Parameterized.Parameter()
+  public int expectedSize;
+
+  @Test
+  public void shouldWriteFileToStream() throws IOException {
+    final File file = createTemporaryFile(expectedSize);
+    final MFileOS7 mFile = new MFileOS7(file.toPath());
+    final long length = mFile.getLength();
+    assertThat(length).isEqualTo(expectedSize);
+
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    mFile.writeToStream(outputStream);
+    assertThat(outputStream.size()).isEqualTo(expectedSize);
+    assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
+  }
+
+  @Test
+  public void shouldWritePartialFileToStream() throws IOException {
+    final File file = createTemporaryFile(expectedSize);
+    final MFileOS7 mFile = new MFileOS7(file.toPath());
+    final long length = mFile.getLength();
+    assertThat(length).isEqualTo(expectedSize);
+
+    final long[][] testCases = {{0, 0}, {10, 10}, {0, length}, {0, 100}, {42, 100}};
+
+    for (long[] testCase : testCases) {
+      final long offset = testCase[0];
+      final long maxBytes = testCase[1];
+
+      final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      mFile.writeToStream(outputStream, offset, maxBytes);
+
+      final long startPosition = Math.min(offset, expectedSize);
+      final long endPosition = Math.min(offset + maxBytes, expectedSize);
+
+      assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+
+      final byte[] partialFile =
+          Arrays.copyOfRange(Files.readAllBytes(file.toPath()), (int) startPosition, (int) endPosition);
+      assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
+    }
+  }
+
+  private File createTemporaryFile(int size) throws IOException {
+    final File tempFile = tempFolder.newFile();
+
+    byte[] bytes = new byte[size];
+    new Random().nextBytes(bytes);
+    Files.write(tempFile.toPath(), bytes);
+
+    return tempFile;
+  }
+}

--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -19,8 +19,10 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest.Builder;
 import thredds.inventory.MFile;
 import thredds.inventory.MFileProvider;
 import ucar.nc2.util.IO;
+import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.io.s3.CdmS3Client;
 import ucar.unidata.io.s3.CdmS3Uri;
+import ucar.unidata.io.s3.S3RandomAccessFile;
 
 /**
  * Implements {@link thredds.inventory.MFile} for objects stored on AWS S3 compatible object stores.
@@ -292,7 +294,11 @@ public class MFileS3 implements MFile {
 
   @Override
   public void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException {
-    throw new IOException("Writing MFileZip with a byte range to stream not implemented. Filename: " + getName());
+    final S3RandomAccessFile.Provider provider = new S3RandomAccessFile.Provider();
+
+    try (RandomAccessFile randomAccessFile = provider.open(cdmS3Uri.toString())) {
+      IO.copyRafB(randomAccessFile, offset, maxBytes, outputStream);
+    }
   }
 
   public static class Provider implements MFileProvider {

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -188,6 +188,25 @@ public class TestMFileS3 {
   }
 
   @Test
+  public void shouldWritePartialObjectToStream() throws IOException {
+    final MFile mFile = new MFileS3(AWS_G16_S3_OBJECT_1);
+    final long length = mFile.getLength();
+
+    final long[][] testCases = {{0, 0}, {10, 10}, {0, length}, {0, 100}, {42, 100}};
+
+    for (long[] testCase : testCases) {
+      final long offset = testCase[0];
+      final long maxBytes = testCase[1];
+
+      final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      mFile.writeToStream(outputStream, offset, maxBytes);
+
+      final long bytesWritten = Math.min(maxBytes, length - offset);
+      assertThat(outputStream.size()).isEqualTo(bytesWritten);
+    }
+  }
+
+  @Test
   public void shouldNotWriteDirectoryToStream() throws IOException {
     final MFile mFile = new MFileS3(AWS_G16_S3_URI_DIR + "/" + DELIMITER_FRAGMENT);
     assertThat(mFile.isDirectory()).isTrue();

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -153,7 +153,7 @@ public class MFileZip implements MFile {
   public void writeToStream(OutputStream outputStream) throws IOException {
     for (ZipEntry entry : leafEntries) {
       final File file = new File(entry.getName());
-      IO.copyFileB(file, outputStream, 60 * 1000);
+      IO.copyFile(file, outputStream);
     }
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
@@ -10,6 +10,8 @@ import java.io.OutputStream;
 import javax.annotation.Nullable;
 import thredds.filesystem.MFileOS;
 import thredds.inventory.MFile;
+import ucar.nc2.util.IO;
+import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.util.StringUtil2;
 import java.io.File;
 import java.util.ArrayList;
@@ -113,11 +115,13 @@ public class GcMFile implements thredds.inventory.MFile {
 
   @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
-    throw new IOException("Writing GcMFile to stream not implemented. Filename: " + getName());
+    IO.copyFile(getPath(), outputStream);
   }
 
   @Override
   public void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException {
-    throw new IOException("Writing GcMFile to stream not implemented. Filename: " + getName());
+    try (RandomAccessFile randomAccessFile = RandomAccessFile.acquire(getPath())) {
+      IO.copyRafB(randomAccessFile, offset, maxBytes, outputStream);
+    }
   }
 }

--- a/grib/src/test/java/ucar/nc2/grib/collection/TestGcMFile.java
+++ b/grib/src/test/java/ucar/nc2/grib/collection/TestGcMFile.java
@@ -1,0 +1,82 @@
+package ucar.nc2.grib.collection;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestGcMFile {
+
+  @ClassRule
+  public static final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Parameterized.Parameters(name = "{0}")
+  static public List<Integer> getTestParameters() {
+    return Arrays.asList(0, 1, 60000, 100000);
+  }
+
+  @Parameterized.Parameter()
+  public int expectedSize;
+
+  @Test
+  public void shouldWriteFileToStream() throws IOException {
+    final File file = createTemporaryFile(expectedSize);
+    final GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
+
+    final long length = mFile.getLength();
+    assertThat(length).isEqualTo(expectedSize);
+
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    mFile.writeToStream(outputStream);
+    assertThat(outputStream.size()).isEqualTo(expectedSize);
+    assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
+  }
+
+  @Test
+  public void shouldWritePartialFileToStream() throws IOException {
+    final File file = createTemporaryFile(expectedSize);
+    GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
+
+    final long length = mFile.getLength();
+    assertThat(length).isEqualTo(expectedSize);
+
+    final int[][] testCases = {{0, 0}, {10, 10}, {0, (int) length}, {0, 100}, {42, 100}};
+
+    for (int[] testCase : testCases) {
+      final int offset = testCase[0];
+      final int maxBytes = testCase[1];
+
+      final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      mFile.writeToStream(outputStream, offset, maxBytes);
+
+      final int startPosition = Math.min(offset, expectedSize);
+      final int endPosition = Math.min(offset + maxBytes, expectedSize);
+
+      assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+
+      final byte[] partialFile = Arrays.copyOfRange(Files.readAllBytes(file.toPath()), startPosition, endPosition);
+      assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
+    }
+  }
+
+  private File createTemporaryFile(int size) throws IOException {
+    final File tempFile = tempFolder.newFile();
+
+    byte[] bytes = new byte[size];
+    new Random().nextBytes(bytes);
+    Files.write(tempFile.toPath(), bytes);
+
+    return tempFile;
+  }
+}


### PR DESCRIPTION
-Added a default buffer size version to copy functions

Implemented and tested writeToStream for MFiles:
- MFileS3: byte range (whole file already implemented)
- MFileOS7: whole file and byte range
- GcMFile : whole file and byte range

Left unimplemented, and don't think it makes sense to implement:
- MFileRemote
- MFileZip for byte ranges (whole file already implemented)