### PR TITLE
[5.x] Fix s3 bugs

### DIFF
--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -186,10 +186,7 @@ public class MFileS3 implements MFile {
       // Now, find the location of the rightmost delimiter
       int lastDelimiter = name.lastIndexOf(delimiter);
 
-      // if no rightmost delimiter found, then we are at the top level of the bucket, so the name is blank
-      if (lastDelimiter < 0) {
-        name = "";
-      } else {
+      if (lastDelimiter >= 0) {
         // the "name" is everything after that last delimiter
         name = name.substring(lastDelimiter);
         if (name.startsWith(delimiter)) {

--- a/cdm/s3/src/main/java/ucar/unidata/io/s3/CdmS3Uri.java
+++ b/cdm/s3/src/main/java/ucar/unidata/io/s3/CdmS3Uri.java
@@ -265,11 +265,12 @@ public final class CdmS3Uri {
       newUri = newUri.replace(key, newKey);
     } else {
       int fragLoc = newUri.lastIndexOf("#");
+      String fragment = "";
       if (fragLoc > 0) {
-        String fragment = newUri.substring(fragLoc);
+        fragment = newUri.substring(fragLoc);
         newUri = newUri.substring(0, fragLoc);
-        newUri = newUri + "?" + newKey + fragment;
       }
+      newUri = newUri + "?" + newKey + fragment;
     }
 
     return new CdmS3Uri(newUri);

--- a/cdm/s3/src/test/java/thredds/filesystem/s3/TestControllerS3.java
+++ b/cdm/s3/src/test/java/thredds/filesystem/s3/TestControllerS3.java
@@ -322,12 +322,16 @@ public class TestControllerS3 {
 
   private int countObjects(Iterator<MFile> it) {
     int i = 0;
+    String previousFileName = "";
+
     while (it.hasNext()) {
       MFile mFile = it.next();
       if (PRINT) {
         System.out.print("\n The name of the MFile is " + mFile.getPath() + " " + i);
       }
       i++;
+      assertThat(mFile.getPath()).isNotEqualTo(previousFileName);
+      previousFileName = mFile.getPath();
     }
     return i;
   }

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -27,6 +27,7 @@ public class TestMFileS3 {
 
   private static final String parentDirName = "242";
   private static final String dirName = "00";
+  private static final String topLevelDir = "ABI-L1b-RadC";
   private static final String G16_DIR = "ABI-L1b-RadC/2017/" + parentDirName + "/" + dirName;
   private static final String G16_NAME_1 =
       "OR_ABI-L1b-RadC-M3C01_G16_s20172420002168_e20172420004540_c20172420004583.nc";
@@ -43,6 +44,7 @@ public class TestMFileS3 {
   private static final String AWS_G16_S3_OBJECT_1 = S3TestsCommon.TOP_LEVEL_AWS_BUCKET + "?" + G16_OBJECT_KEY_1;
   private static final String AWS_G16_S3_OBJECT_2 = S3TestsCommon.TOP_LEVEL_AWS_BUCKET + "?" + G16_OBJECT_KEY_2;
   private static final String AWS_G16_S3_URI_DIR = S3TestsCommon.TOP_LEVEL_AWS_BUCKET + "?" + G16_DIR;
+  private static final String AWS_G16_S3_URI_TOP_DIR = S3TestsCommon.TOP_LEVEL_AWS_BUCKET + "?" + topLevelDir;
 
   // Google Cloud Platform constants
   private static final String GCS_G16_S3_OBJECT_1 = S3TestsCommon.TOP_LEVEL_GCS_BUCKET + "?" + G16_OBJECT_KEY_1;
@@ -129,6 +131,15 @@ public class TestMFileS3 {
   public void dirCheckOsdc() throws IOException {
     dirCheckNoDelim(OSDC_G16_S3_URI_DIR, OSDC_G16_DIR);
     dirCheckDelim(OSDC_G16_S3_URI_DIR + DELIMITER_FRAGMENT);
+  }
+
+  @Test
+  public void shouldReturnTopLevelKeyName() throws IOException {
+    final MFileS3 fileWithoutDelimiter = new MFileS3(AWS_G16_S3_URI_TOP_DIR);
+    assertThat(fileWithoutDelimiter.getName()).isEqualTo(topLevelDir);
+
+    final MFileS3 fileWithDelimiter = new MFileS3(AWS_G16_S3_URI_TOP_DIR + DELIMITER_FRAGMENT);
+    assertThat(fileWithDelimiter.getName()).isEqualTo(topLevelDir);
   }
 
   @Test


### PR DESCRIPTION
- Fix bug that next s3 key was not returned when starting with a uri with no key and with no delimiter
- Update tests to check that the s3 iterator returns a new uri
- Fix name of MFileS3 when there is no delimiter (just use key instead of empty string) and add test for this