### PR TITLE
[5.x] Add methods to mfile

### DIFF
--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
@@ -5,6 +5,8 @@
 
 package thredds.filesystem;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -115,6 +117,11 @@ public class MFileOS implements MFile {
   @Override
   public boolean exists() {
     return file.exists();
+  }
+
+  @Override
+  public FileInputStream getInputStream() throws FileNotFoundException {
+    return new FileInputStream(file);
   }
 
   @Override

--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
@@ -113,6 +113,11 @@ public class MFileOS implements MFile {
   }
 
   @Override
+  public boolean exists() {
+    return file.exists();
+  }
+
+  @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
     IO.copyFile(file, outputStream);
   }

--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
@@ -118,6 +118,11 @@ public class MFileOS7 implements MFile {
   }
 
   @Override
+  public boolean exists() {
+    return Files.exists(path);
+  }
+
+  @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
     IO.copyFile(path.toFile(), outputStream);
   }

--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
@@ -5,6 +5,8 @@
 
 package thredds.filesystem;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.OutputStream;
 import thredds.inventory.MFile;
 import ucar.nc2.util.IO;
@@ -120,6 +122,11 @@ public class MFileOS7 implements MFile {
   @Override
   public boolean exists() {
     return Files.exists(path);
+  }
+
+  @Override
+  public FileInputStream getInputStream() throws FileNotFoundException {
+    return new FileInputStream(path.toFile());
   }
 
   @Override

--- a/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
+++ b/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
@@ -5,6 +5,7 @@
 
 package thredds.inventory;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import thredds.client.catalog.Access;
 import thredds.client.catalog.Dataset;
@@ -151,6 +152,11 @@ public class CollectionManagerCatalog extends CollectionManagerAbstract implemen
     @Override
     public boolean exists() {
       return false;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      throw new UnsupportedOperationException("MFileRemote::getInputStream not implemented");
     }
 
     @Override

--- a/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
+++ b/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
@@ -149,6 +149,11 @@ public class CollectionManagerCatalog extends CollectionManagerAbstract implemen
     }
 
     @Override
+    public boolean exists() {
+      return false;
+    }
+
+    @Override
     public void writeToStream(OutputStream outputStream) throws IOException {
       throw new IOException("Writing MFileRemote not implemented. Filename: " + getName());
     }

--- a/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
+++ b/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
@@ -160,13 +160,13 @@ public class CollectionManagerCatalog extends CollectionManagerAbstract implemen
     }
 
     @Override
-    public void writeToStream(OutputStream outputStream) throws IOException {
-      throw new IOException("Writing MFileRemote not implemented. Filename: " + getName());
+    public void writeToStream(OutputStream outputStream) {
+      throw new UnsupportedOperationException("Writing MFileRemote not implemented. Filename: " + getName());
     }
 
     @Override
-    public void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException {
-      throw new IOException("Writing MFileRemote not implemented. Filename: " + getName());
+    public void writeToStream(OutputStream outputStream, long offset, long maxBytes) {
+      throw new UnsupportedOperationException("Writing MFileRemote not implemented. Filename: " + getName());
     }
   }
 

--- a/cdm/core/src/main/java/thredds/inventory/MFile.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFile.java
@@ -5,7 +5,9 @@
 
 package thredds.inventory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
@@ -70,6 +72,13 @@ public interface MFile extends Comparable<MFile> {
    * @return true if the MFile exists, else false
    */
   boolean exists();
+
+  /**
+   * Get the MFile InputStream
+   *
+   * @return the MFile InputStream
+   */
+  InputStream getInputStream() throws FileNotFoundException;
 
   /**
    * Write the MFile to an OutputStream

--- a/cdm/core/src/main/java/thredds/inventory/MFile.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFile.java
@@ -65,6 +65,13 @@ public interface MFile extends Comparable<MFile> {
   void setAuxInfo(Object info);
 
   /**
+   * Check if the MFile exists
+   *
+   * @return true if the MFile exists, else false
+   */
+  boolean exists();
+
+  /**
    * Write the MFile to an OutputStream
    *
    * @param outputStream the OutputStream the MFile contents should be written to

--- a/cdm/core/src/test/java/thredds/filesystem/TestMFileOS.java
+++ b/cdm/core/src/test/java/thredds/filesystem/TestMFileOS.java
@@ -5,66 +5,94 @@ import static com.google.common.truth.Truth.assertThat;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class TestMFileOS {
 
   @ClassRule
   public static final TemporaryFolder tempFolder = new TemporaryFolder();
 
-  @Parameterized.Parameters(name = "{0}")
-  static public List<Integer> getTestParameters() {
-    return Arrays.asList(0, 1, 60000, 100000);
+  @RunWith(Parameterized.class)
+  public static class TestMFileOSParameterized {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Integer> getTestParameters() {
+      return Arrays.asList(0, 1, 60000, 100000);
+    }
+
+    @Parameterized.Parameter()
+    public int expectedSize;
+
+    @Test
+    public void shouldWriteFileToStream() throws IOException {
+      final File file = createTemporaryFile(expectedSize);
+      final MFileOS mFile = new MFileOS(file);
+      final long length = mFile.getLength();
+      assertThat(length).isEqualTo(expectedSize);
+
+      final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      mFile.writeToStream(outputStream);
+      assertThat(outputStream.size()).isEqualTo(expectedSize);
+      assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
+    }
+
+    @Test
+    public void shouldWritePartialFileToStream() throws IOException {
+      final File file = createTemporaryFile(expectedSize);
+      final MFileOS mFile = new MFileOS(file);
+      final long length = mFile.getLength();
+      assertThat(length).isEqualTo(expectedSize);
+
+      final int offset = 42;
+      final int maxBytes = 100;
+
+      final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      mFile.writeToStream(outputStream, offset, maxBytes);
+
+      final int startPosition = Math.min(offset, expectedSize);
+      final int endPosition = Math.min(offset + maxBytes, expectedSize);
+
+      assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+
+      final byte[] partialFile = Arrays.copyOfRange(Files.readAllBytes(file.toPath()), startPosition, endPosition);
+      assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
+    }
   }
 
-  @Parameterized.Parameter()
-  public int expectedSize;
+  public static class TestMFileOSNonParameterized {
+    @Test
+    public void shouldReturnTrueForExistingFile() throws IOException {
+      final MFileOS mFile = new MFileOS(createTemporaryFile(0));
+      assertThat(mFile.exists()).isEqualTo(true);
+    }
 
-  @Test
-  public void shouldWriteFileToStream() throws IOException {
-    final File file = createTemporaryFile(expectedSize);
-    final MFileOS mFile = new MFileOS(file);
-    final long length = mFile.getLength();
-    assertThat(length).isEqualTo(expectedSize);
+    @Test
+    public void shouldReturnFalseForNonExistingFile() {
+      final MFileOS mFile = new MFileOS("NotARealFile");
+      assertThat(mFile.exists()).isEqualTo(false);
+    }
 
-    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    mFile.writeToStream(outputStream);
-    assertThat(outputStream.size()).isEqualTo(expectedSize);
-    assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
+    @Test
+    public void shouldGetInputStream() throws IOException {
+      final MFileOS mFile = new MFileOS(createTemporaryFile(1));
+      try (final InputStream inputStream = mFile.getInputStream()) {
+        assertThat(inputStream.read()).isNotEqualTo(-1);
+      }
+    }
   }
 
-  @Test
-  public void shouldWritePartialFileToStream() throws IOException {
-    final File file = createTemporaryFile(expectedSize);
-    final MFileOS mFile = new MFileOS(file);
-    final long length = mFile.getLength();
-    assertThat(length).isEqualTo(expectedSize);
-
-    final int offset = 42;
-    final int maxBytes = 100;
-
-    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    mFile.writeToStream(outputStream, offset, maxBytes);
-
-    final int startPosition = Math.min(offset, expectedSize);
-    final int endPosition = Math.min(offset + maxBytes, expectedSize);
-
-    assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
-
-    final byte[] partialFile = Arrays.copyOfRange(Files.readAllBytes(file.toPath()), startPosition, endPosition);
-    assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
-  }
-
-  private File createTemporaryFile(int size) throws IOException {
+  private static File createTemporaryFile(int size) throws IOException {
     final File tempFile = tempFolder.newFile();
 
     byte[] bytes = new byte[size];

--- a/cdm/core/src/test/java/thredds/filesystem/TestMFileOS7.java
+++ b/cdm/core/src/test/java/thredds/filesystem/TestMFileOS7.java
@@ -5,71 +5,102 @@ import static com.google.common.truth.Truth.assertThat;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class TestMFileOS7 {
 
   @ClassRule
   public static final TemporaryFolder tempFolder = new TemporaryFolder();
 
-  @Parameterized.Parameters(name = "{0}")
-  static public List<Integer> getTestParameters() {
-    return Arrays.asList(0, 1, 60000, 100000);
-  }
+  @RunWith(Parameterized.class)
+  public static class TestMFileOS7Parameterized {
 
-  @Parameterized.Parameter()
-  public int expectedSize;
+    @Parameterized.Parameters(name = "{0}")
+    static public List<Integer> getTestParameters() {
+      return Arrays.asList(0, 1, 60000, 100000);
+    }
 
-  @Test
-  public void shouldWriteFileToStream() throws IOException {
-    final File file = createTemporaryFile(expectedSize);
-    final MFileOS7 mFile = new MFileOS7(file.toPath());
-    final long length = mFile.getLength();
-    assertThat(length).isEqualTo(expectedSize);
+    @Parameterized.Parameter()
+    public int expectedSize;
 
-    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    mFile.writeToStream(outputStream);
-    assertThat(outputStream.size()).isEqualTo(expectedSize);
-    assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
-  }
-
-  @Test
-  public void shouldWritePartialFileToStream() throws IOException {
-    final File file = createTemporaryFile(expectedSize);
-    final MFileOS7 mFile = new MFileOS7(file.toPath());
-    final long length = mFile.getLength();
-    assertThat(length).isEqualTo(expectedSize);
-
-    final long[][] testCases = {{0, 0}, {10, 10}, {0, length}, {0, 100}, {42, 100}};
-
-    for (long[] testCase : testCases) {
-      final long offset = testCase[0];
-      final long maxBytes = testCase[1];
+    @Test
+    public void shouldWriteFileToStream() throws IOException {
+      final File file = createTemporaryFile(expectedSize);
+      final MFileOS7 mFile = new MFileOS7(file.toPath());
+      final long length = mFile.getLength();
+      assertThat(length).isEqualTo(expectedSize);
 
       final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-      mFile.writeToStream(outputStream, offset, maxBytes);
+      mFile.writeToStream(outputStream);
+      assertThat(outputStream.size()).isEqualTo(expectedSize);
+      assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
+    }
 
-      final long startPosition = Math.min(offset, expectedSize);
-      final long endPosition = Math.min(offset + maxBytes, expectedSize);
+    @Test
+    public void shouldWritePartialFileToStream() throws IOException {
+      final File file = createTemporaryFile(expectedSize);
+      final MFileOS7 mFile = new MFileOS7(file.toPath());
+      final long length = mFile.getLength();
+      assertThat(length).isEqualTo(expectedSize);
 
-      assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+      final long[][] testCases = {{0, 0}, {10, 10}, {0, length}, {0, 100}, {42, 100}};
 
-      final byte[] partialFile =
-          Arrays.copyOfRange(Files.readAllBytes(file.toPath()), (int) startPosition, (int) endPosition);
-      assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
+      for (long[] testCase : testCases) {
+        final long offset = testCase[0];
+        final long maxBytes = testCase[1];
+
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        mFile.writeToStream(outputStream, offset, maxBytes);
+
+        final long startPosition = Math.min(offset, expectedSize);
+        final long endPosition = Math.min(offset + maxBytes, expectedSize);
+
+        assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+
+        final byte[] partialFile =
+            Arrays.copyOfRange(Files.readAllBytes(file.toPath()), (int) startPosition, (int) endPosition);
+        assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
+      }
     }
   }
 
-  private File createTemporaryFile(int size) throws IOException {
+  public static class TestMFileOS7NonParameterized {
+    @Test
+    public void shouldReturnTrueForExistingFile() throws IOException {
+      final File file = createTemporaryFile(0);
+      final MFileOS7 mFile = new MFileOS7(file.toPath());
+      assertThat(mFile.exists()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldReturnFalseForNonExistingFile() {
+      final MFileOS7 mFile = new MFileOS7(Paths.get("NotARealFile"), null);
+      assertThat(mFile.exists()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldGetInputStream() throws IOException {
+      final File file = createTemporaryFile(1);
+      final MFileOS7 mFile = new MFileOS7(file.toPath());
+      try (final InputStream inputStream = mFile.getInputStream()) {
+        assertThat(inputStream.read()).isNotEqualTo(-1);
+      }
+    }
+  }
+
+  private static File createTemporaryFile(int size) throws IOException {
     final File tempFile = tempFolder.newFile();
 
     byte[] bytes = new byte[size];

--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -296,15 +296,20 @@ public class MFileS3 implements MFile {
   }
 
   @Override
-  public void writeToStream(OutputStream outputStream) throws IOException {
+  public ResponseInputStream<GetObjectResponse> getInputStream() {
     S3Client client = getClient();
 
-    if (client == null)
-      return;
+    if (client == null) {
+      return null;
+    }
 
     GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(cdmS3Uri.getBucket()).key(key).build();
+    return client.getObject(getObjectRequest);
+  }
 
-    ResponseInputStream<GetObjectResponse> responseInputStream = client.getObject(getObjectRequest);
+  @Override
+  public void writeToStream(OutputStream outputStream) throws IOException {
+    ResponseInputStream<GetObjectResponse> responseInputStream = getInputStream();
 
     IO.copy(responseInputStream, outputStream);
   }

--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -40,6 +40,7 @@ public class MFileS3 implements MFile {
 
   private long length;
   private long lastMod;
+  private Boolean exists;
 
   private Object auxInfo;
 
@@ -273,6 +274,25 @@ public class MFileS3 implements MFile {
 
     return (cdmS3Uri.equals(mFileS3.cdmS3Uri) && Objects.equals(key, mFileS3.key)
         && Objects.equals(delimiter, mFileS3.delimiter) && Objects.equals(auxInfo, mFileS3.auxInfo));
+  }
+
+  @Override
+  public boolean exists() {
+    if (exists == null) {
+      updateExists();
+    }
+
+    return exists;
+  }
+
+  // Update file exists by fetching from a head request
+  private void updateExists() {
+    try {
+      headObjectResponse.get();
+      exists = true;
+    } catch (NoSuchKeyException e) {
+      exists = false;
+    }
   }
 
   @Override

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -232,6 +233,26 @@ public class TestMFileS3 {
 
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     assertThrows(NoSuchKeyException.class, () -> mFile.writeToStream(outputStream));
+  }
+
+  @Test
+  public void shouldReturnTrueForExistingFile() throws IOException {
+    final MFile mFile = new MFileS3(AWS_G16_S3_OBJECT_1);
+    assertThat(mFile.exists()).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldReturnFalseForNonExistingFile() throws IOException {
+    final MFile mFile = new MFileS3(AWS_G16_S3_URI_DIR + "?NotARealKey");
+    assertThat(mFile.exists()).isEqualTo(false);
+  }
+
+  @Test
+  public void shouldGetInputStream() throws IOException {
+    final MFile mFile = new MFileS3(AWS_G16_S3_OBJECT_1);
+    try (final InputStream inputStream = mFile.getInputStream()) {
+      assertThat(inputStream.read()).isNotEqualTo(-1);
+    }
   }
 
   private void checkWithBucket(String cdmS3Uri) throws IOException {

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -150,6 +150,11 @@ public class MFileZip implements MFile {
   }
 
   @Override
+  public boolean exists() {
+    return Files.exists(Paths.get(root.getName()));
+  }
+
+  @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
     for (ZipEntry entry : leafEntries) {
       final File file = new File(entry.getName());

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -5,6 +5,7 @@
 
 package thredds.inventory.zarr;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import thredds.filesystem.MFileOS;
 import thredds.inventory.MFile;
@@ -152,6 +153,11 @@ public class MFileZip implements MFile {
   @Override
   public boolean exists() {
     return Files.exists(Paths.get(root.getName()));
+  }
+
+  @Override
+  public InputStream getInputStream() {
+    throw new UnsupportedOperationException("MFileZip::getInputStream not implemented");
   }
 
   @Override

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -170,7 +170,8 @@ public class MFileZip implements MFile {
 
   @Override
   public void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException {
-    throw new IOException("Writing MFileZip with a byte range to stream not implemented. Filename: " + getName());
+    throw new UnsupportedOperationException(
+        "Writing MFileZip with a byte range to stream not implemented. Filename: " + getName());
   }
 
   public Path getRootPath() {

--- a/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
@@ -5,6 +5,8 @@
 
 package ucar.nc2.grib.collection;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import javax.annotation.Nullable;
@@ -116,6 +118,11 @@ public class GcMFile implements thredds.inventory.MFile {
   @Override
   public boolean exists() {
     return new File(directory, name).exists();
+  }
+
+  @Override
+  public FileInputStream getInputStream() throws FileNotFoundException {
+    return new FileInputStream(new File(directory, name));
   }
 
   @Override

--- a/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
@@ -114,6 +114,11 @@ public class GcMFile implements thredds.inventory.MFile {
   }
 
   @Override
+  public boolean exists() {
+    return new File(directory, name).exists();
+  }
+
+  @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
     IO.copyFile(getPath(), outputStream);
   }

--- a/grib/src/test/java/ucar/nc2/grib/collection/TestGcMFile.java
+++ b/grib/src/test/java/ucar/nc2/grib/collection/TestGcMFile.java
@@ -5,72 +5,103 @@ import static com.google.common.truth.Truth.assertThat;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class TestGcMFile {
 
   @ClassRule
   public static final TemporaryFolder tempFolder = new TemporaryFolder();
 
-  @Parameterized.Parameters(name = "{0}")
-  static public List<Integer> getTestParameters() {
-    return Arrays.asList(0, 1, 60000, 100000);
-  }
+  @RunWith(Parameterized.class)
+  public static class TestGcMFileParameterized {
 
-  @Parameterized.Parameter()
-  public int expectedSize;
+    @Parameterized.Parameters(name = "{0}")
+    static public List<Integer> getTestParameters() {
+      return Arrays.asList(0, 1, 60000, 100000);
+    }
 
-  @Test
-  public void shouldWriteFileToStream() throws IOException {
-    final File file = createTemporaryFile(expectedSize);
-    final GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
+    @Parameterized.Parameter()
+    public int expectedSize;
 
-    final long length = mFile.getLength();
-    assertThat(length).isEqualTo(expectedSize);
+    @Test
+    public void shouldWriteFileToStream() throws IOException {
+      final File file = createTemporaryFile(expectedSize);
+      final GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
 
-    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    mFile.writeToStream(outputStream);
-    assertThat(outputStream.size()).isEqualTo(expectedSize);
-    assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
-  }
-
-  @Test
-  public void shouldWritePartialFileToStream() throws IOException {
-    final File file = createTemporaryFile(expectedSize);
-    GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
-
-    final long length = mFile.getLength();
-    assertThat(length).isEqualTo(expectedSize);
-
-    final int[][] testCases = {{0, 0}, {10, 10}, {0, (int) length}, {0, 100}, {42, 100}};
-
-    for (int[] testCase : testCases) {
-      final int offset = testCase[0];
-      final int maxBytes = testCase[1];
+      final long length = mFile.getLength();
+      assertThat(length).isEqualTo(expectedSize);
 
       final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-      mFile.writeToStream(outputStream, offset, maxBytes);
+      mFile.writeToStream(outputStream);
+      assertThat(outputStream.size()).isEqualTo(expectedSize);
+      assertThat(outputStream.toByteArray()).isEqualTo(Files.readAllBytes(file.toPath()));
+    }
 
-      final int startPosition = Math.min(offset, expectedSize);
-      final int endPosition = Math.min(offset + maxBytes, expectedSize);
+    @Test
+    public void shouldWritePartialFileToStream() throws IOException {
+      final File file = createTemporaryFile(expectedSize);
+      GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
 
-      assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+      final long length = mFile.getLength();
+      assertThat(length).isEqualTo(expectedSize);
 
-      final byte[] partialFile = Arrays.copyOfRange(Files.readAllBytes(file.toPath()), startPosition, endPosition);
-      assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
+      final int[][] testCases = {{0, 0}, {10, 10}, {0, (int) length}, {0, 100}, {42, 100}};
+
+      for (int[] testCase : testCases) {
+        final int offset = testCase[0];
+        final int maxBytes = testCase[1];
+
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        mFile.writeToStream(outputStream, offset, maxBytes);
+
+        final int startPosition = Math.min(offset, expectedSize);
+        final int endPosition = Math.min(offset + maxBytes, expectedSize);
+
+        assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+
+        final byte[] partialFile = Arrays.copyOfRange(Files.readAllBytes(file.toPath()), startPosition, endPosition);
+        assertThat(outputStream.toByteArray()).isEqualTo(partialFile);
+      }
     }
   }
 
-  private File createTemporaryFile(int size) throws IOException {
+  public static class TestGcMFileNonParameterized {
+    @Test
+    public void shouldReturnTrueForExistingFile() throws IOException {
+      final File file = createTemporaryFile(0);
+      final GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
+      assertThat(mFile.exists()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldReturnFalseForNonExistingFile() {
+      final GcMFile mFile = new GcMFile(tempFolder.getRoot(), "notARealFile", 0, 0, 0);
+      assertThat(mFile.exists()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldGetInputStream() throws IOException {
+      final File file = createTemporaryFile(1);
+      final GcMFile mFile = new GcMFile(tempFolder.getRoot(), file.getName(), file.lastModified(), file.length(), 0);
+      try (final InputStream inputStream = mFile.getInputStream()) {
+        assertThat(inputStream.read()).isNotEqualTo(-1);
+      }
+    }
+  }
+
+
+  private static File createTemporaryFile(int size) throws IOException {
     final File tempFile = tempFolder.newFile();
 
     byte[] bytes = new byte[size];


### PR DESCRIPTION
Add `exists` and `getInputStream` methods to MFile. This is needed so that an S3 `MFile`s can be used for grib indexes. The `exists` method will be useful in checking whether a grib index already exists or needs to be created. The `getInputStream` method is needed for reading a grib index.