### PR TITLE
[5.x] Fix MFileCollectionManager tests

### DIFF
--- a/cdm/core/src/test/java/thredds/inventory/TestMFileCollectionManager.java
+++ b/cdm/core/src/test/java/thredds/inventory/TestMFileCollectionManager.java
@@ -26,9 +26,7 @@ public class TestMFileCollectionManager {
   public static List<Object[]> getTestParameters() {
     return Arrays.asList(new Object[][] {
 
-        {cdmUnitTestDir + ".*", true},
-
-        {cdmUnitTestDir + "ncss/GFS/.*", true},
+        {cdmUnitTestDir + "ncss/GFS/CONUS_80km/.*", true},
 
         {cdmUnitTestDir + "ncss/GFS/CONUS_80km/.*grib1", true},
 

--- a/cdm/core/src/test/java/thredds/inventory/TestMFileCollectionManager.java
+++ b/cdm/core/src/test/java/thredds/inventory/TestMFileCollectionManager.java
@@ -51,7 +51,7 @@ public class TestMFileCollectionManager {
 
   @Test
   public void shouldGetFilteredFiles() throws IOException {
-    final CollectionManager collectionManager = MFileCollectionManager.open("testWithDelimiter", spec, null, null);
+    final CollectionManager collectionManager = MFileCollectionManager.open("TestFilteredFiles", spec, null, null);
     final List<String> fileList = collectionManager.getFilenames();
     assertThat(!fileList.isEmpty()).isEqualTo(haveFiles);
     assertFileNamesMatchRegEx(fileList);
@@ -70,7 +70,7 @@ public class TestMFileCollectionManager {
     for (String file : fileList) {
       final long numberOfSlashesInFile = file.chars().filter(c -> c == '/').count();
 
-      assertWithMessage("Expected file " + file + "to be in directory defined by spec: " + spec)
+      assertWithMessage("Expected file " + file + " to be in directory defined by spec: " + spec)
           .that(numberOfSlashesInFile).isEqualTo(numberOfSlashesInPattern);
     }
   }


### PR DESCRIPTION
Fix the tests that fail on Jenkins that were added with the [S3 Collection spec parsing PR](https://github.com/Unidata/netcdf-java/pull/1012). The tests expect to find files in a folder but the folder only contains directories. Not sure why they pass for me locally but not on Jenkins.

