### PR TITLE
Add an SPI hook to handle CF sub-conventions

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/spi/CFSubConventionProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/spi/CFSubConventionProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 1998-2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.internal.dataset.spi;
+
+import ucar.nc2.dataset.spi.CoordSystemBuilderFactory;
+
+/**
+ * A special SPI to register CF sub-convention or incubating convention CoordSystemBuilderFactory classes.
+ *
+ * FOR INTERNAL USE ONLY
+ *
+ * This interface is the same as CoordSystemBuilderFactory, except these are dynamically loaded and placed at the top of
+ * the list of conventions, as opposed to being appended to the bottom of the list of conventions. The reason we must
+ * do this is because the current CF CoordSystemBuilderFactory looks for a global attribute named "Convention" that
+ * starts with the string "CF-1.". That means we'd either need to handle all sub-conventions or incubating conventions
+ * within the main CF CoordSystemBuilder, or somehow make sure these conventions are loaded before the main CF
+ * CoordSystemBuilder (which is what this interface is intended to facilitate).
+ */
+public interface CFSubConventionProvider extends CoordSystemBuilderFactory {
+}

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestCfSubConventionProvider.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestCfSubConventionProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 1998-2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.dataset;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import ucar.nc2.Attribute;
+import ucar.nc2.Group;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.constants.CDM;
+import ucar.nc2.dataset.conv.CfSubConvForTest;
+import ucar.nc2.internal.dataset.CoordSystemBuilder;
+import ucar.nc2.internal.dataset.CoordSystemFactory;
+import ucar.nc2.internal.dataset.conv.CF1Convention;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class TestCfSubConventionProvider {
+
+  private static final NetcdfDataset.Builder<?> CF_NCDB = NetcdfDataset.builder();
+  private static final NetcdfDataset.Builder<?> YOLO_NCDB = NetcdfDataset.builder();
+
+  @BeforeClass
+  public static void makeNcdBuilders() throws IOException {
+    NetcdfFile.Builder<?> cfNcfb = NetcdfFile.builder();
+    NetcdfFile.Builder<?> yoloNcfb = NetcdfFile.builder();
+
+    Group.Builder cfRoot = Group.builder().setName("");
+    cfNcfb.setRootGroup(cfRoot);
+    Attribute cfConvAttr = Attribute.builder(CDM.CONVENTIONS).setStringValue("CF-1.6").build();
+    cfRoot.addAttribute(cfConvAttr);
+    try (NetcdfFile cfNcf = cfNcfb.build()) {
+      CF_NCDB.copyFrom(cfNcf);
+      CF_NCDB.setOrgFile(cfNcf);
+    } catch (IOException ioe) {
+      throw new IOException("Error building NetcdfFile object to mock a CF netCDF file for testing.", ioe);
+    }
+
+    Group.Builder yoloRoot = Group.builder().setName("");
+    yoloNcfb.setRootGroup(yoloRoot);
+    Attribute yoloConvAttr =
+        Attribute.builder(CDM.CONVENTIONS).setStringValue(CfSubConvForTest.CONVENTION_NAME).build();
+    yoloRoot.addAttribute(yoloConvAttr);
+    try (NetcdfFile yoloNcf = yoloNcfb.build()) {
+      YOLO_NCDB.copyFrom(yoloNcf);
+      YOLO_NCDB.setOrgFile(yoloNcf);
+    } catch (IOException ioe) {
+      throw new IOException("Error building NetcdfFile object to mock a CF/YOLO netCDF file for testing.", ioe);
+    }
+  }
+
+  @Test
+  public void testCfSubLoadOrder() throws IOException {
+    Optional<CoordSystemBuilder> cfFacOpt = CoordSystemFactory.factory(CF_NCDB, null);
+    assertThat(cfFacOpt.isPresent());
+    CoordSystemBuilder cfFac = cfFacOpt.get();
+    assertThat(cfFac).isInstanceOf(CF1Convention.class);
+
+    Optional<CoordSystemBuilder> yoloFacOpt = CoordSystemFactory.factory(YOLO_NCDB, null);
+    assertThat(yoloFacOpt.isPresent());
+    CoordSystemBuilder yoloFac = yoloFacOpt.get();
+    assertThat(yoloFac).isInstanceOf(CfSubConvForTest.class);
+    assertThat(yoloFac.getConventionUsed()).isEqualTo(CfSubConvForTest.CONVENTION_NAME);
+  }
+}

--- a/cdm/core/src/test/java/ucar/nc2/dataset/conv/CfSubConvForTest.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/conv/CfSubConvForTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1998-2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.dataset.conv;
+
+import ucar.nc2.Attribute;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.constants.CDM;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.internal.dataset.CoordSystemBuilder;
+import ucar.nc2.internal.dataset.spi.CFSubConventionProvider;
+
+/**
+ * An implementation of CoordSystemBuilder for testing CFSubConvention hooks.
+ *
+ * @see ucar.nc2.dataset.TestCfSubConventionProvider
+ */
+public class CfSubConvForTest extends CoordSystemBuilder {
+  public static String CONVENTION_NAME = "CF-1.200/YOLO";
+
+  private CfSubConvForTest(NetcdfDataset.Builder<?> datasetBuilder) {
+    super(datasetBuilder);
+    this.conventionName = CONVENTION_NAME;
+  }
+
+  public static class Factory implements CFSubConventionProvider {
+    @Override
+    public boolean isMine(NetcdfFile ncfile) {
+      boolean mine = false;
+      Attribute conventionAttr = ncfile.findGlobalAttributeIgnoreCase(CDM.CONVENTIONS);
+      if (conventionAttr != null) {
+        String conventionValue = conventionAttr.getStringValue();
+        if (conventionValue != null) {
+          mine = conventionValue.equals(CONVENTION_NAME);
+        }
+      }
+      return mine;
+    }
+
+    @Override
+    public String getConventionName() {
+      return CONVENTION_NAME;
+    }
+
+    @Override
+    public CoordSystemBuilder open(NetcdfDataset.Builder datasetBuilder) {
+      return new CfSubConvForTest(datasetBuilder);
+    }
+  }
+}

--- a/cdm/core/src/test/resources/META-INF/services/ucar.nc2.internal.dataset.spi.CFSubConventionProvider
+++ b/cdm/core/src/test/resources/META-INF/services/ucar.nc2.internal.dataset.spi.CFSubConventionProvider
@@ -1,0 +1,1 @@
+ucar.nc2.dataset.conv.CfSubConvForTest$Factory


### PR DESCRIPTION
This PR adds a hook to handle the registration and use of CF sub-conventions (or incubating CF sub-conventions). This allows us to play with new CF conventions without the need of tweaking the main CF coordinate system builder class.