### PR TITLE
[5.x] Fix nullptr exception

### DIFF
--- a/cdm/core/src/main/java/thredds/inventory/MFileProvider.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFileProvider.java
@@ -18,7 +18,7 @@ public interface MFileProvider {
 
   /** Determine if this Provider can provide an MFile for a given location. */
   default boolean canProvide(String location) {
-    return location.startsWith(getProtocol() + ":");
+    return location != null && location.startsWith(getProtocol() + ":");
   }
 
   /**


### PR DESCRIPTION
When creating a nested aggregation, the location for the outer aggregation can be null, leading to a nullptr exception here. (reported in https://github.com/Unidata/tds/issues/225)

I went ahead and added a test, but since the bug only occurred when MFileProviders were loaded, it seemed easier to make an integration test in TDS (https://github.com/Unidata/tds/pull/226)