### PR TITLE
[5.x] Fix nullptr exception in coverage as point

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
@@ -55,8 +55,17 @@ public class CoverageAsPoint {
       this.name = name;
       this.varData = new ArrayList<>();
       for (Coverage cov : wantCovs) {
-        this.varData.add(new VarData(cov));
+        try {
+          this.varData.add(new VarData(cov));
+        } catch (InvalidRangeException e) {
+          e.printStackTrace();
+        }
       }
+
+      if (varData.isEmpty()) {
+        throw new IllegalArgumentException("No coverage data found for parameters " + subset);
+      }
+
       CoverageCoordSys subsetSys = this.varData.get(0).array.getCoordSysForData();
 
       // single point subset, so only one lat/lon to grab, and this will be the lat/lon
@@ -82,16 +91,11 @@ public class CoverageAsPoint {
     Coverage cov;
     GeoReferencedArray array;
 
-    VarData(Coverage cov) throws IOException {
+    VarData(Coverage cov) throws IOException, InvalidRangeException {
       this.cov = cov;
-      try {
-        this.array = cov.readData(subset);
-        if (debug) {
-          System.out.printf(" Coverage %s data shape = %s%n", cov.getName(),
-              Arrays.toString(array.getData().getShape()));
-        }
-      } catch (InvalidRangeException e) {
-        e.printStackTrace();
+      this.array = cov.readData(subset);
+      if (debug) {
+        System.out.printf(" Coverage %s data shape = %s%n", cov.getName(), Arrays.toString(array.getData().getShape()));
       }
     }
   }

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/writer/TestCoverageAsPoint.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/writer/TestCoverageAsPoint.java
@@ -1,6 +1,7 @@
 package ucar.nc2.ft2.coverage.writer;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -75,6 +76,21 @@ public class TestCoverageAsPoint {
     varNames.add("T1noZ");
     params.setVariables(varNames);
     readCoverageAsPoint(varNames, params, alts[0], times, vals);
+  }
+
+  @Test
+  public void testExceptionThrownForPointOutsideCoverage() {
+    double[] vals = Arrays.copyOfRange(expected, 0, 1);
+    // test single point (no time)
+    List<String> varNames = new ArrayList<>();
+    varNames.add("2D");
+    SubsetParams params = new SubsetParams();
+    params.setVariables(varNames);
+    params.setLatLonPoint(LatLonPoint.create(100, 100));
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> readCoverageAsPoint(varNames, params, alts[0], times, vals));
+    assertThat(e).hasMessageThat()
+        .contains("No coverage data found for parameters  latlonPoint == 90.0000N 100.0000E, var == [2D],");
   }
 
   @Test


### PR DESCRIPTION
## Description of Changes

When you specify an out of bounds latLon parameter in coverage as point, instead of getting a nullptr exception from VarData.array, you now get an IllegalArgumentException with a hopefully clearer message of what went wrong.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
