### PR TITLE
[5.x] Fix ncss NaNs

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
@@ -496,7 +496,7 @@ class CoordAxisHelper {
 
     // subset(int ncoords, double start, double end, double[] values)
     CoverageCoordAxisBuilder builder = new CoverageCoordAxisBuilder(axis);
-    builder.subset(ncoords, axis.getCoordMidpoint(range.first()), axis.getCoordMidpoint(range.last()), resolution,
+    builder.subset(ncoords, axis.getCoordEdge1(range.first()), axis.getCoordEdge1(range.last()), resolution,
         subsetValues);
     builder.setRange(range);
     return builder;

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
@@ -100,11 +100,11 @@ class CoordAxisHelper {
       double lower = axis.getCoordEdge1(index);
       double upper = axis.getCoordEdge2(index);
       if (axis.isAscending()) {
-        assert lower <= coordValue : lower + " should be le " + coordValue;
-        assert upper >= coordValue : upper + " should be ge " + coordValue;
+        assert lower <= coordValue : lower + " should be <= " + coordValue;
+        assert upper >= coordValue : upper + " should be >= " + coordValue;
       } else {
-        assert lower >= coordValue : lower + " should be ge " + coordValue;
-        assert upper <= coordValue : upper + " should be le " + coordValue;
+        assert lower >= coordValue : lower + " should be >= " + coordValue;
+        assert upper <= coordValue : upper + " should be <= " + coordValue;
       }
     }
 

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
@@ -1,0 +1,35 @@
+package ucar.nc2.ft2.coverage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Range;
+import ucar.nc2.constants.AxisType;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis.Spacing;
+
+public class TestCoordAxisHelper {
+
+  @Test
+  public void shouldSubsetAxisByRange() throws InvalidRangeException {
+    final AxisType axisType = AxisType.Time;
+    final double[] values = new double[] {0.0, 10.0, 20.0, 30.0, 40.0};
+    final Spacing spacing = Spacing.regularInterval;
+    final double resolution = values[1] - values[0];
+
+    final CoverageCoordAxisBuilder coverageCoordAxisBuilder = new CoverageCoordAxisBuilder("name", "unit",
+        "description", DataType.DOUBLE, axisType, null, CoverageCoordAxis.DependenceType.independent, null, spacing,
+        values.length, values[0], values[values.length - 1], resolution, values, null);
+    final CoverageCoordAxis1D coverageCoordAxis = new CoverageCoordAxis1D(coverageCoordAxisBuilder);
+    final CoordAxisHelper coordAxisHelper = new CoordAxisHelper(coverageCoordAxis);
+
+    final Range subsetRange = new Range(1, 3);
+    final CoverageCoordAxisBuilder subsetBuilder = coordAxisHelper.subsetByIndex(subsetRange);
+    assertThat(subsetBuilder).isNotNull();
+    assertThat(subsetBuilder.axisType).isEqualTo(axisType);
+    assertThat(subsetBuilder.startValue).isEqualTo(values[subsetRange.first()]);
+    assertThat(subsetBuilder.endValue).isEqualTo(values[subsetRange.last()]);
+    assertThat(subsetBuilder.values).isNull(); // null for regular values
+  }
+}


### PR DESCRIPTION
## Description of Changes

This fixes the NaNs reported in BOM-253456. 

- Error message improved
- Add test
- Don't return the interval midpoints when subsetting by a range. This caused no record to be found for subset coordinates, and so NaNs were returned.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
