### PR TITLE
[5.x] Use interval midpoint as coordinate

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
@@ -57,6 +57,7 @@ import java.util.Collection;
 @Category(NeedsCdmUnitTest.class)
 public class TestIntervalsTimeCoords2D {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final double TOLERANCE = 1e-6;
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> getTestParameters() throws IOException {
@@ -113,12 +114,18 @@ public class TestIntervalsTimeCoords2D {
       Variable interval = best.findVariableLocal(dimBounds);
       assertThat(interval != null).isTrue();
 
+      Variable coordinate = best.findVariableLocal(dim.getShortName());
+      assertThat(coordinate != null).isTrue();
+
       Array data = interval.read();
       IndexIterator iter = data.getIndexIterator();
+      Array coordinateData = coordinate.read();
+      IndexIterator coordinateIter = coordinateData.getIndexIterator();
       int idx = 0;
       while (iter.hasNext()) {
         int start = iter.getIntNext();
         int end = iter.getIntNext();
+        double coordinateValue = coordinateIter.getDoubleNext();
         if (start != bounds[idx][0] || end != bounds[idx][1]) {
           logger.error("bounds " + interval.getFullName() + " for file " + filename + ", parameter " + var.getFullName()
               + " failed");
@@ -126,6 +133,7 @@ public class TestIntervalsTimeCoords2D {
         }
         assertThat(start).isEqualTo(bounds[idx][0]);
         assertThat(end).isEqualTo(bounds[idx][1]);
+        assertThat(coordinateValue).isWithin(TOLERANCE).of((start + end) / 2.0);
         idx++;
       }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
@@ -10,6 +10,8 @@
 
 package ucar.nc2.iosp.grib;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -103,7 +105,7 @@ public class TestIntervalsTimeCoords2D {
         best = ncf.getRootGroup();
       }
       Variable var = ncf.findVariableByAttribute(best, Grib.VARIABLE_ID_ATTNAME, parameter);
-      assert var != null : parameter;
+      assertThat(var != null).isTrue();
       logger.debug(" using variable " + var.getFullName());
 
       Dimension dim = var.getDimension(0);
@@ -111,7 +113,7 @@ public class TestIntervalsTimeCoords2D {
         dim = var.getDimension(1);
       String bounds = dim.getShortName() + "_bounds";
       Variable interval = best.findVariableLocal(bounds);
-      assert interval != null : bounds;
+      assertThat(interval != null).isTrue();
 
       Array data = interval.read();
       IndexIterator iter = data.getIndexIterator();
@@ -124,8 +126,8 @@ public class TestIntervalsTimeCoords2D {
               + " failed");
           logger.error("interval " + start + " - " + end + " known " + tb[idx][0] + " - " + tb[idx][0]);
         }
-        assert (start == tb[idx][0]);
-        assert (end == tb[idx][1]);
+        assertThat(start).isEqualTo(tb[idx][0]);
+        assertThat(end).isEqualTo(tb[idx][1]);
         idx++;
       }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
@@ -95,7 +95,7 @@ public class TestIntervalsTimeCoords2D {
   public void checkTimeIntervalCoordinates() throws Exception {
     int[][] tb = (int[][]) bounds;
 
-    System.out.printf("Open %s (%s)%n", filename, parameter);
+    logger.debug("Open " + filename + "(" + parameter + ")");
 
     try (NetcdfFile ncf = NetcdfFiles.open(filename)) {
       Group best = ncf.findGroup("Best"); // use best group if it exists, may be null
@@ -104,7 +104,7 @@ public class TestIntervalsTimeCoords2D {
       }
       Variable var = ncf.findVariableByAttribute(best, Grib.VARIABLE_ID_ATTNAME, parameter);
       assert var != null : parameter;
-      System.out.printf(" using variable %s%n", var.getFullName());
+      logger.debug(" using variable " + var.getFullName());
 
       Dimension dim = var.getDimension(0);
       if (dim.getShortName().startsWith("reftime"))
@@ -120,9 +120,9 @@ public class TestIntervalsTimeCoords2D {
         int start = iter.getIntNext();
         int end = iter.getIntNext();
         if (start != tb[idx][0] || end != tb[idx][1]) {
-          System.out.printf("bounds %s for file %s, parameter %s failed%n", interval.getFullName(), filename,
-              var.getFullName());
-          System.out.printf("interval %d - %d  known %d - %d%n", start, end, tb[idx][0], tb[idx][1]);
+          logger.error("bounds " + interval.getFullName() + " for file " + filename + ", parameter " + var.getFullName()
+              + " failed");
+          logger.error("interval " + start + " - " + end + " known " + tb[idx][0] + " - " + tb[idx][0]);
         }
         assert (start == tb[idx][0]);
         assert (end == tb[idx][1]);

--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
@@ -80,10 +80,10 @@ public class TestIntervalsTimeCoords2D {
 
   String filename;
   String parameter;
-  Object bounds;
+  int[][] bounds;
   int ndim;
 
-  public TestIntervalsTimeCoords2D(String filename, String parameter, Object bounds, int ndim) {
+  public TestIntervalsTimeCoords2D(String filename, String parameter, int[][] bounds, int ndim) {
     this.filename = filename;
     this.parameter = parameter;
     this.bounds = bounds;
@@ -95,8 +95,6 @@ public class TestIntervalsTimeCoords2D {
    */
   @Test
   public void checkTimeIntervalCoordinates() throws Exception {
-    int[][] tb = (int[][]) bounds;
-
     logger.debug("Open " + filename + "(" + parameter + ")");
 
     try (NetcdfFile ncf = NetcdfFiles.open(filename)) {
@@ -111,8 +109,8 @@ public class TestIntervalsTimeCoords2D {
       Dimension dim = var.getDimension(0);
       if (dim.getShortName().startsWith("reftime"))
         dim = var.getDimension(1);
-      String bounds = dim.getShortName() + "_bounds";
-      Variable interval = best.findVariableLocal(bounds);
+      String dimBounds = dim.getShortName() + "_bounds";
+      Variable interval = best.findVariableLocal(dimBounds);
       assertThat(interval != null).isTrue();
 
       Array data = interval.read();
@@ -121,13 +119,13 @@ public class TestIntervalsTimeCoords2D {
       while (iter.hasNext()) {
         int start = iter.getIntNext();
         int end = iter.getIntNext();
-        if (start != tb[idx][0] || end != tb[idx][1]) {
+        if (start != bounds[idx][0] || end != bounds[idx][1]) {
           logger.error("bounds " + interval.getFullName() + " for file " + filename + ", parameter " + var.getFullName()
               + " failed");
-          logger.error("interval " + start + " - " + end + " known " + tb[idx][0] + " - " + tb[idx][0]);
+          logger.error("interval " + start + " - " + end + " known " + bounds[idx][0] + " - " + bounds[idx][0]);
         }
-        assertThat(start).isEqualTo(tb[idx][0]);
-        assertThat(end).isEqualTo(tb[idx][1]);
+        assertThat(start).isEqualTo(bounds[idx][0]);
+        assertThat(end).isEqualTo(bounds[idx][1]);
         idx++;
       }
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIosp.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIosp.java
@@ -780,12 +780,7 @@ public abstract class GribIosp extends AbstractIOServiceProvider {
           CoordinateTimeIntv timeIntv = (CoordinateTimeIntv) time2D.getTimeCoordinate(runIdx);
           int timeIdx = 0;
           for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals()) {
-            data[runIdx * ntimes + timeIdx] = timeUnit.getValue() * tinv.getBounds2() + time2D.getOffset(runIdx); // use
-                                                                                                                  // upper
-                                                                                                                  // bounds
-                                                                                                                  // for
-                                                                                                                  // coord
-                                                                                                                  // value
+            data[runIdx * ntimes + timeIdx] = timeUnit.getValue() * tinv.getCoordValue() + time2D.getOffset(runIdx);
             timeIdx++;
           }
         }
@@ -796,8 +791,7 @@ public abstract class GribIosp extends AbstractIOServiceProvider {
         for (int runIdx = 0; runIdx < nruns; runIdx++) {
           CoordinateTimeIntv timeIntv = (CoordinateTimeIntv) time2D.getTimeCoordinate(runIdx);
           for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals()) {
-            data[count++] = timeUnit.getValue() * tinv.getBounds2() + time2D.getOffset(runIdx); // use upper bounds for
-                                                                                                // coord value
+            data[count++] = timeUnit.getValue() * tinv.getCoordValue() + time2D.getOffset(runIdx);
           }
         }
         break;
@@ -910,9 +904,8 @@ public abstract class GribIosp extends AbstractIOServiceProvider {
     double[] data = new double[ntimes];
     int count = 0;
 
-    // use upper bounds for coord value
     for (TimeCoordIntvValue tinv : coordTime.getTimeIntervals()) {
-      data[count++] = tinv.getBounds2();
+      data[count++] = tinv.getCoordValue();
     }
     v.setCachedData(Array.factory(DataType.DOUBLE, new int[] {ntimes}, data));
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
@@ -580,12 +580,7 @@ class GribIospBuilder {
           CoordinateTimeIntv timeIntv = (CoordinateTimeIntv) time2D.getTimeCoordinate(runIdx);
           int timeIdx = 0;
           for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals()) {
-            data[runIdx * ntimes + timeIdx] = timeUnit.getValue() * tinv.getBounds2() + time2D.getOffset(runIdx); // use
-            // upper
-            // bounds
-            // for
-            // coord
-            // value
+            data[runIdx * ntimes + timeIdx] = timeUnit.getValue() * tinv.getCoordValue() + time2D.getOffset(runIdx);
             timeIdx++;
           }
         }
@@ -596,8 +591,7 @@ class GribIospBuilder {
         for (int runIdx = 0; runIdx < nruns; runIdx++) {
           CoordinateTimeIntv timeIntv = (CoordinateTimeIntv) time2D.getTimeCoordinate(runIdx);
           for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals()) {
-            data[count++] = timeUnit.getValue() * tinv.getBounds2() + time2D.getOffset(runIdx); // use upper bounds for
-            // coord value
+            data[count++] = timeUnit.getValue() * tinv.getCoordValue() + time2D.getOffset(runIdx);
           }
         }
         break;
@@ -715,9 +709,8 @@ class GribIospBuilder {
     double[] data = new double[ntimes];
     int count = 0;
 
-    // use upper bounds for coord value
     for (TimeCoordIntvValue tinv : coordTime.getTimeIntervals()) {
-      data[count++] = tinv.getBounds2();
+      data[count++] = tinv.getCoordValue();
     }
     v.setCachedData(Array.factory(DataType.DOUBLE, new int[] {ntimes}, data), false);
 

--- a/grib/src/main/java/ucar/nc2/grib/coord/TimeCoordIntvValue.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/TimeCoordIntvValue.java
@@ -28,6 +28,11 @@ public class TimeCoordIntvValue implements Comparable<TimeCoordIntvValue> {
     return Math.abs(b2 - b1);
   }
 
+  public double getCoordValue() {
+    // Choose interval midpoint as the coordinate value
+    return (b1 + b2) / 2.0;
+  }
+
   public TimeCoordIntvValue convertReferenceDate(CalendarDate fromDate, CalendarPeriod fromUnit, CalendarDate toDate,
       CalendarPeriod toUnit) {
     CalendarDate start = fromDate.add(fromUnit.multiply(b1));


### PR DESCRIPTION
## Description of Changes

Currently a time interval's coordinate uses the interval endpoint, see for example: [time coordinate variable](https://threddsrc.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_onedeg/GFS_Global_onedeg_20220613_0000.grib2.asc?time) and [time bounds variable](https://threddsrc.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_onedeg/GFS_Global_onedeg_20220613_0000.grib2.asc?time_bounds)

- Change the coordinate to use the interval midpoint instead
- Cleanup tests, and test a time interval's coordinate value


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
