### PR TITLE
[5.x] Fix ncss nans

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
@@ -496,8 +496,7 @@ class CoordAxisHelper {
 
     // subset(int ncoords, double start, double end, double[] values)
     CoverageCoordAxisBuilder builder = new CoverageCoordAxisBuilder(axis);
-    builder.subset(ncoords, axis.getCoordMidpoint(range.first()), axis.getCoordMidpoint(range.last()), resolution,
-        subsetValues);
+    builder.subset(ncoords, axis.getCoord(range.first()), axis.getCoord(range.last()), resolution, subsetValues);
     builder.setRange(range);
     return builder;
   }

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoordAxisHelper.java
@@ -100,11 +100,11 @@ class CoordAxisHelper {
       double lower = axis.getCoordEdge1(index);
       double upper = axis.getCoordEdge2(index);
       if (axis.isAscending()) {
-        assert lower <= coordValue : lower + " should be le " + coordValue;
-        assert upper >= coordValue : upper + " should be ge " + coordValue;
+        assert lower <= coordValue : lower + " should be <= " + coordValue;
+        assert upper >= coordValue : upper + " should be >= " + coordValue;
       } else {
-        assert lower >= coordValue : lower + " should be ge " + coordValue;
-        assert upper <= coordValue : upper + " should be le " + coordValue;
+        assert lower >= coordValue : lower + " should be >= " + coordValue;
+        assert upper <= coordValue : upper + " should be <= " + coordValue;
       }
     }
 

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis1D.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis1D.java
@@ -114,6 +114,25 @@ public class CoverageCoordAxis1D extends CoverageCoordAxis { // implements Itera
     throw new IllegalStateException("unknown spacing" + spacing);
   }
 
+  public double getCoord(int index) {
+    if (index < 0 || index >= getNcoords()) {
+      throw new IllegalArgumentException("Index out of range=" + index);
+    }
+    loadValuesIfNeeded();
+
+    switch (spacing) {
+      case regularPoint:
+      case regularInterval:
+        return startValue + index * getResolution();
+
+      case irregularPoint:
+      case contiguousInterval:
+      case discontiguousInterval:
+        return values[index];
+    }
+    throw new IllegalStateException("Unknown spacing=" + spacing);
+  }
+
   public double getCoordMidpoint(int index) {
     if (index < 0 || index >= getNcoords())
       throw new IllegalArgumentException("Index out of range=" + index);

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
@@ -1,0 +1,64 @@
+package ucar.nc2.ft2.coverage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Range;
+import ucar.nc2.constants.AxisType;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis.Spacing;
+
+@RunWith(Parameterized.class)
+public class TestCoordAxisHelper {
+
+  @Parameterized.Parameters(name = "{0}, {1}")
+  public static List<Object[]> getTestParameters() {
+    return Arrays.asList(
+
+        new Object[] {Spacing.regularPoint, new double[] {0.0, 10.0, 20.0, 30.0, 40.0}},
+        new Object[] {Spacing.irregularPoint, new double[] {0.0, 5.0, 20.0, 30.0, 40.0}},
+        new Object[] {Spacing.regularInterval, new double[] {0.0, 10.0, 20.0, 30.0, 40.0}},
+        new Object[] {Spacing.contiguousInterval, new double[] {0.0, 5.0, 20.0, 30.0, 40.0}},
+        new Object[] {Spacing.discontiguousInterval, new double[] {0.0, 0.0, 20.0, 30.0, 40.0, 40.0, 50.0, 50.0}}
+
+    );
+  }
+
+  private final Spacing spacing;
+  private final double[] values;
+
+  public TestCoordAxisHelper(Spacing spacing, double[] values) {
+    this.spacing = spacing;
+    this.values = values;
+  }
+
+  @Test
+  public void shouldSubsetAxisByRange() throws InvalidRangeException {
+    final AxisType axisType = AxisType.Time;
+    final double resolution = values[1] - values[0];
+
+    final CoverageCoordAxisBuilder coverageCoordAxisBuilder = new CoverageCoordAxisBuilder("name", "unit",
+        "description", DataType.DOUBLE, axisType, null, CoverageCoordAxis.DependenceType.independent, null, spacing,
+        values.length, values[0], values[values.length - 1], resolution, values, null);
+    final CoverageCoordAxis1D coverageCoordAxis = new CoverageCoordAxis1D(coverageCoordAxisBuilder);
+    final CoordAxisHelper coordAxisHelper = new CoordAxisHelper(coverageCoordAxis);
+
+    final Range subsetRange = new Range(1, 3);
+    final CoverageCoordAxisBuilder subsetBuilder = coordAxisHelper.subsetByIndex(subsetRange);
+    assertThat(subsetBuilder).isNotNull();
+    assertThat(subsetBuilder.axisType).isEqualTo(axisType);
+    assertThat(subsetBuilder.startValue).isEqualTo(values[subsetRange.first()]);
+    assertThat(subsetBuilder.endValue).isEqualTo(values[subsetRange.last()]);
+
+    if (spacing == Spacing.regularPoint || spacing == Spacing.regularInterval) {
+      assertThat(subsetBuilder.values).isNull();
+    } else {
+      assertThat(subsetBuilder.values).isNotNull();
+    }
+  }
+}


### PR DESCRIPTION
## Description of Changes

From support ticket BOM-253456. When requesting a variable with a regular interval time coordinate, the values returned [were NaN](https://threddsrc.ucar.edu/thredds/ncss/grid/grib/NCEP/NAM/CONUS_12km/NAM_CONUS_12km_20220609_1200.grib2?var=Total_precipitation_surface_3_Hour_Accumulation&latitude=52&longitude=-105&time_start=2022-06-09T12%3A00%3A00Z&time_end=2022-06-13T00%3A00%3A00Z&timeStride=&vertCoord=&accept=csv).

This happened because the time bounds were (0,3), (3,6), (6,9), ... and when subsetting a coverage axis, the coordinate midpoints were returned (1.5,4.5), (4.5,7.5), ..., resulting in no records being found at the midpoint coordinates. If we use `axis.getCoordEdge1` instead of using the`axis.getCoordMidpoint`, we have a similar problem for `regularPoints`, since the "edge" is in between the original points. 

- return original values instead of midpoints when subsetting a coverage coordinate axis
- add tests


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
