### PR TITLE
[5.x] Ncss dataset root with location bug

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -388,6 +388,23 @@ public class NcmlReader {
     return reader.readNcml(ncmlLocation, referencedDatasetUri, netcdfElem, cancelTask);
   }
 
+  /**
+   * Find the location attribute in a NcML string
+   *
+   * @param ncml the NcML as a string
+   * @return the resulting location attribute, or null if not found or if the NcML cannot be read
+   */
+  public static String getLocationFromNcml(String ncml) {
+    try {
+      final SAXBuilder builder = new SAXBuilder();
+      builder.setExpandEntities(false);
+      final org.jdom2.Document doc = builder.build(new StringReader(ncml));
+      return getLocation(doc.getRootElement());
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////
   private Namespace ncNS;
   private String location;

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Formatter;
@@ -326,11 +327,7 @@ public class NcmlReader {
     Element netcdfElem = doc.getRootElement();
 
     // the ncml probably refers to another dataset, but doesnt have to
-    String referencedDatasetUri = netcdfElem.getAttributeValue("location");
-    if (referencedDatasetUri == null)
-      referencedDatasetUri = netcdfElem.getAttributeValue("url");
-    if (referencedDatasetUri != null)
-      referencedDatasetUri = AliasTranslator.translateAlias(referencedDatasetUri);
+    final String referencedDatasetUri = getLocation(netcdfElem);
 
     NcmlReader reader = new NcmlReader();
     return reader.readNcml(ncmlLocation, referencedDatasetUri, netcdfElem, cancelTask);
@@ -384,13 +381,7 @@ public class NcmlReader {
 
     if (referencedDatasetUri == null) {
       // the ncml probably refers to another dataset, but doesnt have to
-      referencedDatasetUri = netcdfElem.getAttributeValue("location");
-      if (referencedDatasetUri == null) {
-        referencedDatasetUri = netcdfElem.getAttributeValue("url");
-      }
-    }
-    if (referencedDatasetUri != null) {
-      referencedDatasetUri = AliasTranslator.translateAlias(referencedDatasetUri);
+      referencedDatasetUri = getLocation(netcdfElem);
     }
 
     NcmlReader reader = new NcmlReader();
@@ -1453,13 +1444,7 @@ public class NcmlReader {
     // nested netcdf elements
     java.util.List<Element> ncList = aggElem.getChildren("netcdf", ncNS);
     for (Element netcdfElemNested : ncList) {
-      String location = netcdfElemNested.getAttributeValue("location");
-      if (location == null) {
-        location = netcdfElemNested.getAttributeValue("url");
-      }
-      if (location != null) {
-        location = AliasTranslator.translateAlias(location);
-      }
+      final String location = getLocation(netcdfElemNested);
 
       String id = netcdfElemNested.getAttributeValue("id");
       String ncoords = netcdfElemNested.getAttributeValue("ncoords");
@@ -1551,6 +1536,14 @@ public class NcmlReader {
     }
 
     return agg;
+  }
+
+  private static String getLocation(Element netCdfElem) {
+    String referencedDatasetUri = netCdfElem.getAttributeValue("location");
+    if (referencedDatasetUri == null) {
+      referencedDatasetUri = netCdfElem.getAttributeValue("url");
+    }
+    return referencedDatasetUri != null ? AliasTranslator.translateAlias(referencedDatasetUri) : null;
   }
 
   private class NcmlElementReader implements ucar.nc2.util.cache.FileFactory {


### PR DESCRIPTION
## Description of Changes

- Small refactor to reduce code duplication
- Add a helper function to the NcmlReader so that a dataset with a `location` attribute in its ncml can be found by the TDS FileServer (See also this [TDS github issue](https://github.com/Unidata/tds/issues/235))

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
