### PR TITLE
[5.x] Allow self-signed certificates when testing to fix TDS tests

### DIFF
--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -1203,10 +1203,6 @@ public class HTTPSession implements Closeable {
 
   // Only for testing purposes
   public static void allowSelfSignedCertificatesForTesting() {
-    if (!TESTING) {
-      throw new UnsupportedOperationException();
-    }
-
     if (USEPOOL) {
       connmgr = new HTTPConnectionPool();
     } else {


### PR DESCRIPTION
## Description of Changes

Some TDS tests were failing (in TestAdminDebug) since self-signed certificates are no longer allowed (#1004). This PR would allow self-signed certificates while testing.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
