### PR TITLE
[5.x] Fix horizontal subset for all longitudes

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -493,7 +493,7 @@ public class HorizCoordSys {
       maxLon = Math.max(maxLon, boundaryPoint.getLongitude());
     }
 
-    return new LatLonRect(LatLonPoint.create(minLat, minLon), LatLonPoint.create(maxLat, maxLon));
+    return new LatLonRect(LatLonPoint.create(minLat, minLon), maxLat - minLat, maxLon - minLon);
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/LatLonRect.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/LatLonRect.java
@@ -261,6 +261,9 @@ public class LatLonRect {
    * @return minimum longitude
    */
   public double getLonMin() {
+    if (allLongitude) {
+      return -180.0;
+    }
     return lowerLeft.getLongitude();
   }
 
@@ -270,6 +273,9 @@ public class LatLonRect {
    * @return maximum longitude
    */
   public double getLonMax() {
+    if (allLongitude) {
+      return 180.0;
+    }
     return lowerLeft.getLongitude() + width;
   }
 


### PR DESCRIPTION
## Description of Changes

This fixes the problem with the longitudes shown in the ncss horizontal extent being the same for east and west when the all longitudes are included. Not sure if this is the best way to fix this, and the mouse over still shows non-normalized values (for instance 179 to 539) I think because of the way the connected longitude/latitudes are calculated.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
