### PR TITLE
[5.x]: Extend CFSubConventionProvider to inspect subconvention list

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordSystemFactory.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordSystemFactory.java
@@ -233,7 +233,7 @@ public class CoordSystemFactory {
     if (coordSysFactory != null && ds.orgFile != null && coordSysFactory instanceof CF1Convention.Factory) {
       List<String> convs = breakupConventionNames(convName);
       if (convs.size() > 1) {
-        CoordSystemBuilderFactory potentialCoordSysFactory = findCfSubConvention(ds.orgFile);
+        CoordSystemBuilderFactory potentialCoordSysFactory = findCfSubConvention(ds.orgFile, convs);
         // only use the potentialCoordSysFactory if it is a CF sub-convention
         if (potentialCoordSysFactory != null && potentialCoordSysFactory instanceof CFSubConventionProvider) {
           coordSysFactory = potentialCoordSysFactory;
@@ -289,7 +289,7 @@ public class CoordSystemFactory {
 
   // same as findConventionByIsMine, but only checks CFSubConventionProvider instances of CoordSystemBuilderFactory
   @Nullable
-  private static CoordSystemBuilderFactory findCfSubConvention(NetcdfFile orgFile) {
+  private static CoordSystemBuilderFactory findCfSubConvention(NetcdfFile orgFile, List<String> convs) {
     // Look for Convention using isMine()
     for (Convention conv : conventionList) {
       CoordSystemBuilderFactory candidate = conv.factory;
@@ -299,9 +299,9 @@ public class CoordSystemFactory {
     }
 
     // Use service loader mechanism isMine()
-    for (CoordSystemBuilderFactory csb : ServiceLoader.load(CoordSystemBuilderFactory.class)) {
-      if (csb instanceof CFSubConventionProvider && csb.isMine(orgFile)) {
-        return csb;
+    for (CFSubConventionProvider cfSubCon : ServiceLoader.load(CFSubConventionProvider.class)) {
+      if (cfSubCon.isMine(orgFile) || cfSubCon.isMine(convs)) {
+        return cfSubCon;
       }
     }
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/spi/CFSubConventionProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/spi/CFSubConventionProvider.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2.internal.dataset.spi;
 
+import java.util.List;
 import ucar.nc2.dataset.spi.CoordSystemBuilderFactory;
 
 /**
@@ -20,4 +21,9 @@ import ucar.nc2.dataset.spi.CoordSystemBuilderFactory;
  * CoordSystemBuilder (which is what this interface is intended to facilitate).
  */
 public interface CFSubConventionProvider extends CoordSystemBuilderFactory {
+
+  // check a list of convention names to see if the CFSubConventionProvider is a provider
+  default boolean isMine(List<String> convList) {
+    return false;
+  }
 }

--- a/cdm/core/src/test/java/ucar/nc2/dataset/conv/CfSubConvForTestConvList.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/conv/CfSubConvForTestConvList.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1998-2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.dataset.conv;
+
+import java.util.List;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.internal.dataset.CoordSystemBuilder;
+import ucar.nc2.internal.dataset.spi.CFSubConventionProvider;
+
+/**
+ * An implementation of CoordSystemBuilder for testing CFSubConvention hooks.
+ *
+ * @see ucar.nc2.dataset.TestCfSubConventionProvider
+ */
+public class CfSubConvForTestConvList extends CoordSystemBuilder {
+  private static final String SUBCONVENTAION_NAME = "HECK-1.x";
+  // public for testing
+  public static String CONVENTAION_NAME_STARTS_WITH = "CF-1.X";
+  public static String CONVENTION_NAME = CONVENTAION_NAME_STARTS_WITH + "/" + SUBCONVENTAION_NAME;
+
+  private CfSubConvForTestConvList(NetcdfDataset.Builder<?> datasetBuilder) {
+    super(datasetBuilder);
+    this.conventionName = CONVENTION_NAME;
+  }
+
+  public static class Factory implements CFSubConventionProvider {
+    @Override
+    public boolean isMine(NetcdfFile ncfile) {
+      return false;
+    }
+
+    @Override
+    public boolean isMine(List<String> convs) {
+      boolean mine = false;
+      for (String conv : convs) {
+        if (conv.startsWith(SUBCONVENTAION_NAME)) {
+          mine = true;
+          break;
+        }
+      }
+      return mine;
+    }
+
+    @Override
+    public String getConventionName() {
+      return CONVENTION_NAME;
+    }
+
+    @Override
+    public CoordSystemBuilder open(NetcdfDataset.Builder datasetBuilder) {
+      return new CfSubConvForTestConvList(datasetBuilder);
+    }
+  }
+}

--- a/cdm/core/src/test/resources/META-INF/services/ucar.nc2.internal.dataset.spi.CFSubConventionProvider
+++ b/cdm/core/src/test/resources/META-INF/services/ucar.nc2.internal.dataset.spi.CFSubConventionProvider
@@ -1,1 +1,2 @@
 ucar.nc2.dataset.conv.CfSubConvForTest$Factory
+ucar.nc2.dataset.conv.CfSubConvForTestConvList$Factory


### PR DESCRIPTION
## Description of Changes

When determining if a CFSubConventionProvider "owns" a file, allow it the option to search a list of individual conventions. This is in addition to the normal `isMine` method. Bigger picture, we need to change the internal coordinate system builders to use `NetcdfDataset.Builder` instead of `NetcdfFile` when determining `isMine()`, but that will be a bit more work.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
