### PR TITLE
[5.x]: Enable providers of GridDataset

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dt/grid/internal/spi/GridDatasetProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/dt/grid/internal/spi/GridDatasetProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.dt.grid.internal.spi;
+
+import java.io.IOException;
+import java.util.Formatter;
+import java.util.Set;
+import javax.annotation.Nullable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDataset.Enhance;
+import ucar.nc2.dt.GridDataset;
+
+/**
+ * A special SPI to register GridDataset providers.
+ * <p>
+ * FOR INTERNAL USE ONLY
+ */
+public interface GridDatasetProvider {
+
+  default boolean isMine(NetcdfDataset ncd) {
+    return false;
+  }
+
+  default boolean isMine(String location, Set<Enhance> enhanceMode) {
+    return false;
+  }
+
+  @Nullable
+  default GridDataset open(String location) throws IOException {
+    return open(location, NetcdfDataset.getDefaultEnhanceMode());
+  }
+
+  @Nullable
+  GridDataset open(String location, Set<NetcdfDataset.Enhance> enhanceMode) throws IOException;
+
+  @Nullable
+  default GridDataset open(NetcdfDataset ncd) throws IOException {
+    return open(ncd, null);
+  }
+
+  @Nullable
+  GridDataset open(NetcdfDataset ncd, Formatter parseInfo) throws IOException;
+}

--- a/cdm/core/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2022 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -7,6 +7,18 @@ package ucar.nc2.ft.fmrc;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Formatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.ServiceLoader;
+import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
@@ -27,8 +39,6 @@ import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateFormatter;
 import ucar.nc2.units.DateUnit;
 import ucar.nc2.constants._Coordinate;
-import java.util.*;
-import java.io.*;
 import org.jdom2.output.XMLOutputter;
 import org.jdom2.output.Format;
 import org.jdom2.Document;
@@ -90,7 +100,7 @@ public class GridDatasetInv {
 
     @Override
     public GridDatasetInv call() throws Exception {
-      GridDataset gds = null;
+      ucar.nc2.dt.GridDataset gds = null;
       GridDatasetInv inv = null;
       if (persistedCache != null) {
         inv = persistedCache.get(mfile);
@@ -99,7 +109,7 @@ public class GridDatasetInv {
       if (inv == null) {
         try {
           if (ncml == null) {
-            gds = GridDataset.open(mfile.getPath());
+            gds = GridDataset.openIfce(mfile.getPath());
           } else {
             NetcdfFile nc = NetcdfDataset.acquireFile(DatasetUrl.create(null, mfile.getPath()), null);
             NetcdfDataset ncd = NcMLReader.mergeNcML(nc, ncml); // create new dataset
@@ -134,7 +144,7 @@ public class GridDatasetInv {
 
   private GridDatasetInv() {}
 
-  public GridDatasetInv(ucar.nc2.dt.grid.GridDataset gds, CalendarDate runDate) {
+  public GridDatasetInv(ucar.nc2.dt.GridDataset gds, CalendarDate runDate) {
     this.location = gds.getLocation();
     this.runDate = runDate;
 


### PR DESCRIPTION
## Description of Changes

Provide a hook for `GridDataset` providers, which allow datasets to be opened and returned as implementations of `ucar.nc2.dt.GridDataset` in addition to the current concrete implementation `ucar.nc2.dt.grid.GridDataset`. These changes should not break any existing code, and will allow ugrid datasets to be collected as FMRCs by the TDS.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
