### PR TITLE
[5.x] Update MRMS GRIB table

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/MrmsLocalTables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/MrmsLocalTables.java
@@ -35,78 +35,78 @@ public class MrmsLocalTables extends LocalTables {
    */
   private void init() {
     add(209, 2, 0, "NLDN_CG_001min_AvgDensity", "CG Average Lightning Density 1-min - NLDN", "flashes/km^2/min", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 2, 1, "NLDN_CG_005min_AvgDensity", "CG Average Lightning Density 5-min - NLDN", "flashes/km^2/min", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 2, 2, "NLDN_CG_015min_AvgDensity", "CG Average Lightning Density 15-min - NLDN", "flashes/km^2/min", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 2, 3, "NLDN_CG_030min_AvgDensity", "CG Average Lightning Density 30-min - NLDN", "flashes/km^2/min", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 2, 4, "LightningProbabilityNext30min", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v11.5.5
-    add(209, 2, 5, "LightningProbabilityNext30minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.0
-    add(209, 2, 6, "LightningProbabilityNext60minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.0
-    add(209, 2, 7, "LightningJumpGrid", "Rapid lightning increases and decreases ", "dimensionless", -99903, -99900); // v12.0
+    add(209, 2, 5, "LightningProbabilityNext30minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.2
+    add(209, 2, 6, "LightningProbabilityNext60minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.2
+    add(209, 2, 7, "LightningJumpGrid", "Rapid lightning increases and decreases ", "dimensionless", -99903, -99900); // v12.2
     add(209, 2, 8, "LightningJumpGrid_Max_005min", "Rapid lightning increases and decreases over 5-minutes ",
-        "dimensionless", -99903, -99900); // v12.0
-    add(209, 3, 0, "MergedAzShear0to2kmAGL", "Azimuth Shear 0-2km AGL", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 1, "MergedAzShear3to6kmAGL", "Azimuth Shear 3-6km AGL", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 2, "RotationTrack30min", "Rotation Track 0-2km AGL 30-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 3, "RotationTrack60min", "Rotation Track 0-2km AGL 60-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 4, "RotationTrack120min", "Rotation Track 0-2km AGL 120-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 5, "RotationTrack240min", "Rotation Track 0-2km AGL 240-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 6, "RotationTrack360min", "Rotation Track 0-2km AGL 360-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 7, "RotationTrack1440min", "Rotation Track 0-2km AGL 1440-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 14, "RotationTrackML30min", "Rotation Track 3-6km AGL 30-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 15, "RotationTrackML60min", "Rotation Track 3-6km AGL 60-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 16, "RotationTrackML120min", "Rotation Track 3-6km AGL 120-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 17, "RotationTrackML240min", "Rotation Track 3-6km AGL 240-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 18, "RotationTrackML360min", "Rotation Track 3-6km AGL 360-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 19, "RotationTrackML1440min", "Rotation Track 3-6km AGL 1440-min", "0.001/s", 0, 0); // v12.0
-    add(209, 3, 26, "SHI", "Severe Hail Index", "dimensionless", -3, -1); // v12.0
-    add(209, 3, 27, "POSH", "Prob of Severe Hail", "%", -3, -1); // v12.0
-    add(209, 3, 28, "MESH", "Maximum Estimated Size of Hail (MESH)", "mm", -3, -1); // v12.0
-    add(209, 3, 29, "MESHMax30min", "MESH Hail Swath 30-min", "mm", -3, -1); // v12.0
-    add(209, 3, 30, "MESHMax60min", "MESH Hail Swath 60-min", "mm", -3, -1); // v12.0
-    add(209, 3, 31, "MESHMax120min", "MESH Hail Swath 120-min", "mm", -3, -1); // v12.0
-    add(209, 3, 32, "MESHMax240min", "MESH Hail Swath 240-min", "mm", -3, -1); // v12.0
-    add(209, 3, 33, "MESHMax360min", "MESH Hail Swath 360-min", "mm", -3, -1); // v12.0
-    add(209, 3, 34, "MESHMax1440min", "MESH Hail Swath 1440-min", "mm", -3, -1); // v12.0
-    add(209, 3, 37, "VIL_Max_120min", "VIL Swath 120-min", "kg/m^2", -3, -1); // v12.0
-    add(209, 3, 40, "VIL_Max_1440min", "VIL Swath 1440-min", "kg/m^2", -3, -1); // v12.0
-    add(209, 3, 41, "VIL", "Vertically Integrated Liquid", "kg/m^2", -3, -1); // v12.0
-    add(209, 3, 42, "VIL_Density", "Vertically Integrated Liquid Density", "g/m^3", -3, -1); // v12.0
-    add(209, 3, 43, "VII", "Vertically Integrated Ice", "kg/m^2", -3, -1); // v12.0
-    add(209, 3, 44, "EchoTop_18", "Echo Top - 18 dBZ MSL", "km", -3, -1); // v12.0
-    add(209, 3, 45, "EchoTop_30", "Echo Top - 30 dBZ MSL", "km", -3, -1); // v12.0
-    add(209, 3, 46, "EchoTop_50", "Echo Top - 50 dBZ MSL", "km", -3, -1); // v12.0
-    add(209, 3, 47, "EchoTop_60", "Echo Top - 60 dBZ MSL", "km", -3, -1); // v12.0
-    add(209, 3, 48, "H50AboveM20C", "Thickness [50 dBZ top - (-20C)]", "km", -999, -99); // v12.0
-    add(209, 3, 49, "H50Above0C", "Thickness [50 dBZ top - 0C]", "km", -999, -99); // v12.0
-    add(209, 3, 50, "H60AboveM20C", "Thickness [60 dBZ top - (-20C)]", "km", -999, -99); // v12.0
-    add(209, 3, 51, "H60Above0C", "Thickness [60 dBZ top - 0C]", "km", -999, -99); // v12.0
-    add(209, 3, 52, "Reflectivity_0C", "Isothermal Reflectivity at 0C", "dBZ", -999, -99); // v12.0
-    add(209, 3, 53, "Reflectivity_-5C", "Isothermal Reflectivity at -5C", "dBZ", -999, -99); // v12.0
-    add(209, 3, 54, "Reflectivity_-10C", "Isothermal Reflectivity at -10C", "dBZ", -999, -99); // v12.0
-    add(209, 3, 55, "Reflectivity_-15C", "Isothermal Reflectivity at -15C", "dBZ", -999, -99); // v12.0
-    add(209, 3, 56, "Reflectivity_-20C", "Isothermal Reflectivity at -20C", "dBZ", -999, -99); // v12.0
+        "dimensionless", -99903, -99900); // v12.2
+    add(209, 3, 0, "MergedAzShear0to2kmAGL", "Azimuth Shear 0-2km AGL", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 1, "MergedAzShear3to6kmAGL", "Azimuth Shear 3-6km AGL", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 2, "RotationTrack30min", "Rotation Track 0-2km AGL 30-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 3, "RotationTrack60min", "Rotation Track 0-2km AGL 60-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 4, "RotationTrack120min", "Rotation Track 0-2km AGL 120-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 5, "RotationTrack240min", "Rotation Track 0-2km AGL 240-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 6, "RotationTrack360min", "Rotation Track 0-2km AGL 360-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 7, "RotationTrack1440min", "Rotation Track 0-2km AGL 1440-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 14, "RotationTrackML30min", "Rotation Track 3-6km AGL 30-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 15, "RotationTrackML60min", "Rotation Track 3-6km AGL 60-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 16, "RotationTrackML120min", "Rotation Track 3-6km AGL 120-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 17, "RotationTrackML240min", "Rotation Track 3-6km AGL 240-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 18, "RotationTrackML360min", "Rotation Track 3-6km AGL 360-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 19, "RotationTrackML1440min", "Rotation Track 3-6km AGL 1440-min", "0.001/s", 0, 0); // v12.2
+    add(209, 3, 26, "SHI", "Severe Hail Index", "dimensionless", -3, -1); // v12.2
+    add(209, 3, 27, "POSH", "Prob of Severe Hail", "%", -3, -1); // v12.2
+    add(209, 3, 28, "MESH", "Maximum Estimated Size of Hail (MESH)", "mm", -3, -1); // v12.2
+    add(209, 3, 29, "MESHMax30min", "MESH Hail Swath 30-min", "mm", -3, -1); // v12.2
+    add(209, 3, 30, "MESHMax60min", "MESH Hail Swath 60-min", "mm", -3, -1); // v12.2
+    add(209, 3, 31, "MESHMax120min", "MESH Hail Swath 120-min", "mm", -3, -1); // v12.2
+    add(209, 3, 32, "MESHMax240min", "MESH Hail Swath 240-min", "mm", -3, -1); // v12.2
+    add(209, 3, 33, "MESHMax360min", "MESH Hail Swath 360-min", "mm", -3, -1); // v12.2
+    add(209, 3, 34, "MESHMax1440min", "MESH Hail Swath 1440-min", "mm", -3, -1); // v12.2
+    add(209, 3, 37, "VIL_Max_120min", "VIL Swath 120-min", "kg/m^2", -3, -1); // v12.2
+    add(209, 3, 40, "VIL_Max_1440min", "VIL Swath 1440-min", "kg/m^2", -3, -1); // v12.2
+    add(209, 3, 41, "VIL", "Vertically Integrated Liquid", "kg/m^2", -3, -1); // v12.2
+    add(209, 3, 42, "VIL_Density", "Vertically Integrated Liquid Density", "g/m^3", -3, -1); // v12.2
+    add(209, 3, 43, "VII", "Vertically Integrated Ice", "kg/m^2", -3, -1); // v12.2
+    add(209, 3, 44, "EchoTop_18", "Echo Top - 18 dBZ MSL", "km", -3, -1); // v12.2
+    add(209, 3, 45, "EchoTop_30", "Echo Top - 30 dBZ MSL", "km", -3, -1); // v12.2
+    add(209, 3, 46, "EchoTop_50", "Echo Top - 50 dBZ MSL", "km", -3, -1); // v12.2
+    add(209, 3, 47, "EchoTop_60", "Echo Top - 60 dBZ MSL", "km", -3, -1); // v12.2
+    add(209, 3, 48, "H50AboveM20C", "Thickness [50 dBZ top - (-20C)]", "km", -999, -99); // v12.2
+    add(209, 3, 49, "H50Above0C", "Thickness [50 dBZ top - 0C]", "km", -999, -99); // v12.2
+    add(209, 3, 50, "H60AboveM20C", "Thickness [60 dBZ top - (-20C)]", "km", -999, -99); // v12.2
+    add(209, 3, 51, "H60Above0C", "Thickness [60 dBZ top - 0C]", "km", -999, -99); // v12.2
+    add(209, 3, 52, "Reflectivity_0C", "Isothermal Reflectivity at 0C", "dBZ", -999, -99); // v12.2
+    add(209, 3, 53, "Reflectivity_-5C", "Isothermal Reflectivity at -5C", "dBZ", -999, -99); // v12.2
+    add(209, 3, 54, "Reflectivity_-10C", "Isothermal Reflectivity at -10C", "dBZ", -999, -99); // v12.2
+    add(209, 3, 55, "Reflectivity_-15C", "Isothermal Reflectivity at -15C", "dBZ", -999, -99); // v12.2
+    add(209, 3, 56, "Reflectivity_-20C", "Isothermal Reflectivity at -20C", "dBZ", -999, -99); // v12.2
     add(209, 3, 57, "ReflectivityAtLowestAltitude5km",
-        "ReflectivityAtLowestAltitude resampled from 1 to 5km resolution", "dBZ", -999, -99); // v12.0
+        "ReflectivityAtLowestAltitude resampled from 1 to 5km resolution", "dBZ", -999, -99); // v12.2
     add(209, 3, 58, "MergedReflectivityAtLowestAltitude", "Non Quality Controlled Reflectivity At Lowest Altitude",
-        "dBZ", -999, -99); // v12.0
+        "dBZ", -999, -99); // v12.2
     add(209, 4, 0, "IRband4", "Infrared (E/W blend)", "K", -999, -99); // v11.5.5
     add(209, 4, 1, "Visible", "Visible (E/W blend)", "dimensionless", -3, -1); // v11.5.5
     add(209, 4, 2, "WaterVapor", "Water Vapor (E/W blend)", "K", -999, -99); // v11.5.5
     add(209, 4, 3, "CloudCover", "Cloud Cover", "K", -999, -99); // v11.5.5
     add(209, 6, 0, "PrecipFlag", "Surface Precipitation Type (Convective, Stratiform, Tropical, Hail, Snow)",
-        "dimensionless", -3, -1); // v12.0
-    add(209, 6, 1, "PrecipRate", "Radar Precipitation Rate", "mm/hr", -3, -1); // v12.0
-    add(209, 6, 2, "RadarOnly_QPE_01H", "Radar precipitation accumulation 1-hour", "mm", -3, -1); // v12.0
-    add(209, 6, 3, "RadarOnly_QPE_03H", "Radar precipitation accumulation 3-hour", "mm", -3, -1); // v12.0
-    add(209, 6, 4, "RadarOnly_QPE_06H", "Radar precipitation accumulation 6-hour", "mm", -3, -1); // v12.0
-    add(209, 6, 5, "RadarOnly_QPE_12H", "Radar precipitation accumulation 12-hour", "mm", -3, -1); // v12.0
-    add(209, 6, 6, "RadarOnly_QPE_24H", "Radar precipitation accumulation 24-hour", "mm", -3, -1); // v12.0
-    add(209, 6, 7, "RadarOnly_QPE_48H", "Radar precipitation accumulation 48-hour", "mm", -3, -1); // v12.0
-    add(209, 6, 8, "RadarOnly_QPE_72H", "Radar precipitation accumulation 72-hour", "mm", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
+    add(209, 6, 1, "PrecipRate", "Radar Precipitation Rate", "mm/hr", -3, -1); // v12.2
+    add(209, 6, 2, "RadarOnly_QPE_01H", "Radar precipitation accumulation 1-hour", "mm", -3, -1); // v12.2
+    add(209, 6, 3, "RadarOnly_QPE_03H", "Radar precipitation accumulation 3-hour", "mm", -3, -1); // v12.2
+    add(209, 6, 4, "RadarOnly_QPE_06H", "Radar precipitation accumulation 6-hour", "mm", -3, -1); // v12.2
+    add(209, 6, 5, "RadarOnly_QPE_12H", "Radar precipitation accumulation 12-hour", "mm", -3, -1); // v12.2
+    add(209, 6, 6, "RadarOnly_QPE_24H", "Radar precipitation accumulation 24-hour", "mm", -3, -1); // v12.2
+    add(209, 6, 7, "RadarOnly_QPE_48H", "Radar precipitation accumulation 48-hour", "mm", -3, -1); // v12.2
+    add(209, 6, 8, "RadarOnly_QPE_72H", "Radar precipitation accumulation 72-hour", "mm", -3, -1); // v12.2
     add(209, 6, 9, "GaugeCorrQPE01H", "Local gauge bias corrected radar precipitation accumulation 1-hour", "mm", -3,
         -1); // v11.5.5
     add(209, 6, 10, "GaugeCorrQPE03H", "Local gauge bias corrected radar precipitation accumulation 3-hour", "mm", -3,
@@ -135,126 +135,127 @@ public class MrmsLocalTables extends LocalTables {
     add(209, 6, 27, "MountainMapperQPE24H", "Mountain Mapper precipitation accumulation 24-hour", "mm", -3, -1); // v11.5.5
     add(209, 6, 28, "MountainMapperQPE48H", "Mountain Mapper precipitation accumulation 48-hour", "mm", -3, -1); // v11.5.5
     add(209, 6, 29, "MountainMapperQPE72H", "Mountain Mapper precipitation accumulation 72-hour", "mm", -3, -1); // v11.5.5
-    add(209, 6, 30, "MultiSensor_QPE_01H_Pass1", "Multi-sensor accumulation 1-hour (1-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 31, "MultiSensor_QPE_03H_Pass1", "Multi-sensor accumulation 3-hour (1-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 32, "MultiSensor_QPE_06H_Pass1", "Multi-sensor accumulation 6-hour (1-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 33, "MultiSensor_QPE_12H_Pass1", "Multi-sensor accumulation 12-hour (1-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 34, "MultiSensor_QPE_24H_Pass1", "Multi-sensor accumulation 24-hour (1-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 35, "MultiSensor_QPE_48H_Pass1", "Multi-sensor accumulation 48-hour (1-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 36, "MultiSensor_QPE_72H_Pass1", "Multi-sensor accumulation 72-hour (1-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 37, "MultiSensor_QPE_01H_Pass2", "Multi-sensor accumulation 1-hour (2-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 38, "MultiSensor_QPE_03H_Pass2", "Multi-sensor accumulation 3-hour (2-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 39, "MultiSensor_QPE_06H_Pass2", "Multi-sensor accumulation 6-hour (2-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 40, "MultiSensor_QPE_12H_Pass2", "Multi-sensor accumulation 12-hour (2-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 41, "MultiSensor_QPE_24H_Pass2", "Multi-sensor accumulation 24-hour (2-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 42, "MultiSensor_QPE_48H_Pass2", "Multi-sensor accumulation 48-hour (2-hour latency)", "mm", -3, -1); // v12.0
-    add(209, 6, 43, "MultiSensor_QPE_72H_Pass2", "Multi-sensor accumulation 72-hour (2-hour latency)", "mm", -3, -1); // v12.0
+    add(209, 6, 30, "MultiSensor_QPE_01H_Pass1", "Multi-sensor accumulation 1-hour (1-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 31, "MultiSensor_QPE_03H_Pass1", "Multi-sensor accumulation 3-hour (1-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 32, "MultiSensor_QPE_06H_Pass1", "Multi-sensor accumulation 6-hour (1-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 33, "MultiSensor_QPE_12H_Pass1", "Multi-sensor accumulation 12-hour (1-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 34, "MultiSensor_QPE_24H_Pass1", "Multi-sensor accumulation 24-hour (1-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 35, "MultiSensor_QPE_48H_Pass1", "Multi-sensor accumulation 48-hour (1-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 36, "MultiSensor_QPE_72H_Pass1", "Multi-sensor accumulation 72-hour (1-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 37, "MultiSensor_QPE_01H_Pass2", "Multi-sensor accumulation 1-hour (2-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 38, "MultiSensor_QPE_03H_Pass2", "Multi-sensor accumulation 3-hour (2-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 39, "MultiSensor_QPE_06H_Pass2", "Multi-sensor accumulation 6-hour (2-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 40, "MultiSensor_QPE_12H_Pass2", "Multi-sensor accumulation 12-hour (2-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 41, "MultiSensor_QPE_24H_Pass2", "Multi-sensor accumulation 24-hour (2-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 42, "MultiSensor_QPE_48H_Pass2", "Multi-sensor accumulation 48-hour (2-hour latency)", "mm", -3, -1); // v12.2
+    add(209, 6, 43, "MultiSensor_QPE_72H_Pass2", "Multi-sensor accumulation 72-hour (2-hour latency)", "mm", -3, -1); // v12.2
     add(209, 6, 44, "SyntheticPrecipRateID", "Method IDs for blended single and dual-pol derived precip rates ",
-        "dimensionless", -3, -1); // v12.0
-    add(209, 6, 45, "RadarOnly_QPE_15M", "Radar precipitation accumulation 15-minute", "mm", -3, -1); // v12.0
-    add(209, 7, 0, "Model_SurfaceTemp", "Model Surface temperature", "degree_Celsius", -999, -99); // v12.0
-    add(209, 7, 1, "Model_WetBulbTemp", "Model Surface wet bulb temperature", "degree_Celsius", -999, -99); // v12.0
-    add(209, 7, 2, "WarmRainProbability", "Probability of warm rain", "%", -3, -1); // v12.0
-    add(209, 7, 3, "Model_0degC_Height", "Model Freezing Level Height MSL", "m", -3, -1); // v12.0
-    add(209, 7, 4, "BrightBandTopHeight", "Brightband Top Height AGL", "m", -3, -1); // v12.0
-    add(209, 7, 5, "BrightBandBottomHeight", "Brightband Bottom Height AGL", "m", -3, -1); // v12.0
-    add(209, 8, 0, "RadarQualityIndex", "Radar Quality Index", "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
+    add(209, 6, 45, "RadarOnly_QPE_15M", "Radar precipitation accumulation 15-minute", "mm", -3, -1); // v12.2
+    add(209, 6, 46, "RadarOnly_QPE_Since12Z", "Radar precipitation accumulation since 12Z", "mm", -3, -1); // v12.2
+    add(209, 7, 0, "Model_SurfaceTemp", "Model Surface temperature", "degree_Celsius", -999, -99); // v12.2
+    add(209, 7, 1, "Model_WetBulbTemp", "Model Surface wet bulb temperature", "degree_Celsius", -999, -99); // v12.2
+    add(209, 7, 2, "WarmRainProbability", "Probability of warm rain", "%", -3, -1); // v12.2
+    add(209, 7, 3, "Model_0degC_Height", "Model Freezing Level Height MSL", "m", -3, -1); // v12.2
+    add(209, 7, 4, "BrightBandTopHeight", "Brightband Top Height AGL", "m", -3, -1); // v12.2
+    add(209, 7, 5, "BrightBandBottomHeight", "Brightband Bottom Height AGL", "m", -3, -1); // v12.2
+    add(209, 8, 0, "RadarQualityIndex", "Radar Quality Index", "dimensionless", -3, -1); // v12.2
     add(209, 8, 1, "GaugeInflIndex_01H_Pass1", "Gauge Influence Index for 1-hour QPE (1-hour latency)", "dimensionless",
-        -3, -1); // v12.0
+        -3, -1); // v12.2
     add(209, 8, 2, "GaugeInflIndex_03H_Pass1", "Gauge Influence Index for 3-hour QPE (1-hour latency)", "dimensionless",
-        -3, -1); // v12.0
+        -3, -1); // v12.2
     add(209, 8, 3, "GaugeInflIndex_06H_Pass1", "Gauge Influence Index for 6-hour QPE (1-hour latency)", "dimensionless",
-        -3, -1); // v12.0
+        -3, -1); // v12.2
     add(209, 8, 4, "GaugeInflIndex_12H_Pass1", "Gauge Influence Index for 12-hour QPE (1-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 5, "GaugeInflIndex_24H_Pass1", "Gauge Influence Index for 24-hour QPE (1-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 6, "GaugeInflIndex_48H_Pass1", "Gauge Influence Index for 48-hour QPE (1-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 7, "GaugeInflIndex_72H_Pass1", "Gauge Influence Index for 72-hour QPE (1-hour latency)",
-        "dimensionless", -3, -1); // v12.0
-    add(209, 8, 8, "SeamlessHSR", "Seamless Hybrid Scan Reflectivity with VPR correction", "dBZ", -999, -99); // v12.0
-    add(209, 8, 9, "SeamlessHSRHeight", "Height of Seamless Hybrid Scan Reflectivity AGL", "km", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
+    add(209, 8, 8, "SeamlessHSR", "Seamless Hybrid Scan Reflectivity with VPR correction", "dBZ", -999, -99); // v12.2
+    add(209, 8, 9, "SeamlessHSRHeight", "Height of Seamless Hybrid Scan Reflectivity AGL", "km", -3, -1); // v12.2
     add(209, 8, 10, "RadarAccumulationQualityIndex_01H", "Radar 1-hour QPE Accumulation Quality", "dimensionless", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 8, 11, "RadarAccumulationQualityIndex_03H", "Radar 3-hour QPE Accumulation Quality", "dimensionless", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 8, 12, "RadarAccumulationQualityIndex_06H", "Radar 6-hour QPE Accumulation Quality", "dimensionless", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 8, 13, "RadarAccumulationQualityIndex_12H", "Radar 12-hour QPE Accumulation Quality", "dimensionless", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 8, 14, "RadarAccumulationQualityIndex_24H", "Radar 24-hour QPE Accumulation Quality", "dimensionless", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 8, 15, "RadarAccumulationQualityIndex_48H", "Radar 48-hour QPE Accumulation Quality", "dimensionless", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 8, 16, "RadarAccumulationQualityIndex_72H", "Radar 72-hour QPE Accumulation Quality", "dimensionless", -3,
-        -1); // v12.0
+        -1); // v12.2
     add(209, 8, 17, "GaugeInflIndex_01H_Pass2", "Gauge Influence Index for 1-hour QPE (2-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 18, "GaugeInflIndex_03H_Pass2", "Gauge Influence Index for 3-hour QPE (2-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 19, "GaugeInflIndex_06H_Pass2", "Gauge Influence Index for 6-hour QPE (2-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 20, "GaugeInflIndex_12H_Pass2", "Gauge Influence Index for 12-hour QPE (2-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 21, "GaugeInflIndex_24H_Pass2", "Gauge Influence Index for 24-hour QPE (2-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 22, "GaugeInflIndex_48H_Pass2", "Gauge Influence Index for 48-hour QPE (2-hour latency)",
-        "dimensionless", -3, -1); // v12.0
+        "dimensionless", -3, -1); // v12.2
     add(209, 8, 23, "GaugeInflIndex_72H_Pass2", "Gauge Influence Index for 72-hour QPE (2-hour latency)",
-        "dimensionless", -3, -1); // v12.0
-    add(209, 9, 0, "MergedReflectivityQC", "3D Reflectivity Mosaic - 33 CAPPIS (500-19000m)", "dBZ", -999, -99); // v12.0
+        "dimensionless", -3, -1); // v12.2
+    add(209, 9, 0, "MergedReflectivityQC", "3D Reflectivity Mosaic - 33 CAPPIS (500-19000m)", "dBZ", -999, -99); // v12.2
     add(209, 9, 1, "ConusPlusMergedReflectivityQC", "All Radar 3D Reflectivity Mosaic - 33 CAPPIS (500-19000m)", "dBZ",
         -999, -99); // v11.5.5
-    add(209, 9, 3, "MergedRhoHV", "3D RhoHV Mosaic - 33 CAPPIS (500-19000m)", "dimensionless", -999, -99); // v12.0
-    add(209, 9, 4, "MergedZdr", "3D Zdr Mosaic - 33 CAPPIS (500-19000m)", "dB", -999, -99); // v12.0
+    add(209, 9, 3, "MergedRhoHV", "3D RhoHV Mosaic - 33 CAPPIS (500-19000m)", "dimensionless", -999, -99); // v12.2
+    add(209, 9, 4, "MergedZdr", "3D Zdr Mosaic - 33 CAPPIS (500-19000m)", "dB", -999, -99); // v12.2
     add(209, 10, 0, "MergedReflectivityQCComposite5km",
-        "Composite Reflectivity Mosaic (optimal method) resampled from 1 to 5km", "dBZ", -999, -99); // v12.0
+        "Composite Reflectivity Mosaic (optimal method) resampled from 1 to 5km", "dBZ", -999, -99); // v12.2
     add(209, 10, 1, "HeightCompositeReflectivity", "Height of Composite Reflectivity Mosaic (optimal method) MSL", "m",
-        -3, -1); // v12.0
+        -3, -1); // v12.2
     add(209, 10, 2, "LowLevelCompositeReflectivity", "Low-Level Composite Reflectivity Mosaic (0-4km)", "dBZ", -999,
-        -99); // v12.0
+        -99); // v12.2
     add(209, 10, 3, "HeightLowLevelCompositeReflectivity",
-        "Height of Low-Level Composite Reflectivity Mosaic (0-4km) MSL", "m", -3, -1); // v12.0
+        "Height of Low-Level Composite Reflectivity Mosaic (0-4km) MSL", "m", -3, -1); // v12.2
     add(209, 10, 4, "LayerCompositeReflectivity_Low", "Layer Composite Reflectivity Mosaic 0-24kft (low altitude)",
-        "dBZ", -999, -99); // v12.0
+        "dBZ", -999, -99); // v12.2
     add(209, 10, 5, "LayerCompositeReflectivity_High",
-        "Layer Composite Reflectivity Mosaic 24-60 kft (highest altitude)", "dBZ", -999, -99); // v12.0
+        "Layer Composite Reflectivity Mosaic 24-60 kft (highest altitude)", "dBZ", -999, -99); // v12.2
     add(209, 10, 6, "LayerCompositeReflectivity_Super",
-        "Layer Composite Reflectivity Mosaic 33-60 kft (super high altitude)", "dBZ", -999, -99); // v12.0
-    add(209, 10, 7, "CREF_1HR_MAX", "Composite Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.0
+        "Layer Composite Reflectivity Mosaic 33-60 kft (super high altitude)", "dBZ", -999, -99); // v12.2
+    add(209, 10, 7, "CREF_1HR_MAX", "Composite Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.2
     add(209, 10, 8, "ReflectivityMaxAboveM10C", "Maximum Reflectivity at -10 deg C height and above", "dBZ", -999, -99); // v10.0.1
     add(209, 10, 9, "LayerCompositeReflectivity_ANC", "Layer Composite Reflectivity Mosaic (2-4.5km) (for ANC)", "dBZ",
-        -999, -99); // v12.0
-    add(209, 10, 10, "BREF_1HR_MAX", "Base Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.0
-    add(209, 11, 0, "MergedBaseReflectivityQC", "Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.0
-    add(209, 11, 1, "MergedReflectivityComposite", "Raw Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.0
-    add(209, 11, 2, "MergedReflectivityQComposite", "Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.0
-    add(209, 11, 3, "MergedBaseReflectivity", "Raw Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.0
+        -999, -99); // v12.2
+    add(209, 10, 10, "BREF_1HR_MAX", "Base Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.2
+    add(209, 11, 0, "MergedBaseReflectivityQC", "Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.2
+    add(209, 11, 1, "MergedReflectivityComposite", "Raw Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.2
+    add(209, 11, 2, "MergedReflectivityQComposite", "Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.2
+    add(209, 11, 3, "MergedBaseReflectivity", "Raw Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.2
     add(209, 11, 4, "Merged_LVL3_BaseDHC", "Level III Base HCA Mosaic (nearest neighbor)", "dimensionless", -3, -1); // v11.5.5
-    add(209, 12, 0, "FLASH_CREST_MAXUNITSTREAMFLOW", "FLASH QPE-CREST Unit Streamflow", "m^3/s/km^2", -999, -9999); // v12.0_unidata_reported
-    add(209, 12, 1, "FLASH_CREST_MAXSTREAMFLOW", "FLASH QPE-CREST Streamflow", "m^3/s", -999, -9999); // v12.0_unidata_reported
-    add(209, 12, 2, "FLASH_CREST_MAXSOILSAT", "FLASH QPE-CREST Soil Saturation", "%", -999, -9999); // v12.0_unidata_reported
-    add(209, 12, 4, "FLASH_SAC_MAXUNITSTREAMFLOW", "FLASH QPE-SAC Unit Streamflow", "m^3/s/km^2", -999, -9999); // v12.0_unidata_reported
-    add(209, 12, 5, "FLASH_SAC_MAXSTREAMFLOW", "FLASH QPE-SAC Streamflow", "m^3/s", -999, -9999); // v12.0_unidata_reported
-    add(209, 12, 6, "FLASH_SAC_MAXSOILSAT", "FLASH QPE-SAC Soil Saturation", "%", -999, -9999); // v12.0_unidata_reported
-    add(209, 12, 14, "FLASH_QPE_ARI30M", "FLASH QPE Average Recurrence Interval 30-min", "year", -999, -999); // v12.0
-    add(209, 12, 15, "FLASH_QPE_ARI01H", "FLASH QPE Average Recurrence Interval 01H", "year", -999, -999); // v12.0
-    add(209, 12, 16, "FLASH_QPE_ARI03H", "FLASH QPE Average Recurrence Interval 03H", "year", -999, -999); // v12.0
-    add(209, 12, 17, "FLASH_QPE_ARI06H", "FLASH QPE Average Recurrence Interval 06H", "year", -999, -999); // v12.0
-    add(209, 12, 18, "FLASH_QPE_ARI12H", "FLASH QPE Average Recurrence Interval 12H", "year", -999, -999); // v12.0
-    add(209, 12, 19, "FLASH_QPE_ARI24H", "FLASH QPE Average Recurrence Interval 24H", "year", -999, -999); // v12.0
-    add(209, 12, 20, "FLASH_QPE_ARIMAX", "FLASH QPE Average Recurrence Interval Maximum", "year", -999, -999); // v12.0
-    add(209, 12, 26, "FLASH_QPE_FFG01H", "FLASH QPE-to-FFG Ratio 01H", "dimensionless", -999, -999); // v12.0
-    add(209, 12, 27, "FLASH_QPE_FFG03H", "FLASH QPE-to-FFG Ratio 03H", "dimensionless", -999, -999); // v12.0
-    add(209, 12, 28, "FLASH_QPE_FFG06H", "FLASH QPE-to-FFG Ratio 06H", "dimensionless", -999, -999); // v12.0
-    add(209, 12, 29, "FLASH_QPE_FFGMAX", "FLASH QPE-to-FFG Ratio Maximum", "dimensionless", -999, -999); // v12.0
-    add(209, 12, 39, "FLASH_HP_MAXUNITSTREAMFLOW", "FLASH QPE-Hydrophobic Unit Streamflow", "m^3/s/km^2", -999, -9999); // v12.0_unidata_reported
-    add(209, 12, 40, "FLASH_HP_MAXSTREAMFLOW", "FLASH QPE-Hydrophobic Streamflow", "m^3/s", -999, -9999); // v12.0_unidata_reported
-    add(209, 13, 0, "ANC_ConvectiveLikelihood", "Likelihood of convection over the next 01H", "dimensionless", 0, 0); // v12.0
-    add(209, 13, 1, "ANC_FinalForecast", "01H reflectivity forecast", "dBZ", 0, 0); // v12.0
-    add(209, 14, 0, "LVL3_HREET", "Level III High Resolution Enhanced Echo Top mosaic", "kft", -3, -1); // v12.0
-    add(209, 14, 1, "LVL3_HighResVIL", "Level III High Resolution VIL mosaic", "kg/m^2", -3, -1); // v12.0
+    add(209, 12, 0, "FLASH_CREST_MAXUNITSTREAMFLOW", "FLASH QPE-CREST Unit Streamflow", "m^3/s/km^2", -9999, -9999); // v12.2
+    add(209, 12, 1, "FLASH_CREST_MAXSTREAMFLOW", "FLASH QPE-CREST Streamflow", "m^3/s", -9999, -9999); // v12.2
+    add(209, 12, 2, "FLASH_CREST_MAXSOILSAT", "FLASH QPE-CREST Soil Saturation", "%", -9999, -9999); // v12.2
+    add(209, 12, 4, "FLASH_SAC_MAXUNITSTREAMFLOW", "FLASH QPE-SAC Unit Streamflow", "m^3/s/km^2", -9999, -9999); // v12.2
+    add(209, 12, 5, "FLASH_SAC_MAXSTREAMFLOW", "FLASH QPE-SAC Streamflow", "m^3/s", -9999, -9999); // v12.2
+    add(209, 12, 6, "FLASH_SAC_MAXSOILSAT", "FLASH QPE-SAC Soil Saturation", "%", -9999, -9999); // v12.2
+    add(209, 12, 14, "FLASH_QPE_ARI30M", "FLASH QPE Average Recurrence Interval 30-min", "year", -999, -999); // v12.2
+    add(209, 12, 15, "FLASH_QPE_ARI01H", "FLASH QPE Average Recurrence Interval 01H", "year", -999, -999); // v12.2
+    add(209, 12, 16, "FLASH_QPE_ARI03H", "FLASH QPE Average Recurrence Interval 03H", "year", -999, -999); // v12.2
+    add(209, 12, 17, "FLASH_QPE_ARI06H", "FLASH QPE Average Recurrence Interval 06H", "year", -999, -999); // v12.2
+    add(209, 12, 18, "FLASH_QPE_ARI12H", "FLASH QPE Average Recurrence Interval 12H", "year", -999, -999); // v12.2
+    add(209, 12, 19, "FLASH_QPE_ARI24H", "FLASH QPE Average Recurrence Interval 24H", "year", -999, -999); // v12.2
+    add(209, 12, 20, "FLASH_QPE_ARIMAX", "FLASH QPE Average Recurrence Interval Maximum", "year", -999, -999); // v12.2
+    add(209, 12, 26, "FLASH_QPE_FFG01H", "FLASH QPE-to-FFG Ratio 01H", "dimensionless", -999, -999); // v12.2
+    add(209, 12, 27, "FLASH_QPE_FFG03H", "FLASH QPE-to-FFG Ratio 03H", "dimensionless", -999, -999); // v12.2
+    add(209, 12, 28, "FLASH_QPE_FFG06H", "FLASH QPE-to-FFG Ratio 06H", "dimensionless", -999, -999); // v12.2
+    add(209, 12, 29, "FLASH_QPE_FFGMAX", "FLASH QPE-to-FFG Ratio Maximum", "dimensionless", -999, -999); // v12.2
+    add(209, 12, 39, "FLASH_HP_MAXUNITSTREAMFLOW", "FLASH QPE-Hydrophobic Unit Streamflow", "m^3/s/km^2", -9999, -9999); // v12.2
+    add(209, 12, 40, "FLASH_HP_MAXSTREAMFLOW", "FLASH QPE-Hydrophobic Streamflow", "m^3/s", -9999, -9999); // v12.2
+    add(209, 13, 0, "ANC_ConvectiveLikelihood", "Likelihood of convection over the next 01H", "dimensionless", 0, 0); // v12.2
+    add(209, 13, 1, "ANC_FinalForecast", "01H reflectivity forecast", "dBZ", 0, 0); // v12.2
+    add(209, 14, 0, "LVL3_HREET", "Level III High Resolution Enhanced Echo Top mosaic", "kft", -3, -1); // v12.2
+    add(209, 14, 1, "LVL3_HighResVIL", "Level III High Resolution VIL mosaic", "kg/m^2", -3, -1); // v12.2
   }
 
   private void add(int discipline, int category, int number, String name, String desc, String unit, float fill,

--- a/grib/src/main/resources/resources/grib2/mrms/MergedTableCode.txt
+++ b/grib/src/main/resources/resources/grib2/mrms/MergedTableCode.txt
@@ -1,70 +1,70 @@
-# created 2021-06-15T0531
-# using tables tables\UserTable_MRMS_v10.0.0.csv, tables\UserTable_MRMS_v10.0.1.csv, tables\UserTable_MRMS_v10.0.1_updated20150407.csv, tables\UserTable_MRMS_v11.0.4.csv, tables\UserTable_MRMS_v11.5.5.csv, tables\UserTable_MRMS_v12.0.csv, tables\UserTable_MRMS_v12.0_unidata_reported.csv
-add(209, 2, 0, "NLDN_CG_001min_AvgDensity", "CG Average Lightning Density 1-min - NLDN", "flashes/km^2/min", -3, -1); // v12.0
-add(209, 2, 1, "NLDN_CG_005min_AvgDensity", "CG Average Lightning Density 5-min - NLDN", "flashes/km^2/min", -3, -1); // v12.0
-add(209, 2, 2, "NLDN_CG_015min_AvgDensity", "CG Average Lightning Density 15-min - NLDN", "flashes/km^2/min", -3, -1); // v12.0
-add(209, 2, 3, "NLDN_CG_030min_AvgDensity", "CG Average Lightning Density 30-min - NLDN", "flashes/km^2/min", -3, -1); // v12.0
+# created 2022-08-24T0203
+# using tables tables/UserTable_MRMS_v10.0.0.csv, tables/UserTable_MRMS_v10.0.1.csv, tables/UserTable_MRMS_v10.0.1_updated20150407.csv, tables/UserTable_MRMS_v11.0.4.csv, tables/UserTable_MRMS_v11.5.5.csv, tables/UserTable_MRMS_v12.0.csv, tables/UserTable_MRMS_v12.0_unidata_reported.csv, tables/UserTable_MRMS_v12.2.csv
+add(209, 2, 0, "NLDN_CG_001min_AvgDensity", "CG Average Lightning Density 1-min - NLDN", "flashes/km^2/min", -3, -1); // v12.2
+add(209, 2, 1, "NLDN_CG_005min_AvgDensity", "CG Average Lightning Density 5-min - NLDN", "flashes/km^2/min", -3, -1); // v12.2
+add(209, 2, 2, "NLDN_CG_015min_AvgDensity", "CG Average Lightning Density 15-min - NLDN", "flashes/km^2/min", -3, -1); // v12.2
+add(209, 2, 3, "NLDN_CG_030min_AvgDensity", "CG Average Lightning Density 30-min - NLDN", "flashes/km^2/min", -3, -1); // v12.2
 add(209, 2, 4, "LightningProbabilityNext30min", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v11.5.5
-add(209, 2, 5, "LightningProbabilityNext30minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.0
-add(209, 2, 6, "LightningProbabilityNext60minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.0
-add(209, 2, 7, "LightningJumpGrid", "Rapid lightning increases and decreases ", "dimensionless", -99903, -99900); // v12.0
-add(209, 2, 8, "LightningJumpGrid_Max_005min", "Rapid lightning increases and decreases over 5-minutes ", "dimensionless", -99903, -99900); // v12.0
-add(209, 3, 0, "MergedAzShear0to2kmAGL", "Azimuth Shear 0-2km AGL", "0.001/s", 0, 0); // v12.0
-add(209, 3, 1, "MergedAzShear3to6kmAGL", "Azimuth Shear 3-6km AGL", "0.001/s", 0, 0); // v12.0
-add(209, 3, 2, "RotationTrack30min", "Rotation Track 0-2km AGL 30-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 3, "RotationTrack60min", "Rotation Track 0-2km AGL 60-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 4, "RotationTrack120min", "Rotation Track 0-2km AGL 120-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 5, "RotationTrack240min", "Rotation Track 0-2km AGL 240-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 6, "RotationTrack360min", "Rotation Track 0-2km AGL 360-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 7, "RotationTrack1440min", "Rotation Track 0-2km AGL 1440-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 14, "RotationTrackML30min", "Rotation Track 3-6km AGL 30-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 15, "RotationTrackML60min", "Rotation Track 3-6km AGL 60-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 16, "RotationTrackML120min", "Rotation Track 3-6km AGL 120-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 17, "RotationTrackML240min", "Rotation Track 3-6km AGL 240-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 18, "RotationTrackML360min", "Rotation Track 3-6km AGL 360-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 19, "RotationTrackML1440min", "Rotation Track 3-6km AGL 1440-min", "0.001/s", 0, 0); // v12.0
-add(209, 3, 26, "SHI", "Severe Hail Index", "dimensionless", -3, -1); // v12.0
-add(209, 3, 27, "POSH", "Prob of Severe Hail", "%", -3, -1); // v12.0
-add(209, 3, 28, "MESH", "Maximum Estimated Size of Hail (MESH)", "mm", -3, -1); // v12.0
-add(209, 3, 29, "MESHMax30min", "MESH Hail Swath 30-min", "mm", -3, -1); // v12.0
-add(209, 3, 30, "MESHMax60min", "MESH Hail Swath 60-min", "mm", -3, -1); // v12.0
-add(209, 3, 31, "MESHMax120min", "MESH Hail Swath 120-min", "mm", -3, -1); // v12.0
-add(209, 3, 32, "MESHMax240min", "MESH Hail Swath 240-min", "mm", -3, -1); // v12.0
-add(209, 3, 33, "MESHMax360min", "MESH Hail Swath 360-min", "mm", -3, -1); // v12.0
-add(209, 3, 34, "MESHMax1440min", "MESH Hail Swath 1440-min", "mm", -3, -1); // v12.0
-add(209, 3, 37, "VIL_Max_120min", "VIL Swath 120-min", "kg/m^2", -3, -1); // v12.0
-add(209, 3, 40, "VIL_Max_1440min", "VIL Swath 1440-min", "kg/m^2", -3, -1); // v12.0
-add(209, 3, 41, "VIL", "Vertically Integrated Liquid", "kg/m^2", -3, -1); // v12.0
-add(209, 3, 42, "VIL_Density", "Vertically Integrated Liquid Density", "g/m^3", -3, -1); // v12.0
-add(209, 3, 43, "VII", "Vertically Integrated Ice", "kg/m^2", -3, -1); // v12.0
-add(209, 3, 44, "EchoTop_18", "Echo Top - 18 dBZ MSL", "km", -3, -1); // v12.0
-add(209, 3, 45, "EchoTop_30", "Echo Top - 30 dBZ MSL", "km", -3, -1); // v12.0
-add(209, 3, 46, "EchoTop_50", "Echo Top - 50 dBZ MSL", "km", -3, -1); // v12.0
-add(209, 3, 47, "EchoTop_60", "Echo Top - 60 dBZ MSL", "km", -3, -1); // v12.0
-add(209, 3, 48, "H50AboveM20C", "Thickness [50 dBZ top - (-20C)]", "km", -999, -99); // v12.0
-add(209, 3, 49, "H50Above0C", "Thickness [50 dBZ top - 0C]", "km", -999, -99); // v12.0
-add(209, 3, 50, "H60AboveM20C", "Thickness [60 dBZ top - (-20C)]", "km", -999, -99); // v12.0
-add(209, 3, 51, "H60Above0C", "Thickness [60 dBZ top - 0C]", "km", -999, -99); // v12.0
-add(209, 3, 52, "Reflectivity_0C", "Isothermal Reflectivity at 0C", "dBZ", -999, -99); // v12.0
-add(209, 3, 53, "Reflectivity_-5C", "Isothermal Reflectivity at -5C", "dBZ", -999, -99); // v12.0
-add(209, 3, 54, "Reflectivity_-10C", "Isothermal Reflectivity at -10C", "dBZ", -999, -99); // v12.0
-add(209, 3, 55, "Reflectivity_-15C", "Isothermal Reflectivity at -15C", "dBZ", -999, -99); // v12.0
-add(209, 3, 56, "Reflectivity_-20C", "Isothermal Reflectivity at -20C", "dBZ", -999, -99); // v12.0
-add(209, 3, 57, "ReflectivityAtLowestAltitude5km", "ReflectivityAtLowestAltitude resampled from 1 to 5km resolution", "dBZ", -999, -99); // v12.0
-add(209, 3, 58, "MergedReflectivityAtLowestAltitude", "Non Quality Controlled Reflectivity At Lowest Altitude", "dBZ", -999, -99); // v12.0
+add(209, 2, 5, "LightningProbabilityNext30minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.2
+add(209, 2, 6, "LightningProbabilityNext60minGrid", "Lightning Probability 0-30 minutes - NLDN", "%", 0, 0); // v12.2
+add(209, 2, 7, "LightningJumpGrid", "Rapid lightning increases and decreases ", "dimensionless", -99903, -99900); // v12.2
+add(209, 2, 8, "LightningJumpGrid_Max_005min", "Rapid lightning increases and decreases over 5-minutes ", "dimensionless", -99903, -99900); // v12.2
+add(209, 3, 0, "MergedAzShear0to2kmAGL", "Azimuth Shear 0-2km AGL", "0.001/s", 0, 0); // v12.2
+add(209, 3, 1, "MergedAzShear3to6kmAGL", "Azimuth Shear 3-6km AGL", "0.001/s", 0, 0); // v12.2
+add(209, 3, 2, "RotationTrack30min", "Rotation Track 0-2km AGL 30-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 3, "RotationTrack60min", "Rotation Track 0-2km AGL 60-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 4, "RotationTrack120min", "Rotation Track 0-2km AGL 120-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 5, "RotationTrack240min", "Rotation Track 0-2km AGL 240-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 6, "RotationTrack360min", "Rotation Track 0-2km AGL 360-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 7, "RotationTrack1440min", "Rotation Track 0-2km AGL 1440-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 14, "RotationTrackML30min", "Rotation Track 3-6km AGL 30-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 15, "RotationTrackML60min", "Rotation Track 3-6km AGL 60-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 16, "RotationTrackML120min", "Rotation Track 3-6km AGL 120-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 17, "RotationTrackML240min", "Rotation Track 3-6km AGL 240-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 18, "RotationTrackML360min", "Rotation Track 3-6km AGL 360-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 19, "RotationTrackML1440min", "Rotation Track 3-6km AGL 1440-min", "0.001/s", 0, 0); // v12.2
+add(209, 3, 26, "SHI", "Severe Hail Index", "dimensionless", -3, -1); // v12.2
+add(209, 3, 27, "POSH", "Prob of Severe Hail", "%", -3, -1); // v12.2
+add(209, 3, 28, "MESH", "Maximum Estimated Size of Hail (MESH)", "mm", -3, -1); // v12.2
+add(209, 3, 29, "MESHMax30min", "MESH Hail Swath 30-min", "mm", -3, -1); // v12.2
+add(209, 3, 30, "MESHMax60min", "MESH Hail Swath 60-min", "mm", -3, -1); // v12.2
+add(209, 3, 31, "MESHMax120min", "MESH Hail Swath 120-min", "mm", -3, -1); // v12.2
+add(209, 3, 32, "MESHMax240min", "MESH Hail Swath 240-min", "mm", -3, -1); // v12.2
+add(209, 3, 33, "MESHMax360min", "MESH Hail Swath 360-min", "mm", -3, -1); // v12.2
+add(209, 3, 34, "MESHMax1440min", "MESH Hail Swath 1440-min", "mm", -3, -1); // v12.2
+add(209, 3, 37, "VIL_Max_120min", "VIL Swath 120-min", "kg/m^2", -3, -1); // v12.2
+add(209, 3, 40, "VIL_Max_1440min", "VIL Swath 1440-min", "kg/m^2", -3, -1); // v12.2
+add(209, 3, 41, "VIL", "Vertically Integrated Liquid", "kg/m^2", -3, -1); // v12.2
+add(209, 3, 42, "VIL_Density", "Vertically Integrated Liquid Density", "g/m^3", -3, -1); // v12.2
+add(209, 3, 43, "VII", "Vertically Integrated Ice", "kg/m^2", -3, -1); // v12.2
+add(209, 3, 44, "EchoTop_18", "Echo Top - 18 dBZ MSL", "km", -3, -1); // v12.2
+add(209, 3, 45, "EchoTop_30", "Echo Top - 30 dBZ MSL", "km", -3, -1); // v12.2
+add(209, 3, 46, "EchoTop_50", "Echo Top - 50 dBZ MSL", "km", -3, -1); // v12.2
+add(209, 3, 47, "EchoTop_60", "Echo Top - 60 dBZ MSL", "km", -3, -1); // v12.2
+add(209, 3, 48, "H50AboveM20C", "Thickness [50 dBZ top - (-20C)]", "km", -999, -99); // v12.2
+add(209, 3, 49, "H50Above0C", "Thickness [50 dBZ top - 0C]", "km", -999, -99); // v12.2
+add(209, 3, 50, "H60AboveM20C", "Thickness [60 dBZ top - (-20C)]", "km", -999, -99); // v12.2
+add(209, 3, 51, "H60Above0C", "Thickness [60 dBZ top - 0C]", "km", -999, -99); // v12.2
+add(209, 3, 52, "Reflectivity_0C", "Isothermal Reflectivity at 0C", "dBZ", -999, -99); // v12.2
+add(209, 3, 53, "Reflectivity_-5C", "Isothermal Reflectivity at -5C", "dBZ", -999, -99); // v12.2
+add(209, 3, 54, "Reflectivity_-10C", "Isothermal Reflectivity at -10C", "dBZ", -999, -99); // v12.2
+add(209, 3, 55, "Reflectivity_-15C", "Isothermal Reflectivity at -15C", "dBZ", -999, -99); // v12.2
+add(209, 3, 56, "Reflectivity_-20C", "Isothermal Reflectivity at -20C", "dBZ", -999, -99); // v12.2
+add(209, 3, 57, "ReflectivityAtLowestAltitude5km", "ReflectivityAtLowestAltitude resampled from 1 to 5km resolution", "dBZ", -999, -99); // v12.2
+add(209, 3, 58, "MergedReflectivityAtLowestAltitude", "Non Quality Controlled Reflectivity At Lowest Altitude", "dBZ", -999, -99); // v12.2
 add(209, 4, 0, "IRband4", "Infrared (E/W blend)", "K", -999, -99); // v11.5.5
 add(209, 4, 1, "Visible", "Visible (E/W blend)", "dimensionless", -3, -1); // v11.5.5
 add(209, 4, 2, "WaterVapor", "Water Vapor (E/W blend)", "K", -999, -99); // v11.5.5
 add(209, 4, 3, "CloudCover", "Cloud Cover", "K", -999, -99); // v11.5.5
-add(209, 6, 0, "PrecipFlag", "Surface Precipitation Type (Convective, Stratiform, Tropical, Hail, Snow)", "dimensionless", -3, -1); // v12.0
-add(209, 6, 1, "PrecipRate", "Radar Precipitation Rate", "mm/hr", -3, -1); // v12.0
-add(209, 6, 2, "RadarOnly_QPE_01H", "Radar precipitation accumulation 1-hour", "mm", -3, -1); // v12.0
-add(209, 6, 3, "RadarOnly_QPE_03H", "Radar precipitation accumulation 3-hour", "mm", -3, -1); // v12.0
-add(209, 6, 4, "RadarOnly_QPE_06H", "Radar precipitation accumulation 6-hour", "mm", -3, -1); // v12.0
-add(209, 6, 5, "RadarOnly_QPE_12H", "Radar precipitation accumulation 12-hour", "mm", -3, -1); // v12.0
-add(209, 6, 6, "RadarOnly_QPE_24H", "Radar precipitation accumulation 24-hour", "mm", -3, -1); // v12.0
-add(209, 6, 7, "RadarOnly_QPE_48H", "Radar precipitation accumulation 48-hour", "mm", -3, -1); // v12.0
-add(209, 6, 8, "RadarOnly_QPE_72H", "Radar precipitation accumulation 72-hour", "mm", -3, -1); // v12.0
+add(209, 6, 0, "PrecipFlag", "Surface Precipitation Type (Convective, Stratiform, Tropical, Hail, Snow)", "dimensionless", -3, -1); // v12.2
+add(209, 6, 1, "PrecipRate", "Radar Precipitation Rate", "mm/hr", -3, -1); // v12.2
+add(209, 6, 2, "RadarOnly_QPE_01H", "Radar precipitation accumulation 1-hour", "mm", -3, -1); // v12.2
+add(209, 6, 3, "RadarOnly_QPE_03H", "Radar precipitation accumulation 3-hour", "mm", -3, -1); // v12.2
+add(209, 6, 4, "RadarOnly_QPE_06H", "Radar precipitation accumulation 6-hour", "mm", -3, -1); // v12.2
+add(209, 6, 5, "RadarOnly_QPE_12H", "Radar precipitation accumulation 12-hour", "mm", -3, -1); // v12.2
+add(209, 6, 6, "RadarOnly_QPE_24H", "Radar precipitation accumulation 24-hour", "mm", -3, -1); // v12.2
+add(209, 6, 7, "RadarOnly_QPE_48H", "Radar precipitation accumulation 48-hour", "mm", -3, -1); // v12.2
+add(209, 6, 8, "RadarOnly_QPE_72H", "Radar precipitation accumulation 72-hour", "mm", -3, -1); // v12.2
 add(209, 6, 9, "GaugeCorrQPE01H", "Local gauge bias corrected radar precipitation accumulation 1-hour", "mm", -3, -1); // v11.5.5
 add(209, 6, 10, "GaugeCorrQPE03H", "Local gauge bias corrected radar precipitation accumulation 3-hour", "mm", -3, -1); // v11.5.5
 add(209, 6, 11, "GaugeCorrQPE06H", "Local gauge bias corrected radar precipitation accumulation 6-hour", "mm", -3, -1); // v11.5.5
@@ -86,92 +86,93 @@ add(209, 6, 26, "MountainMapperQPE12H", "Mountain Mapper precipitation accumulat
 add(209, 6, 27, "MountainMapperQPE24H", "Mountain Mapper precipitation accumulation 24-hour", "mm", -3, -1); // v11.5.5
 add(209, 6, 28, "MountainMapperQPE48H", "Mountain Mapper precipitation accumulation 48-hour", "mm", -3, -1); // v11.5.5
 add(209, 6, 29, "MountainMapperQPE72H", "Mountain Mapper precipitation accumulation 72-hour", "mm", -3, -1); // v11.5.5
-add(209, 6, 30, "MultiSensor_QPE_01H_Pass1", "Multi-sensor accumulation 1-hour (1-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 31, "MultiSensor_QPE_03H_Pass1", "Multi-sensor accumulation 3-hour (1-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 32, "MultiSensor_QPE_06H_Pass1", "Multi-sensor accumulation 6-hour (1-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 33, "MultiSensor_QPE_12H_Pass1", "Multi-sensor accumulation 12-hour (1-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 34, "MultiSensor_QPE_24H_Pass1", "Multi-sensor accumulation 24-hour (1-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 35, "MultiSensor_QPE_48H_Pass1", "Multi-sensor accumulation 48-hour (1-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 36, "MultiSensor_QPE_72H_Pass1", "Multi-sensor accumulation 72-hour (1-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 37, "MultiSensor_QPE_01H_Pass2", "Multi-sensor accumulation 1-hour (2-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 38, "MultiSensor_QPE_03H_Pass2", "Multi-sensor accumulation 3-hour (2-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 39, "MultiSensor_QPE_06H_Pass2", "Multi-sensor accumulation 6-hour (2-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 40, "MultiSensor_QPE_12H_Pass2", "Multi-sensor accumulation 12-hour (2-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 41, "MultiSensor_QPE_24H_Pass2", "Multi-sensor accumulation 24-hour (2-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 42, "MultiSensor_QPE_48H_Pass2", "Multi-sensor accumulation 48-hour (2-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 43, "MultiSensor_QPE_72H_Pass2", "Multi-sensor accumulation 72-hour (2-hour latency)", "mm", -3, -1); // v12.0
-add(209, 6, 44, "SyntheticPrecipRateID", "Method IDs for blended single and dual-pol derived precip rates ", "dimensionless", -3, -1); // v12.0
-add(209, 6, 45, "RadarOnly_QPE_15M", "Radar precipitation accumulation 15-minute", "mm", -3, -1); // v12.0
-add(209, 7, 0, "Model_SurfaceTemp", "Model Surface temperature", "degree_Celsius", -999, -99); // v12.0
-add(209, 7, 1, "Model_WetBulbTemp", "Model Surface wet bulb temperature", "degree_Celsius", -999, -99); // v12.0
-add(209, 7, 2, "WarmRainProbability", "Probability of warm rain", "%", -3, -1); // v12.0
-add(209, 7, 3, "Model_0degC_Height", "Model Freezing Level Height MSL", "m", -3, -1); // v12.0
-add(209, 7, 4, "BrightBandTopHeight", "Brightband Top Height AGL", "m", -3, -1); // v12.0
-add(209, 7, 5, "BrightBandBottomHeight", "Brightband Bottom Height AGL", "m", -3, -1); // v12.0
-add(209, 8, 0, "RadarQualityIndex", "Radar Quality Index", "dimensionless", -3, -1); // v12.0
-add(209, 8, 1, "GaugeInflIndex_01H_Pass1", "Gauge Influence Index for 1-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 2, "GaugeInflIndex_03H_Pass1", "Gauge Influence Index for 3-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 3, "GaugeInflIndex_06H_Pass1", "Gauge Influence Index for 6-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 4, "GaugeInflIndex_12H_Pass1", "Gauge Influence Index for 12-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 5, "GaugeInflIndex_24H_Pass1", "Gauge Influence Index for 24-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 6, "GaugeInflIndex_48H_Pass1", "Gauge Influence Index for 48-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 7, "GaugeInflIndex_72H_Pass1", "Gauge Influence Index for 72-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 8, "SeamlessHSR", "Seamless Hybrid Scan Reflectivity with VPR correction", "dBZ", -999, -99); // v12.0
-add(209, 8, 9, "SeamlessHSRHeight", "Height of Seamless Hybrid Scan Reflectivity AGL", "km", -3, -1); // v12.0
-add(209, 8, 10, "RadarAccumulationQualityIndex_01H", "Radar 1-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.0
-add(209, 8, 11, "RadarAccumulationQualityIndex_03H", "Radar 3-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.0
-add(209, 8, 12, "RadarAccumulationQualityIndex_06H", "Radar 6-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.0
-add(209, 8, 13, "RadarAccumulationQualityIndex_12H", "Radar 12-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.0
-add(209, 8, 14, "RadarAccumulationQualityIndex_24H", "Radar 24-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.0
-add(209, 8, 15, "RadarAccumulationQualityIndex_48H", "Radar 48-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.0
-add(209, 8, 16, "RadarAccumulationQualityIndex_72H", "Radar 72-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.0
-add(209, 8, 17, "GaugeInflIndex_01H_Pass2", "Gauge Influence Index for 1-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 18, "GaugeInflIndex_03H_Pass2", "Gauge Influence Index for 3-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 19, "GaugeInflIndex_06H_Pass2", "Gauge Influence Index for 6-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 20, "GaugeInflIndex_12H_Pass2", "Gauge Influence Index for 12-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 21, "GaugeInflIndex_24H_Pass2", "Gauge Influence Index for 24-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 22, "GaugeInflIndex_48H_Pass2", "Gauge Influence Index for 48-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 8, 23, "GaugeInflIndex_72H_Pass2", "Gauge Influence Index for 72-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.0
-add(209, 9, 0, "MergedReflectivityQC", "3D Reflectivity Mosaic - 33 CAPPIS (500-19000m)", "dBZ", -999, -99); // v12.0
+add(209, 6, 30, "MultiSensor_QPE_01H_Pass1", "Multi-sensor accumulation 1-hour (1-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 31, "MultiSensor_QPE_03H_Pass1", "Multi-sensor accumulation 3-hour (1-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 32, "MultiSensor_QPE_06H_Pass1", "Multi-sensor accumulation 6-hour (1-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 33, "MultiSensor_QPE_12H_Pass1", "Multi-sensor accumulation 12-hour (1-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 34, "MultiSensor_QPE_24H_Pass1", "Multi-sensor accumulation 24-hour (1-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 35, "MultiSensor_QPE_48H_Pass1", "Multi-sensor accumulation 48-hour (1-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 36, "MultiSensor_QPE_72H_Pass1", "Multi-sensor accumulation 72-hour (1-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 37, "MultiSensor_QPE_01H_Pass2", "Multi-sensor accumulation 1-hour (2-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 38, "MultiSensor_QPE_03H_Pass2", "Multi-sensor accumulation 3-hour (2-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 39, "MultiSensor_QPE_06H_Pass2", "Multi-sensor accumulation 6-hour (2-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 40, "MultiSensor_QPE_12H_Pass2", "Multi-sensor accumulation 12-hour (2-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 41, "MultiSensor_QPE_24H_Pass2", "Multi-sensor accumulation 24-hour (2-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 42, "MultiSensor_QPE_48H_Pass2", "Multi-sensor accumulation 48-hour (2-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 43, "MultiSensor_QPE_72H_Pass2", "Multi-sensor accumulation 72-hour (2-hour latency)", "mm", -3, -1); // v12.2
+add(209, 6, 44, "SyntheticPrecipRateID", "Method IDs for blended single and dual-pol derived precip rates ", "dimensionless", -3, -1); // v12.2
+add(209, 6, 45, "RadarOnly_QPE_15M", "Radar precipitation accumulation 15-minute", "mm", -3, -1); // v12.2
+add(209, 6, 46, "RadarOnly_QPE_Since12Z", "Radar precipitation accumulation since 12Z", "mm", -3, -1); // v12.2
+add(209, 7, 0, "Model_SurfaceTemp", "Model Surface temperature", "degree_Celsius", -999, -99); // v12.2
+add(209, 7, 1, "Model_WetBulbTemp", "Model Surface wet bulb temperature", "degree_Celsius", -999, -99); // v12.2
+add(209, 7, 2, "WarmRainProbability", "Probability of warm rain", "%", -3, -1); // v12.2
+add(209, 7, 3, "Model_0degC_Height", "Model Freezing Level Height MSL", "m", -3, -1); // v12.2
+add(209, 7, 4, "BrightBandTopHeight", "Brightband Top Height AGL", "m", -3, -1); // v12.2
+add(209, 7, 5, "BrightBandBottomHeight", "Brightband Bottom Height AGL", "m", -3, -1); // v12.2
+add(209, 8, 0, "RadarQualityIndex", "Radar Quality Index", "dimensionless", -3, -1); // v12.2
+add(209, 8, 1, "GaugeInflIndex_01H_Pass1", "Gauge Influence Index for 1-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 2, "GaugeInflIndex_03H_Pass1", "Gauge Influence Index for 3-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 3, "GaugeInflIndex_06H_Pass1", "Gauge Influence Index for 6-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 4, "GaugeInflIndex_12H_Pass1", "Gauge Influence Index for 12-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 5, "GaugeInflIndex_24H_Pass1", "Gauge Influence Index for 24-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 6, "GaugeInflIndex_48H_Pass1", "Gauge Influence Index for 48-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 7, "GaugeInflIndex_72H_Pass1", "Gauge Influence Index for 72-hour QPE (1-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 8, "SeamlessHSR", "Seamless Hybrid Scan Reflectivity with VPR correction", "dBZ", -999, -99); // v12.2
+add(209, 8, 9, "SeamlessHSRHeight", "Height of Seamless Hybrid Scan Reflectivity AGL", "km", -3, -1); // v12.2
+add(209, 8, 10, "RadarAccumulationQualityIndex_01H", "Radar 1-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.2
+add(209, 8, 11, "RadarAccumulationQualityIndex_03H", "Radar 3-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.2
+add(209, 8, 12, "RadarAccumulationQualityIndex_06H", "Radar 6-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.2
+add(209, 8, 13, "RadarAccumulationQualityIndex_12H", "Radar 12-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.2
+add(209, 8, 14, "RadarAccumulationQualityIndex_24H", "Radar 24-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.2
+add(209, 8, 15, "RadarAccumulationQualityIndex_48H", "Radar 48-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.2
+add(209, 8, 16, "RadarAccumulationQualityIndex_72H", "Radar 72-hour QPE Accumulation Quality", "dimensionless", -3, -1); // v12.2
+add(209, 8, 17, "GaugeInflIndex_01H_Pass2", "Gauge Influence Index for 1-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 18, "GaugeInflIndex_03H_Pass2", "Gauge Influence Index for 3-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 19, "GaugeInflIndex_06H_Pass2", "Gauge Influence Index for 6-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 20, "GaugeInflIndex_12H_Pass2", "Gauge Influence Index for 12-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 21, "GaugeInflIndex_24H_Pass2", "Gauge Influence Index for 24-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 22, "GaugeInflIndex_48H_Pass2", "Gauge Influence Index for 48-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 8, 23, "GaugeInflIndex_72H_Pass2", "Gauge Influence Index for 72-hour QPE (2-hour latency)", "dimensionless", -3, -1); // v12.2
+add(209, 9, 0, "MergedReflectivityQC", "3D Reflectivity Mosaic - 33 CAPPIS (500-19000m)", "dBZ", -999, -99); // v12.2
 add(209, 9, 1, "ConusPlusMergedReflectivityQC", "All Radar 3D Reflectivity Mosaic - 33 CAPPIS (500-19000m)", "dBZ", -999, -99); // v11.5.5
-add(209, 9, 3, "MergedRhoHV", "3D RhoHV Mosaic - 33 CAPPIS (500-19000m)", "dimensionless", -999, -99); // v12.0
-add(209, 9, 4, "MergedZdr", "3D Zdr Mosaic - 33 CAPPIS (500-19000m)", "dB", -999, -99); // v12.0
-add(209, 10, 0, "MergedReflectivityQCComposite5km", "Composite Reflectivity Mosaic (optimal method) resampled from 1 to 5km", "dBZ", -999, -99); // v12.0
-add(209, 10, 1, "HeightCompositeReflectivity", "Height of Composite Reflectivity Mosaic (optimal method) MSL", "m", -3, -1); // v12.0
-add(209, 10, 2, "LowLevelCompositeReflectivity", "Low-Level Composite Reflectivity Mosaic (0-4km)", "dBZ", -999, -99); // v12.0
-add(209, 10, 3, "HeightLowLevelCompositeReflectivity", "Height of Low-Level Composite Reflectivity Mosaic (0-4km) MSL", "m", -3, -1); // v12.0
-add(209, 10, 4, "LayerCompositeReflectivity_Low", "Layer Composite Reflectivity Mosaic 0-24kft (low altitude)", "dBZ", -999, -99); // v12.0
-add(209, 10, 5, "LayerCompositeReflectivity_High", "Layer Composite Reflectivity Mosaic 24-60 kft (highest altitude)", "dBZ", -999, -99); // v12.0
-add(209, 10, 6, "LayerCompositeReflectivity_Super", "Layer Composite Reflectivity Mosaic 33-60 kft (super high altitude)", "dBZ", -999, -99); // v12.0
-add(209, 10, 7, "CREF_1HR_MAX", "Composite Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.0
+add(209, 9, 3, "MergedRhoHV", "3D RhoHV Mosaic - 33 CAPPIS (500-19000m)", "dimensionless", -999, -99); // v12.2
+add(209, 9, 4, "MergedZdr", "3D Zdr Mosaic - 33 CAPPIS (500-19000m)", "dB", -999, -99); // v12.2
+add(209, 10, 0, "MergedReflectivityQCComposite5km", "Composite Reflectivity Mosaic (optimal method) resampled from 1 to 5km", "dBZ", -999, -99); // v12.2
+add(209, 10, 1, "HeightCompositeReflectivity", "Height of Composite Reflectivity Mosaic (optimal method) MSL", "m", -3, -1); // v12.2
+add(209, 10, 2, "LowLevelCompositeReflectivity", "Low-Level Composite Reflectivity Mosaic (0-4km)", "dBZ", -999, -99); // v12.2
+add(209, 10, 3, "HeightLowLevelCompositeReflectivity", "Height of Low-Level Composite Reflectivity Mosaic (0-4km) MSL", "m", -3, -1); // v12.2
+add(209, 10, 4, "LayerCompositeReflectivity_Low", "Layer Composite Reflectivity Mosaic 0-24kft (low altitude)", "dBZ", -999, -99); // v12.2
+add(209, 10, 5, "LayerCompositeReflectivity_High", "Layer Composite Reflectivity Mosaic 24-60 kft (highest altitude)", "dBZ", -999, -99); // v12.2
+add(209, 10, 6, "LayerCompositeReflectivity_Super", "Layer Composite Reflectivity Mosaic 33-60 kft (super high altitude)", "dBZ", -999, -99); // v12.2
+add(209, 10, 7, "CREF_1HR_MAX", "Composite Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.2
 add(209, 10, 8, "ReflectivityMaxAboveM10C", "Maximum Reflectivity at -10 deg C height and above", "dBZ", -999, -99); // v10.0.1
-add(209, 10, 9, "LayerCompositeReflectivity_ANC", "Layer Composite Reflectivity Mosaic (2-4.5km) (for ANC)", "dBZ", -999, -99); // v12.0
-add(209, 10, 10, "BREF_1HR_MAX", "Base Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.0
-add(209, 11, 0, "MergedBaseReflectivityQC", "Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.0
-add(209, 11, 1, "MergedReflectivityComposite", "Raw Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.0
-add(209, 11, 2, "MergedReflectivityQComposite", "Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.0
-add(209, 11, 3, "MergedBaseReflectivity", "Raw Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.0
+add(209, 10, 9, "LayerCompositeReflectivity_ANC", "Layer Composite Reflectivity Mosaic (2-4.5km) (for ANC)", "dBZ", -999, -99); // v12.2
+add(209, 10, 10, "BREF_1HR_MAX", "Base Reflectivity Hourly Maximum", "dBZ", -999, -99); // v12.2
+add(209, 11, 0, "MergedBaseReflectivityQC", "Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.2
+add(209, 11, 1, "MergedReflectivityComposite", "Raw Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.2
+add(209, 11, 2, "MergedReflectivityQComposite", "Composite Reflectivity Mosaic (max ref)", "dBZ", -999, -99); // v12.2
+add(209, 11, 3, "MergedBaseReflectivity", "Raw Base Reflectivity Mosaic (optimal method)", "dBZ", -999, -99); // v12.2
 add(209, 11, 4, "Merged_LVL3_BaseDHC", "Level III Base HCA Mosaic (nearest neighbor)", "dimensionless", -3, -1); // v11.5.5
-add(209, 12, 0, "FLASH_CREST_MAXUNITSTREAMFLOW", "FLASH QPE-CREST Unit Streamflow", "m^3/s/km^2", -999, -9999); // v12.0_unidata_reported
-add(209, 12, 1, "FLASH_CREST_MAXSTREAMFLOW", "FLASH QPE-CREST Streamflow", "m^3/s", -999, -9999); // v12.0_unidata_reported
-add(209, 12, 2, "FLASH_CREST_MAXSOILSAT", "FLASH QPE-CREST Soil Saturation", "%", -999, -9999); // v12.0_unidata_reported
-add(209, 12, 4, "FLASH_SAC_MAXUNITSTREAMFLOW", "FLASH QPE-SAC Unit Streamflow", "m^3/s/km^2", -999, -9999); // v12.0_unidata_reported
-add(209, 12, 5, "FLASH_SAC_MAXSTREAMFLOW", "FLASH QPE-SAC Streamflow", "m^3/s", -999, -9999); // v12.0_unidata_reported
-add(209, 12, 6, "FLASH_SAC_MAXSOILSAT", "FLASH QPE-SAC Soil Saturation", "%", -999, -9999); // v12.0_unidata_reported
-add(209, 12, 14, "FLASH_QPE_ARI30M", "FLASH QPE Average Recurrence Interval 30-min", "year", -999, -999); // v12.0
-add(209, 12, 15, "FLASH_QPE_ARI01H", "FLASH QPE Average Recurrence Interval 01H", "year", -999, -999); // v12.0
-add(209, 12, 16, "FLASH_QPE_ARI03H", "FLASH QPE Average Recurrence Interval 03H", "year", -999, -999); // v12.0
-add(209, 12, 17, "FLASH_QPE_ARI06H", "FLASH QPE Average Recurrence Interval 06H", "year", -999, -999); // v12.0
-add(209, 12, 18, "FLASH_QPE_ARI12H", "FLASH QPE Average Recurrence Interval 12H", "year", -999, -999); // v12.0
-add(209, 12, 19, "FLASH_QPE_ARI24H", "FLASH QPE Average Recurrence Interval 24H", "year", -999, -999); // v12.0
-add(209, 12, 20, "FLASH_QPE_ARIMAX", "FLASH QPE Average Recurrence Interval Maximum", "year", -999, -999); // v12.0
-add(209, 12, 26, "FLASH_QPE_FFG01H", "FLASH QPE-to-FFG Ratio 01H", "dimensionless", -999, -999); // v12.0
-add(209, 12, 27, "FLASH_QPE_FFG03H", "FLASH QPE-to-FFG Ratio 03H", "dimensionless", -999, -999); // v12.0
-add(209, 12, 28, "FLASH_QPE_FFG06H", "FLASH QPE-to-FFG Ratio 06H", "dimensionless", -999, -999); // v12.0
-add(209, 12, 29, "FLASH_QPE_FFGMAX", "FLASH QPE-to-FFG Ratio Maximum", "dimensionless", -999, -999); // v12.0
-add(209, 12, 39, "FLASH_HP_MAXUNITSTREAMFLOW", "FLASH QPE-Hydrophobic Unit Streamflow", "m^3/s/km^2", -999, -9999); // v12.0_unidata_reported
-add(209, 12, 40, "FLASH_HP_MAXSTREAMFLOW", "FLASH QPE-Hydrophobic Streamflow", "m^3/s", -999, -9999); // v12.0_unidata_reported
-add(209, 13, 0, "ANC_ConvectiveLikelihood", "Likelihood of convection over the next 01H", "dimensionless", 0, 0); // v12.0
-add(209, 13, 1, "ANC_FinalForecast", "01H reflectivity forecast", "dBZ", 0, 0); // v12.0
-add(209, 14, 0, "LVL3_HREET", "Level III High Resolution Enhanced Echo Top mosaic", "kft", -3, -1); // v12.0
-add(209, 14, 1, "LVL3_HighResVIL", "Level III High Resolution VIL mosaic", "kg/m^2", -3, -1); // v12.0
+add(209, 12, 0, "FLASH_CREST_MAXUNITSTREAMFLOW", "FLASH QPE-CREST Unit Streamflow", "m^3/s/km^2", -9999, -9999); // v12.2
+add(209, 12, 1, "FLASH_CREST_MAXSTREAMFLOW", "FLASH QPE-CREST Streamflow", "m^3/s", -9999, -9999); // v12.2
+add(209, 12, 2, "FLASH_CREST_MAXSOILSAT", "FLASH QPE-CREST Soil Saturation", "%", -9999, -9999); // v12.2
+add(209, 12, 4, "FLASH_SAC_MAXUNITSTREAMFLOW", "FLASH QPE-SAC Unit Streamflow", "m^3/s/km^2", -9999, -9999); // v12.2
+add(209, 12, 5, "FLASH_SAC_MAXSTREAMFLOW", "FLASH QPE-SAC Streamflow", "m^3/s", -9999, -9999); // v12.2
+add(209, 12, 6, "FLASH_SAC_MAXSOILSAT", "FLASH QPE-SAC Soil Saturation", "%", -9999, -9999); // v12.2
+add(209, 12, 14, "FLASH_QPE_ARI30M", "FLASH QPE Average Recurrence Interval 30-min", "year", -999, -999); // v12.2
+add(209, 12, 15, "FLASH_QPE_ARI01H", "FLASH QPE Average Recurrence Interval 01H", "year", -999, -999); // v12.2
+add(209, 12, 16, "FLASH_QPE_ARI03H", "FLASH QPE Average Recurrence Interval 03H", "year", -999, -999); // v12.2
+add(209, 12, 17, "FLASH_QPE_ARI06H", "FLASH QPE Average Recurrence Interval 06H", "year", -999, -999); // v12.2
+add(209, 12, 18, "FLASH_QPE_ARI12H", "FLASH QPE Average Recurrence Interval 12H", "year", -999, -999); // v12.2
+add(209, 12, 19, "FLASH_QPE_ARI24H", "FLASH QPE Average Recurrence Interval 24H", "year", -999, -999); // v12.2
+add(209, 12, 20, "FLASH_QPE_ARIMAX", "FLASH QPE Average Recurrence Interval Maximum", "year", -999, -999); // v12.2
+add(209, 12, 26, "FLASH_QPE_FFG01H", "FLASH QPE-to-FFG Ratio 01H", "dimensionless", -999, -999); // v12.2
+add(209, 12, 27, "FLASH_QPE_FFG03H", "FLASH QPE-to-FFG Ratio 03H", "dimensionless", -999, -999); // v12.2
+add(209, 12, 28, "FLASH_QPE_FFG06H", "FLASH QPE-to-FFG Ratio 06H", "dimensionless", -999, -999); // v12.2
+add(209, 12, 29, "FLASH_QPE_FFGMAX", "FLASH QPE-to-FFG Ratio Maximum", "dimensionless", -999, -999); // v12.2
+add(209, 12, 39, "FLASH_HP_MAXUNITSTREAMFLOW", "FLASH QPE-Hydrophobic Unit Streamflow", "m^3/s/km^2", -9999, -9999); // v12.2
+add(209, 12, 40, "FLASH_HP_MAXSTREAMFLOW", "FLASH QPE-Hydrophobic Streamflow", "m^3/s", -9999, -9999); // v12.2
+add(209, 13, 0, "ANC_ConvectiveLikelihood", "Likelihood of convection over the next 01H", "dimensionless", 0, 0); // v12.2
+add(209, 13, 1, "ANC_FinalForecast", "01H reflectivity forecast", "dBZ", 0, 0); // v12.2
+add(209, 14, 0, "LVL3_HREET", "Level III High Resolution Enhanced Echo Top mosaic", "kft", -3, -1); // v12.2
+add(209, 14, 1, "LVL3_HighResVIL", "Level III High Resolution VIL mosaic", "kg/m^2", -3, -1); // v12.2

--- a/grib/src/main/resources/resources/grib2/mrms/convert_mrms_table.py
+++ b/grib/src/main/resources/resources/grib2/mrms/convert_mrms_table.py
@@ -11,7 +11,7 @@ def parse_table_version(fname):
 
 def parse_file(fname):
     table_version = parse_table_version(fname)
-    with open(fname, 'r') as infile:
+    with open(fname, 'r', encoding='latin-1') as infile:
         reader = csv.reader(infile)
         ret = []
         cols = next(reader)

--- a/grib/src/main/resources/resources/grib2/mrms/tables/UserTable_MRMS_v12.2.csv
+++ b/grib/src/main/resources/resources/grib2/mrms/tables/UserTable_MRMS_v12.2.csv
@@ -1,0 +1,152 @@
+Discipline,Category,Parameter,Name,Frequency,Unit,Missing,Range Folded,No Coverage,Description,Notes
+209,2,0,NLDN_CG_001min_AvgDensity,1-min,flashes/km^2/min,-1,n/a,-3,CG Average Lightning Density 1-min - NLDN,was NLDN_CG_001min; ConUS only
+209,2,1,NLDN_CG_005min_AvgDensity,1-min,flashes/km^2/min,-1,n/a,-3,CG Average Lightning Density 5-min - NLDN,was NLDN_CG_005min; ConUS only
+209,2,2,NLDN_CG_015min_AvgDensity,1-min,flashes/km^2/min,-1,n/a,-3,CG Average Lightning Density 15-min - NLDN,was NLDN_CG_015min; ConUS only
+209,2,3,NLDN_CG_030min_AvgDensity,1-min,flashes/km^2/min,-1,n/a,-3,CG Average Lightning Density 30-min - NLDN,was NLDN_CG_030min; ConUS only
+209,2,5,LightningProbabilityNext30minGrid,2-min,%,0,n/a,0,Lightning Probability 0-30 minutes - NLDN,ConUS Only
+209,2,6,LightningProbabilityNext60minGrid,2-min,%,0,n/a,0,Lightning Probability 0-30 minutes - NLDN,ConUS Only
+209,2,7,LightningJumpGrid,2-min,non-dim,-99900,n/a,-99903,Rapid lightning increases and decreases ,ConUS Only
+209,2,8,LightningJumpGrid_Max_005min,2-min,non-dim,-99900,n/a,-99903,Rapid lightning increases and decreases over 5-minutes ,ConUS Only
+209,3,0,MergedAzShear0to2kmAGL,2-min,0.001/s,0,0,0,Azimuth Shear 0-2km AGL,no Alaska product
+209,3,1,MergedAzShear3to6kmAGL,2-min,0.001/s,0,0,0,Azimuth Shear 3-6km AGL,no Alaska product
+209,3,2,RotationTrack30min,2-min,0.001/s,0,n/a,0,Rotation Track 0-2km AGL 30-min,no Alaska product
+209,3,3,RotationTrack60min,2-min,0.001/s,0,n/a,0,Rotation Track 0-2km AGL 60-min,no Alaska product
+209,3,4,RotationTrack120min,30-min,0.001/s,0,n/a,0,Rotation Track 0-2km AGL 120-min,no Alaska product
+209,3,5,RotationTrack240min,30-min,0.001/s,0,n/a,0,Rotation Track 0-2km AGL 240-min,no Alaska product
+209,3,6,RotationTrack360min,30-min,0.001/s,0,n/a,0,Rotation Track 0-2km AGL 360-min,no Alaska product
+209,3,7,RotationTrack1440min,30-min,0.001/s,0,n/a,0,Rotation Track 0-2km AGL 1440-min,no Alaska product
+209,3,14,RotationTrackML30min,2-min,0.001/s,0,n/a,0,Rotation Track 3-6km AGL 30-min,no Alaska product
+209,3,15,RotationTrackML60min,2-min,0.001/s,0,n/a,0,Rotation Track 3-6km AGL 60-min,no Alaska product
+209,3,16,RotationTrackML120min,30-min,0.001/s,0,n/a,0,Rotation Track 3-6km AGL 120-min,no Alaska product
+209,3,17,RotationTrackML240min,30-min,0.001/s,0,n/a,0,Rotation Track 3-6km AGL 240-min,no Alaska product
+209,3,18,RotationTrackML360min,30-min,0.001/s,0,n/a,0,Rotation Track 3-6km AGL 360-min,no Alaska product
+209,3,19,RotationTrackML1440min,30-min,0.001/s,0,n/a,0,Rotation Track 3-6km AGL 1440-min,no Alaska product
+209,3,26,SHI,2-min,index,-1,n/a,-3,Severe Hail Index,
+209,3,27,POSH,2-min,%,-1,n/a,-3,Prob of Severe Hail,
+209,3,28,MESH,2-min,mm,-1,n/a,-3,Maximum Estimated Size of Hail (MESH),
+209,3,29,MESHMax30min,2-min,mm,-1,n/a,-3,MESH Hail Swath 30-min,
+209,3,30,MESHMax60min,2-min,mm,-1,n/a,-3,MESH Hail Swath 60-min,
+209,3,31,MESHMax120min,30-min,mm,-1,n/a,-3,MESH Hail Swath 120-min,
+209,3,32,MESHMax240min,30-min,mm,-1,n/a,-3,MESH Hail Swath 240-min,
+209,3,33,MESHMax360min,30-min,mm,-1,n/a,-3,MESH Hail Swath 360-min,
+209,3,34,MESHMax1440min,30-min,mm,-1,n/a,-3,MESH Hail Swath 1440-min,
+209,3,37,VIL_Max_120min,30-min,kg/m^2,-1,n/a,-3,VIL Swath 120-min,
+209,3,40,VIL_Max_1440min,30-min,kg/m^2,-1,n/a,-3,VIL Swath 1440-min,
+209,3,41,VIL,2-min,kg/m^2,-1,n/a,-3,Vertically Integrated Liquid,
+209,3,42,VIL_Density,2-min,g/m^3,-1,n/a,-3,Vertically Integrated Liquid Density,
+209,3,43,VII,2-min,kg/m^2,-1,n/a,-3,Vertically Integrated Ice,
+209,3,44,EchoTop_18,2-min,km MSL,-1,n/a,-3,Echo Top - 18 dBZ,
+209,3,45,EchoTop_30,2-min,km MSL,-1,n/a,-3,Echo Top - 30 dBZ,
+209,3,46,EchoTop_50,2-min,km MSL,-1,n/a,-3,Echo Top - 50 dBZ,
+209,3,47,EchoTop_60,2-min,km MSL,-1,n/a,-3,Echo Top - 60 dBZ,
+209,3,48,H50AboveM20C,2-min,km,-99,n/a,-999,Thickness [50 dBZ top - (-20C)],
+209,3,49,H50Above0C,2-min,km,-99,n/a,-999,Thickness [50 dBZ top - 0C],
+209,3,50,H60AboveM20C,2-min,km,-99,n/a,-999,Thickness [60 dBZ top - (-20C)],
+209,3,51,H60Above0C,2-min,km,-99,n/a,-999,Thickness [60 dBZ top - 0C],
+209,3,52,Reflectivity_0C,2-min,dBZ,-99,n/a,-999,Isothermal Reflectivity at 0C,
+209,3,53,Reflectivity_-5C,2-min,dBZ,-99,n/a,-999,Isothermal Reflectivity at -5C,
+209,3,54,Reflectivity_-10C,2-min,dBZ,-99,n/a,-999,Isothermal Reflectivity at -10C,
+209,3,55,Reflectivity_-15C,2-min,dBZ,-99,n/a,-999,Isothermal Reflectivity at -15C,
+209,3,56,Reflectivity_-20C,2-min,dBZ,-99,n/a,-999,Isothermal Reflectivity at -20C,
+209,3,57,ReflectivityAtLowestAltitude,2-min,dBZ,-99,n/a,-999,ReflectivityAtLowestAltitude,
+209,3,57,ReflectivityAtLowestAltitude5km,2-min,dBZ,-99,n/a,-999,ReflectivityAtLowestAltitude resampled from 1 to 5km resolution,ConUS only - removed at v12.1
+209,3,58,MergedReflectivityAtLowestAltitude,2-min,dBZ,-99,n/a,-999,Non Quality Controlled Reflectivity At Lowest Altitude,
+209,6,0,PrecipFlag,2-min,flag,-1,n/a,-3,"Surface Precipitation Type (Convective, Stratiform, Tropical, Hail, Snow)",see flag table
+209,6,1,PrecipRate,2-min,mm/hr,-1,n/a,-3,Radar Precipitation Rate,
+209,6,2,RadarOnly_QPE_01H,2-min,mm,-1,n/a,-3,Radar precipitation accumulation 1-hour,
+209,6,3,RadarOnly_QPE_03H,60-min,mm,-1,n/a,-3,Radar precipitation accumulation 3-hour,
+209,6,4,RadarOnly_QPE_06H,60-min,mm,-1,n/a,-3,Radar precipitation accumulation 6-hour,
+209,6,5,RadarOnly_QPE_12H,60-min,mm,-1,n/a,-3,Radar precipitation accumulation 12-hour,
+209,6,6,RadarOnly_QPE_24H,60-min,mm,-1,n/a,-3,Radar precipitation accumulation 24-hour,
+209,6,7,RadarOnly_QPE_48H,60-min,mm,-1,n/a,-3,Radar precipitation accumulation 48-hour,
+209,6,8,RadarOnly_QPE_72H,60-min,mm,-1,n/a,-3,Radar precipitation accumulation 72-hour,
+209,6,30,MultiSensor_QPE_01H_Pass1,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 1-hour (1-hour latency),
+209,6,31,MultiSensor_QPE_03H_Pass1,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 3-hour (1-hour latency),
+209,6,32,MultiSensor_QPE_06H_Pass1,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 6-hour (1-hour latency),
+209,6,33,MultiSensor_QPE_12H_Pass1,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 12-hour (1-hour latency),
+209,6,34,MultiSensor_QPE_24H_Pass1,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 24-hour (1-hour latency),
+209,6,35,MultiSensor_QPE_48H_Pass1,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 48-hour (1-hour latency),
+209,6,36,MultiSensor_QPE_72H_Pass1,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 72-hour (1-hour latency),
+209,6,37,MultiSensor_QPE_01H_Pass2,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 1-hour (2-hour latency),
+209,6,38,MultiSensor_QPE_03H_Pass2,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 3-hour (2-hour latency),
+209,6,39,MultiSensor_QPE_06H_Pass2,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 6-hour (2-hour latency),
+209,6,40,MultiSensor_QPE_12H_Pass2,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 12-hour (2-hour latency),
+209,6,41,MultiSensor_QPE_24H_Pass2,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 24-hour (2-hour latency),
+209,6,42,MultiSensor_QPE_48H_Pass2,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 48-hour (2-hour latency),
+209,6,43,MultiSensor_QPE_72H_Pass2,60-min,mm,-1,n/a,-3,Multi-sensor accumulation 72-hour (2-hour latency),
+209,6,44,SyntheticPrecipRateID,2-min,flag,-1,n/a,-3,Method IDs for blended single and dual-pol derived precip rates ,
+209,6,45,RadarOnly_QPE_15M,15-min,mm,-1,n/a,-3,Radar precipitation accumulation 15-minute,
+209,6,46,RadarOnly_QPE_Since12Z,60-min,mm,-1,n/a,-3,Radar precipitation accumulation since 12Z,
+209,7,0,Model_SurfaceTemp,60-min,C,-99,n/a,-999,Model Surface temperature,
+209,7,1,Model_WetBulbTemp,60-min,C,-99,n/a,-999,Model Surface wet bulb temperature,
+209,7,2,WarmRainProbability,60-min,%,-1,n/a,-3,Probability of warm rain,
+209,7,3,Model_0degC_Height,60-min,m MSL,-1,n/a,-3,Model Freezing Level Height,
+209,7,4,BrightBandTopHeight,2-min,m AGL,-1,n/a,-3,Brightband Top Height,
+209,7,5,BrightBandBottomHeight,2-min,m AGL,-1,n/a,-3,Brightband Bottom Height,
+209,8,0,RadarQualityIndex,2-min,non-dim,-1,n/a,-3,Radar Quality Index,
+209,8,1,GaugeInflIndex_01H_Pass1,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 1-hour QPE (1-hour latency),was GaugeInflIndex_01H prior to v12.0
+209,8,2,GaugeInflIndex_03H_Pass1,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 3-hour QPE (1-hour latency),was GaugeInflIndex_03H  prior to v12.0
+209,8,3,GaugeInflIndex_06H_Pass1,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 6-hour QPE (1-hour latency),was GaugeInflIndex_06H  prior to v12.0
+209,8,4,GaugeInflIndex_12H_Pass1,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 12-hour QPE (1-hour latency),was GaugeInflIndex_12H prior to v12.0
+209,8,5,GaugeInflIndex_24H_Pass1,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 24-hour QPE (1-hour latency),was GaugeInflIndex_24H  prior to v12.0
+209,8,6,GaugeInflIndex_48H_Pass1,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 48-hour QPE (1-hour latency),was GaugeInflIndex_48H  prior to v12.0
+209,8,7,GaugeInflIndex_72H_Pass1,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 72-hour QPE (1-hour latency),was GaugeInflIndex_72H  prior to v12.0
+209,8,8,SeamlessHSR,2-min,dBZ,-99,n/a,-999,Seamless Hybrid Scan Reflectivity with VPR correction,
+209,8,9,SeamlessHSRHeight,2-min,km AGL,-1,n/a,-3,Height of Seamless Hybrid Scan Reflectivity,
+209,8,10,RadarAccumulationQualityIndex_01H,60-min,non-dim,-1,n/a,-3,Radar 1-hour QPE Accumulation Quality,
+209,8,11,RadarAccumulationQualityIndex_03H,60-min,non-dim,-1,n/a,-3,Radar 3-hour QPE Accumulation Quality,
+209,8,12,RadarAccumulationQualityIndex_06H,60-min,non-dim,-1,n/a,-3,Radar 6-hour QPE Accumulation Quality,
+209,8,13,RadarAccumulationQualityIndex_12H,60-min,non-dim,-1,n/a,-3,Radar 12-hour QPE Accumulation Quality,
+209,8,14,RadarAccumulationQualityIndex_24H,60-min,non-dim,-1,n/a,-3,Radar 24-hour QPE Accumulation Quality,
+209,8,15,RadarAccumulationQualityIndex_48H,60-min,non-dim,-1,n/a,-3,Radar 48-hour QPE Accumulation Quality,
+209,8,16,RadarAccumulationQualityIndex_72H,60-min,non-dim,-1,n/a,-3,Radar 72-hour QPE Accumulation Quality,
+209,8,17,GaugeInflIndex_01H_Pass2,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 1-hour QPE (2-hour latency),
+209,8,18,GaugeInflIndex_03H_Pass2,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 3-hour QPE (2-hour latency),
+209,8,19,GaugeInflIndex_06H_Pass2,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 6-hour QPE (2-hour latency),
+209,8,20,GaugeInflIndex_12H_Pass2,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 12-hour QPE (2-hour latency),
+209,8,21,GaugeInflIndex_24H_Pass2,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 24-hour QPE (2-hour latency),
+209,8,22,GaugeInflIndex_48H_Pass2,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 48-hour QPE (2-hour latency),
+209,8,23,GaugeInflIndex_72H_Pass2,60-min,non-dim,-1,n/a,-3,Gauge Influence Index for 72-hour QPE (2-hour latency),
+209,9,0,MergedReflectivityQC,2-min,dBZ,-99,n/a,-999,3D Reflectivty Mosaic - 33 CAPPIS (500-19000m),33 levels (one file per level)
+209,9,3,MergedRhoHV,5-min,non-dim,-99,n/a,-999,3D RhoHV Mosaic - 33 CAPPIS (500-19000m),"33 levels (one file per level), ConUS only"
+209,9,4,MergedZdr,5-min,dB,-99,n/a,-999,3D Zdr Mosaic - 33 CAPPIS (500-19000m),"33 levels (one file per level), ConUS only"
+209,10,0,MergedReflectivityQCComposite,2-min,dBZ,-99,n/a,-999,Composite Reflectivity Mosaic (optimal method),
+209,10,0,MergedReflectivityQCComposite5km,2-min,dBZ,-99,n/a,-999,Composite Reflectivity Mosaic (optimal method) resampled from 1 to 5km,ConUS only - removed at v12.1
+209,10,1,HeightCompositeReflectivity,2-min,m MSL,-1,n/a,-3,Height of Composite Reflectivity Mosaic (optimal method),
+209,10,2,LowLevelCompositeReflectivity,2-min,dBZ,-99,n/a,-999,Low-Level Composite Reflectivity Mosaic (0-4km),
+209,10,3,HeightLowLevelCompositeReflectivity,2-min,m MSL,-1,n/a,-3,Height of Low-Level Composite Reflectivity Mosaic (0-4km),
+209,10,4,LayerCompositeReflectivity_Low,2-min,dBZ,-99,n/a,-999,Layer Composite Reflectivity Mosaic 0-24kft (low altitude),
+209,10,5,LayerCompositeReflectivity_High,2-min,dBZ,-99,n/a,-999,Layer Composite Reflectivity Mosaic 24-60 kft (highest altitude),
+209,10,6,LayerCompositeReflectivity_Super,2-min,dBZ,-99,n/a,-999,Layer Composite Reflectivity Mosaic 33-60 kft (super high altitude),
+209,10,7,CREF_1HR_MAX,60-min,dBZ,-99,n/a,-999,Composite Reflectivity Hourly Maximum,
+209,10,9,LayerCompositeReflectivity_ANC,2-min,dBZ,-99,n/a,-999,Layer Composite Reflectivity Mosaic (2-4.5km) (for ANC),ConUS only
+209,10,10,BREF_1HR_MAX,60-min,dBZ,-99,n/a,-999,Base Reflectivity Hourly Maximum,
+209,11,0,MergedBaseReflectivityQC,2-min,dBZ,-99,n/a,-999,Base Reflectivity Mosaic (optimal method),
+209,11,1,MergedReflectivityComposite,2-min,dBZ,-99,n/a,-999,Raw Composite Reflectivity Mosaic (max ref),
+209,11,2,MergedReflectivityQComposite,2-min,dBZ,-99,n/a,-999,Composite Reflectivity Mosaic (max ref),
+209,11,3,MergedBaseReflectivity,2-min,dBZ,-99,n/a,-999,Raw Base Reflectivity Mosaic (optimal method),
+209,12,0,FLASH_CREST_MAXUNITSTREAMFLOW,10-min,m^3/s/km^2,-9999,n/a,-9999,FLASH QPE-CREST Unit Streamflow,
+209,12,1,FLASH_CREST_MAXSTREAMFLOW,10-min,m^3/s,-9999,n/a,-9999,FLASH QPE-CREST Streamflow,
+209,12,2,FLASH_CREST_MAXSOILSAT,10-min,%,-9999,n/a,-9999,FLASH QPE-CREST Soil Saturation,
+209,12,4,FLASH_SAC_MAXUNITSTREAMFLOW,10-min,m^3/s/km^2,-9999,n/a,-9999,FLASH QPE-SAC Unit Streamflow,
+209,12,5,FLASH_SAC_MAXSTREAMFLOW,10-min,m^3/s,-9999,n/a,-9999,FLASH QPE-SAC Streamflow,
+209,12,6,FLASH_SAC_MAXSOILSAT,10-min,%,-9999,n/a,-9999,FLASH QPE-SAC Soil Saturation,
+209,12,14,FLASH_QPE_ARI30M,2-min,years,-999,n/a,-999,FLASH QPE Average Recurrence Interval 30-min,
+209,12,15,FLASH_QPE_ARI01H,2-min,years,-999,n/a,-999,FLASH QPE Average Recurrence Interval 01H,
+209,12,16,FLASH_QPE_ARI03H,2-min,years,-999,n/a,-999,FLASH QPE Average Recurrence Interval 03H,
+209,12,17,FLASH_QPE_ARI06H,2-min,years,-999,n/a,-999,FLASH QPE Average Recurrence Interval 06H,
+209,12,18,FLASH_QPE_ARI12H,2-min,years,-999,n/a,-999,FLASH QPE Average Recurrence Interval 12H,
+209,12,19,FLASH_QPE_ARI24H,2-min,years,-999,n/a,-999,FLASH QPE Average Recurrence Interval 24H,
+209,12,20,FLASH_QPE_ARIMAX,2-min,years,-999,n/a,-999,FLASH QPE Average Recurrence Interval Maximum,
+209,12,26,FLASH_QPE_FFG01H,2-min,non-dim,-999,n/a,-999,FLASH QPE-to-FFG Ratio 01H,no Alaska product
+209,12,27,FLASH_QPE_FFG03H,2-min,non-dim,-999,n/a,-999,FLASH QPE-to-FFG Ratio 03H,no Alaska product
+209,12,28,FLASH_QPE_FFG06H,2-min,non-dim,-999,n/a,-999,FLASH QPE-to-FFG Ratio 06H,no Alaska product
+209,12,29,FLASH_QPE_FFGMAX,2-min,non-dim,-999,n/a,-999,FLASH QPE-to-FFG Ratio Maximum,no Alaska product
+209,12,39,FLASH_HP_MAXUNITSTREAMFLOW,10-min,m^3/s/km^2,-9999,n/a,-9999,FLASH QPE-Hydrophobic Unit Streamflow,
+209,12,40,FLASH_HP_MAXSTREAMFLOW,10-min,m^3/s,-9999,n/a,-9999,FLASH QPE-Hydrophobic Streamflow,
+209,13,0,ANC_ConvectiveLikelihood,10-min,non-dim,0,n/a,0,Likelihood of convection over the next 01H,ConUS only
+209,13,1,ANC_FinalForecast,10-min,dBZ,0,n/a,0,01H reflectivity forecast,ConUS only
+209,14,0,LVL3_HREET,2-min,kft,-1,n/a,-3,Level III High Resolution Enhanced Echo Top mosaic,ConUS only
+209,14,1,LVL3_HighResVIL,2-min,kg/m^2,-1,n/a,-3,Level III High Resouion VIL mosaic,ConUS only
+Not GRIB2,n/a,n/a,CONVECTPROB (ASCII),2-min,n/a,n/a,n/a,n/a,Prob Severe v1,ConUS only
+Not GRIB2,n/a,n/a,PROBSEVERE (JSON),2-min,n/a,n/a,n/a,n/a,Prob Severe v2,ConUS only

--- a/grib/src/test/java/ucar/nc2/grib/grib2/TestMRMS.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib2/TestMRMS.java
@@ -50,7 +50,7 @@ public class TestMRMS {
 
       att = var.findAttribute("_FillValue");
       Assert.assertNotNull(att);
-      Assert.assertEquals(-999., att.getNumericValue().doubleValue(), 1e-6);
+      Assert.assertEquals(-9999., att.getNumericValue().doubleValue(), 1e-6);
     }
   }
 }


### PR DESCRIPTION
## Description of Changes

Grab the 12.2 version of the MRMS table and update the generated code. Also fix an encoding error spit out by the Python script.

This fixes "RadarOnly_QPE_Since12Z" being reported as `VAR209-6-46_FROM_161-0--1_altitude_above_msl` (from esupport INO-158322).

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [x] Link to any issues that the PR addresses
- [x] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
