### PR TITLE
Update GH PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,8 @@ _Erase this and add a general description of changes, heads-up on any tricky par
 
 ## PR Checklist
 <!-- This will become an interactive checklist once the PR is opened -->
-- [ ] Indicate the version associated with this PR in the Title
-       (e.g. "[5.x]: This is my PR title")
 - [ ] Link to any issues that the PR addresses
-- [ ] Add labels, especially if the PR should be ported to other versions
-       (these labels start with "port: ")
+- [ ] Add labels
 - [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
        until ready for review
 - [ ] Make sure GitHub tests pass


### PR DESCRIPTION
## Description of Changes

Remove no longer needed version related items from the github pr checklist since version branches > 6 are now "frozen"

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Indicate the version associated with this PR in the Title
       (e.g. "[5.x]: This is my PR title")
- [ ] Link to any issues that the PR addresses
- [ ] Add labels, especially if the PR should be ported to other versions
       (these labels start with "port: ")
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
