### PR TITLE
Change time interval coordinate to endpoint

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
@@ -133,7 +133,7 @@ public class TestIntervalsTimeCoords2D {
         }
         assertThat(start).isEqualTo(bounds[idx][0]);
         assertThat(end).isEqualTo(bounds[idx][1]);
-        assertThat(coordinateValue).isWithin(TOLERANCE).of((start + end) / 2.0);
+        assertThat(coordinateValue).isWithin(TOLERANCE).of(end);
         idx++;
       }
 

--- a/grib/src/main/java/ucar/nc2/grib/coord/TimeCoordIntvValue.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/TimeCoordIntvValue.java
@@ -29,8 +29,8 @@ public class TimeCoordIntvValue implements Comparable<TimeCoordIntvValue> {
   }
 
   public double getCoordValue() {
-    // Choose interval midpoint as the coordinate value
-    return (b1 + b2) / 2.0;
+    // Choose interval endpoint as the coordinate value
+    return b2;
   }
 
   public TimeCoordIntvValue convertReferenceDate(CalendarDate fromDate, CalendarPeriod fromUnit, CalendarDate toDate,


### PR DESCRIPTION
## Description of Changes

This reverts part of the changes in [this PR](https://github.com/Unidata/netcdf-java/pull/1035) which recently changed the time interval coordinate to be the midpoint rather than the endpoint.

As discussed, the CF convention allows for either the endpoint or the midpoint. In certain situations the midpoint seems to represent the data better (more likely to be unique for mixed interval data). 

However, as this caused issues in the IDV, we have decided to reconsider this change and to revert back to the endpoint of the interval as the coordinate value.

Documentation updates in the TDS to be added in a separate PR.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
