### PR TITLE
Handle HDF5 file when a variable has a zero dimension

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
@@ -124,13 +124,12 @@ class BufrIospBuilder {
     dkey.name = uname; // name may need to be changed for uniqueness
 
     Structure.Builder struct = Structure.builder().setName(uname);
-    try{
+    try {
       struct.setDimensionsAnonymous(new int[] {count}); // anon vector
-    }
-    catch (InvalidRangeException e){
+    } catch (InvalidRangeException e) {
       log.error(e.getMessage());
     }
-      for (BufrConfig.FieldConverter subKey : fld.flds) {
+    for (BufrConfig.FieldConverter subKey : fld.flds) {
       addMember(group, struct, subKey);
     }
 
@@ -182,10 +181,9 @@ class BufrIospBuilder {
     Structure.Builder struct = Structure.builder().setName(uname);
     parent.addMemberVariable(struct);
     int n = parentFld.dds.replication;
-    try{
+    try {
       struct.setDimensionsAnonymous(new int[] {n}); // anon vector
-    }
-    catch (InvalidRangeException e){
+    } catch (InvalidRangeException e) {
       log.error(e.getMessage());
     }
 
@@ -202,10 +200,9 @@ class BufrIospBuilder {
 
   private void addDpiSequence(Structure.Builder parent, BufrConfig.FieldConverter fld) {
     Structure.Builder struct = Structure.builder().setName("statistics");
-    try{
+    try {
       struct.setDimensionsAnonymous(new int[] {fld.dds.replication}); // scalar
-    }
-    catch (InvalidRangeException e){
+    } catch (InvalidRangeException e) {
       log.error(e.getMessage());
     }
 
@@ -228,10 +225,9 @@ class BufrIospBuilder {
 
     Variable.Builder v = Variable.builder().setName(uname);
     if (count > 1) {
-      try{
+      try {
         v.setDimensionsAnonymous(new int[] {count}); // anon vector
-      }
-      catch (InvalidRangeException e){
+      } catch (InvalidRangeException e) {
         log.error(e.getMessage());
         log.debug("ERROR: makeVariableShapeAndType {}", e.getMessage());
       }
@@ -260,10 +256,9 @@ class BufrIospBuilder {
     if (dataDesc.type == 1) {
       v.setDataType(DataType.CHAR);
       int size = dataDesc.bitWidth / 8;
-      try{
+      try {
         v.setDimensionsAnonymous(new int[] {size});
-      }
-      catch (InvalidRangeException e){
+      } catch (InvalidRangeException e) {
         log.error(e.getMessage());
         log.debug("ERROR: makeVariableShapeAndType {}", e.getMessage());
       }

--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
 import ucar.nc2.Attribute;
 import ucar.nc2.AttributeContainerMutable;
 import ucar.nc2.EnumTypedef;
@@ -123,8 +124,13 @@ class BufrIospBuilder {
     dkey.name = uname; // name may need to be changed for uniqueness
 
     Structure.Builder struct = Structure.builder().setName(uname);
-    struct.setDimensionsAnonymous(new int[] {count}); // anon vector
-    for (BufrConfig.FieldConverter subKey : fld.flds) {
+    try{
+      struct.setDimensionsAnonymous(new int[] {count}); // anon vector
+    }
+    catch (InvalidRangeException e){
+      log.error(e.getMessage());
+    }
+      for (BufrConfig.FieldConverter subKey : fld.flds) {
       addMember(group, struct, subKey);
     }
 
@@ -176,7 +182,12 @@ class BufrIospBuilder {
     Structure.Builder struct = Structure.builder().setName(uname);
     parent.addMemberVariable(struct);
     int n = parentFld.dds.replication;
-    struct.setDimensionsAnonymous(new int[] {n}); // anon vector
+    try{
+      struct.setDimensionsAnonymous(new int[] {n}); // anon vector
+    }
+    catch (InvalidRangeException e){
+      log.error(e.getMessage());
+    }
 
     Variable.Builder v = Variable.builder().setName("name");
     v.setDataType(DataType.STRING); // scalar
@@ -191,7 +202,12 @@ class BufrIospBuilder {
 
   private void addDpiSequence(Structure.Builder parent, BufrConfig.FieldConverter fld) {
     Structure.Builder struct = Structure.builder().setName("statistics");
-    struct.setDimensionsAnonymous(new int[] {fld.dds.replication}); // scalar
+    try{
+      struct.setDimensionsAnonymous(new int[] {fld.dds.replication}); // scalar
+    }
+    catch (InvalidRangeException e){
+      log.error(e.getMessage());
+    }
 
     Variable.Builder v = Variable.builder().setName("name");
     v.setDataType(DataType.STRING); // scalar
@@ -212,7 +228,13 @@ class BufrIospBuilder {
 
     Variable.Builder v = Variable.builder().setName(uname);
     if (count > 1) {
-      v.setDimensionsAnonymous(new int[] {count}); // anon vector
+      try{
+        v.setDimensionsAnonymous(new int[] {count}); // anon vector
+      }
+      catch (InvalidRangeException e){
+        log.error(e.getMessage());
+        log.debug("ERROR: makeVariableShapeAndType {}", e.getMessage());
+      }
     }
 
     if (fld.getDesc() != null) {
@@ -238,7 +260,13 @@ class BufrIospBuilder {
     if (dataDesc.type == 1) {
       v.setDataType(DataType.CHAR);
       int size = dataDesc.bitWidth / 8;
-      v.setDimensionsAnonymous(new int[] {size});
+      try{
+        v.setDimensionsAnonymous(new int[] {size});
+      }
+      catch (InvalidRangeException e){
+        log.error(e.getMessage());
+        log.debug("ERROR: makeVariableShapeAndType {}", e.getMessage());
+      }
 
     } else if ((dataDesc.type == 2) && CodeFlagTables.hasTable(dataDesc.fxy)) { // enum
       int nbits = dataDesc.bitWidth;

--- a/cdm/core/src/main/java/ucar/nc2/Variable.java
+++ b/cdm/core/src/main/java/ucar/nc2/Variable.java
@@ -2062,7 +2062,7 @@ public class Variable extends CDMNode implements VariableSimpleIF, ProxyReader, 
         if ((shape[i] < 1) && (shape[i] != -1))
           throw new InvalidRangeException("shape[" + i + "]=" + shape[i] + " must be > 0");
       }
-        this.dimensions = new ArrayList<>(Dimensions.makeDimensionsAnon(shape));
+      this.dimensions = new ArrayList<>(Dimensions.makeDimensionsAnon(shape));
       return self();
     }
 

--- a/cdm/core/src/main/java/ucar/nc2/Variable.java
+++ b/cdm/core/src/main/java/ucar/nc2/Variable.java
@@ -2055,10 +2055,14 @@ public class Variable extends CDMNode implements VariableSimpleIF, ProxyReader, 
      * Set the dimensions using all anonymous (unshared) dimensions
      *
      * @param shape defines the dimension lengths. must be > 0, or -1 for VLEN
-     * @throws RuntimeException if any shape < 1 and not -1.
+     * @throws InvalidRangeException if any shape < 1 and not -1.
      */
-    public T setDimensionsAnonymous(int[] shape) {
-      this.dimensions = new ArrayList<>(Dimensions.makeDimensionsAnon(shape));
+    public T setDimensionsAnonymous(int[] shape) throws InvalidRangeException {
+      for (int i = 0; i < shape.length; i++) {
+        if ((shape[i] < 1) && (shape[i] != -1))
+          throw new InvalidRangeException("shape[" + i + "]=" + shape[i] + " must be > 0");
+      }
+        this.dimensions = new ArrayList<>(Dimensions.makeDimensionsAnon(shape));
       return self();
     }
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf4/H4header.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf4/H4header.java
@@ -778,7 +778,7 @@ public class H4header implements HdfHeaderIF {
     if (vh.nfields < 1)
       throw new IllegalStateException();
 
-    try{
+    try {
       Variable.Builder vb;
       if (vh.nfields == 1) {
         // String name = createValidObjectName(vh.name);
@@ -841,8 +841,7 @@ public class H4header implements HdfHeaderIF {
       }
 
       return vb;
-    }
-    catch (InvalidRangeException e){
+    } catch (InvalidRangeException e) {
       log.error(e.getMessage());
       throw new IllegalStateException(e.getMessage());
     }
@@ -946,8 +945,7 @@ public class H4header implements HdfHeaderIF {
     if (!ok) {
       try {
         vb.setDimensionsAnonymous(dim.shape);
-      }
-      catch (InvalidRangeException e){
+      } catch (InvalidRangeException e) {
         log.error(e.getMessage());
       }
     }
@@ -997,10 +995,9 @@ public class H4header implements HdfHeaderIF {
       throw new IllegalStateException();
 
     Variable.Builder vb = Variable.builder().setName("SDS-" + group.refno);
-    try{
+    try {
       vb.setDimensionsAnonymous(dim.shape);
-    }
-    catch (InvalidRangeException e){
+    } catch (InvalidRangeException e) {
       log.error(e.getMessage());
     }
     DataType dataType = H4type.setDataType(nt.type, null);

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
@@ -1544,7 +1544,13 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       else
         v.setDimensionsByName(dimNames);
     } else {
-      v.setDimensionsAnonymous(shape);
+        try{
+          v.setDimensionsAnonymous(shape);
+        }
+        catch (InvalidRangeException e){
+          log.error(e.getMessage());
+          return false;
+        }
     }
 
     // set the type

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
@@ -1544,13 +1544,12 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       else
         v.setDimensionsByName(dimNames);
     } else {
-        try{
-          v.setDimensionsAnonymous(shape);
-        }
-        catch (InvalidRangeException e){
-          log.error(e.getMessage());
-          return false;
-        }
+      try {
+        v.setDimensionsAnonymous(shape);
+      } catch (InvalidRangeException e) {
+        log.error(e.getMessage());
+        return false;
+      }
     }
 
     // set the type

--- a/cdm/core/src/test/java/ucar/nc2/TestVariableBuilder.java
+++ b/cdm/core/src/test/java/ucar/nc2/TestVariableBuilder.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import static ucar.nc2.TestUtils.makeDummyGroup;
 import org.junit.Test;
 import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Section;
 
 public class TestVariableBuilder {
@@ -42,7 +43,7 @@ public class TestVariableBuilder {
   }
 
   @Test
-  public void testWithAnonymousDims() {
+  public void testWithAnonymousDims() throws InvalidRangeException {
     int[] shape = new int[] {3, 6, -1};
     Variable var = Variable.builder().setName("name").setDataType(DataType.FLOAT).setDimensionsAnonymous(shape)
         .build(makeDummyGroup());
@@ -53,6 +54,13 @@ public class TestVariableBuilder {
     assertThat(var.getShape()).isEqualTo(new int[] {3, 6, -1});
     assertThat(var.getShapeAsSection()).isEqualTo(new Section(new int[] {3, 6, -1}));
   }
+
+  @Test (expected = ucar.ma2.InvalidRangeException.class)
+  public void testWithZeroDims() throws InvalidRangeException {
+    int[] shape = new int[] {3, 6, 0};
+    Variable var = Variable.builder().setName("name").setDataType(DataType.FLOAT).setDimensionsAnonymous(shape)
+            .build(makeDummyGroup());
+   }
 
   @Test
   public void testCopy() {

--- a/cdm/core/src/test/java/ucar/nc2/TestVariableBuilder.java
+++ b/cdm/core/src/test/java/ucar/nc2/TestVariableBuilder.java
@@ -55,12 +55,12 @@ public class TestVariableBuilder {
     assertThat(var.getShapeAsSection()).isEqualTo(new Section(new int[] {3, 6, -1}));
   }
 
-  @Test (expected = ucar.ma2.InvalidRangeException.class)
+  @Test(expected = ucar.ma2.InvalidRangeException.class)
   public void testWithZeroDims() throws InvalidRangeException {
     int[] shape = new int[] {3, 6, 0};
     Variable var = Variable.builder().setName("name").setDataType(DataType.FLOAT).setDimensionsAnonymous(shape)
-            .build(makeDummyGroup());
-   }
+        .build(makeDummyGroup());
+  }
 
   @Test
   public void testCopy() {

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestVariableDSBuilder.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestVariableDSBuilder.java
@@ -7,10 +7,7 @@ import static ucar.nc2.TestUtils.makeDummyGroup;
 import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
-import ucar.ma2.Array;
-import ucar.ma2.DataType;
-import ucar.ma2.IndexIterator;
-import ucar.ma2.Section;
+import ucar.ma2.*;
 import ucar.nc2.Attribute;
 import ucar.nc2.Dimension;
 import ucar.nc2.Group;
@@ -77,7 +74,7 @@ public class TestVariableDSBuilder {
   }
 
   @Test
-  public void testWithAnonymousDims() {
+  public void testWithAnonymousDims() throws InvalidRangeException {
     // No parent group needed
     int[] shape = new int[] {3, 6, -1};
     VariableDS var = VariableDS.builder().setName("name").setDataType(DataType.FLOAT).setDimensionsAnonymous(shape)


### PR DESCRIPTION
## Description of Changes

_Mimic behavior of version 4 when reading a HDF5 file with a variable where one of the dimensions is 0. Provide warning in the log but do not error out. Addresses Unidata/netcdf-java/issues/1037_

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
