### PR TITLE
Fix projection unit logging

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -670,7 +670,6 @@ public class HorizCoordSys {
     } else if (unit.equals("m") || unit.equals("meters")) {
       return 0.001 * coordinate;
     } else {
-      logger.info("Unrecognized unit '" + unit + "' for axis '" + axisName + "'");
       return coordinate;
     }
   }
@@ -681,7 +680,6 @@ public class HorizCoordSys {
     } else if (desiredUnit.equals("m") || desiredUnit.equals("meters")) {
       return 1000 * coordinateInKm;
     } else {
-      logger.info("Unrecognized unit '" + desiredUnit + "' for axis '" + axisName + "'");
       return coordinateInKm;
     }
   }

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -664,6 +664,8 @@ public class HorizCoordSys {
   }
 
   // TODO is there a better place to handle units?
+  // Some projections are actually just rotations (RotatedPole)
+  // so the "projection" coordinates have units "degrees" and don't need to be converted
   private static double convertToKm(double coordinate, String unit, String axisName) {
     if (unit.equals("km") || unit.equals("kilometers")) {
       return coordinate;

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/Projection.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/Projection.java
@@ -10,6 +10,7 @@ import ucar.unidata.util.Parameter;
 /**
  * Projective geometry transformations from (lat,lon) to (x,y) on
  * a projective cartesian surface.
+ * Unless it is a rotation from (lat,lon) to (lat,lon).
  * 
  * @author John Caron
  *         LOOK will be immutable AutoValue in ver6


### PR DESCRIPTION
## Description of Changes

Remove log message that gets logged too many times (this function is called for every boundary point) and isn't helpful (some projections, like RotatedPole aren't actually projections but rotations, so their "projection" coordinates have units "degrees" which should not be logged as a problem here). See issue: https://github.com/Unidata/tds/issues/286

Probably my original fix that added this log message, for converting between km and m in projection coordinates, isn't the optimal place to handle the units but I will leave that for another time to look into.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
