### PR TITLE
Change cache name

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
@@ -354,8 +354,8 @@ public class NetcdfDataset extends ucar.nc2.NetcdfFile {
   @Deprecated
   public static synchronized void initNetcdfFileCache(int minElementsInMemory, int maxElementsInMemory, int hardLimit,
       int period) {
-    netcdfFileCache = new ucar.nc2.util.cache.FileCache("NetcdfFileCache ", minElementsInMemory, maxElementsInMemory,
-        hardLimit, period);
+    netcdfFileCache = new ucar.nc2.util.cache.FileCache("NetcdfFileCache (deprecated)", minElementsInMemory,
+        maxElementsInMemory, hardLimit, period);
   }
 
   /** @deprecated use NetcdfDatasets.disableNetcdfFileCache */

--- a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDatasets.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDatasets.java
@@ -63,7 +63,7 @@ public class NetcdfDatasets {
    */
   public static synchronized void initNetcdfFileCache(int minElementsInMemory, int maxElementsInMemory, int hardLimit,
       int period) {
-    netcdfFileCache = new FileCache("NetcdfFileCache ", minElementsInMemory, maxElementsInMemory, hardLimit, period);
+    netcdfFileCache = new FileCache("NetcdfFileCache", minElementsInMemory, maxElementsInMemory, hardLimit, period);
   }
 
   public static synchronized void disableNetcdfFileCache() {


### PR DESCRIPTION
## Description of Changes

If you use `thredds/admin/debug?Caches/showCaches` page, you see two `NetcdfFileCache`s. This change would rename the deprecated one so you can distinguish them in the admin service.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
