### PR TITLE
upgrade protobuf and jackson libraries

### DIFF
--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -22,5 +22,5 @@ ext {
   // coords.
   depVersion = [:]
   depVersion.slf4j = '1.7.28'
-  depVersion.protobuf = '3.19.3'
+  depVersion.protobuf = '3.21.7'
 }

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
   compile 'com.amazonaws:aws-java-sdk-s3'  // For CrawlableDatasetAmazonS3.
   constraints {
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.13.2.1') {
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1') {
       because 'Replacement v2.6.7.3, which is recomended by aws-java-sdk v1.x for those who do'
       'not need java 6 compatibility - see https://github.com/aws/aws-sdk-java#cve-2017-15095--cve-2018-7489'
     }

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -11,7 +11,7 @@ javaPlatform {
 dependencies {
   def awsVersion = '2.17.290'
   api enforcedPlatform("software.amazon.awssdk:bom:${awsVersion}")
-  api enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.13.2.20220324')
+  api enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.14.0-rc1')
   constraints {
     // Note: The depVersion variable is defined in gradle/any/shared-mvn-coords.gradle and is used for dependencies
     // that are used in different configurations of a build that need access to the full maven coordinates.


### PR DESCRIPTION
addresses: [CVE-2202-3171](https://nvd.nist.gov/vuln/detail/CVE-2022-3171), [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003), and [CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004)
