### PR TITLE
Exclude netty nio client from aws sts dependency

### DIFF
--- a/cdm/s3/build.gradle
+++ b/cdm/s3/build.gradle
@@ -26,7 +26,10 @@ dependencies {
   implementation 'software.amazon.awssdk:apache-client'
   implementation 'com.google.code.findbugs:jsr305'
 
-  runtimeOnly 'software.amazon.awssdk:sts'
+  runtimeOnly('software.amazon.awssdk:sts') {
+    // see above comment about awssdk and netty-nio-client
+    exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
+  }
 
   testImplementation project(':cdm:cdm-radial')
   testImplementation project(':cdm-test-utils')


### PR DESCRIPTION
Make sure we do not drag in a transitive dependency on netty-nio-client from aws sts. Sorry I missed that in my first sts related PR.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
