### PR TITLE
Fix grib config time unit conversion

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionTimeUnits.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionTimeUnits.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 1998-2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package ucar.nc2.grib;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import thredds.featurecollection.FeatureCollectionConfig;
+import thredds.featurecollection.FeatureCollectionType;
+import thredds.inventory.*;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.CoordinateAxis;
+import ucar.nc2.dataset.CoordinateAxis1D;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.grib.collection.GribCdmIndex;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+public class TestGribCollectionTimeUnits {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  // Grib collection with mixture of hours and minutes
+  private static final String NAME = "testCollectionUnits";
+  private static final String MIXED_UNITS_SPEC =
+      TestDir.cdmUnitTestDir + "/tds/ncep/NDFD_NWS_CONUS_conduit_2p5km_#yyyyMMdd_HHmm#\\.grib2$";
+  private static final String MIXED_UNITS_INDEX =
+      TestDir.cdmUnitTestDir + "/tds/ncep/testCollectionUnits" + GribCdmIndex.NCX_SUFFIX;
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void shouldUseDefaultUnitsInGrib2Collection() throws IOException {
+    final FeatureCollectionConfig config = new FeatureCollectionConfig(NAME, NAME, FeatureCollectionType.GRIB2,
+        MIXED_UNITS_SPEC, null, null, null, "file", null);
+
+    assertThat(config.gribConfig.getTimeUnitConverter()).isEqualTo(null);
+    final double[] valuesInHoursAndMinutes = new double[] {6.0, 12.0, 18.0, 24.0, 30.0, 36.0, 42.0, 48.0, 54.0, 60.0,
+        66.0, 72.0, 360.0, 720.0, 1080.0, 1440.0, 1800.0, 2160.0, 2520.0, 2880.0, 3240.0, 3600.0, 3960.0, 4320.0};
+    checkVariableNameAndTimeAxis(config, "Mixed_intervals", "time3", "Hour", valuesInHoursAndMinutes);
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void shouldConvertTimeToMinutesInGrib2Collection() throws IOException {
+    final FeatureCollectionConfig config = new FeatureCollectionConfig(NAME, NAME, FeatureCollectionType.GRIB2,
+        MIXED_UNITS_SPEC, null, null, null, "file", null);
+
+    setTimeUnitConversionFromHoursToMinutes(config);
+    final double[] valuesInMinutes =
+        new double[] {360.0, 720.0, 1080.0, 1440.0, 1800.0, 2160.0, 2520.0, 2880.0, 3240.0, 3600.0, 3960.0, 4320.0};
+    checkVariableNameAndTimeAxis(config, "360_Minute", "time2", "Minute", valuesInMinutes);
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void shouldConvertTimeToHoursInGrib2Collection() throws IOException {
+    final FeatureCollectionConfig config = new FeatureCollectionConfig(NAME, NAME, FeatureCollectionType.GRIB2,
+        MIXED_UNITS_SPEC, null, null, null, "file", null);
+
+    setTimeUnitConversionFromMinutesToHours(config);
+    // hours get rounded down due to refdate being on the half hour
+    final double[] valuesInHours = new double[] {5.0, 11.0, 17.0, 23.0, 29.0, 35.0, 41.0, 47.0, 53.0, 59.0, 65.0, 71.0};
+    checkVariableNameAndTimeAxis(config, "6_Hour", "time2", "Hour", valuesInHours);
+  }
+
+  private void setTimeUnitConversionFromMinutesToHours(FeatureCollectionConfig config) {
+    config.gribConfig.addTimeUnitConvert("0", "1");
+  }
+
+  private void setTimeUnitConversionFromHoursToMinutes(FeatureCollectionConfig config) {
+    config.gribConfig.addTimeUnitConvert("1", "0");
+  }
+
+  private void checkVariableNameAndTimeAxis(FeatureCollectionConfig config, String intervalName, String timeAxis,
+      String units, double[] values) throws IOException {
+    final boolean changed = GribCdmIndex.updateGribCollection(config, CollectionUpdateType.always, logger);
+    assertThat(changed).isTrue();
+
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(MIXED_UNITS_INDEX)) {
+      final Variable variable =
+          netcdfDataset.findVariable("Best/Total_precipitation_surface_" + intervalName + "_Accumulation");
+      assertThat((Iterable<?>) variable).isNotNull();
+      assertThat(variable.getDimensionsString()).isEqualTo(timeAxis + " y x");
+      final CoordinateAxis coordinateAxis = netcdfDataset.findCoordinateAxis("Best/" + timeAxis);
+      assertThat((Iterable<?>) coordinateAxis).isNotNull();
+      assertThat(coordinateAxis.getUnitsString()).contains(units);
+      assertThat(((CoordinateAxis1D) coordinateAxis).getCoordValues()).isEqualTo(values);
+    }
+  }
+}
+

--- a/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
+++ b/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
@@ -167,7 +167,7 @@ public class CalendarPeriod {
 
   /**
    * Subtract two dates, return difference in units of this period.
-   * If not even, will round down (floor) and log a warning
+   * If not even, will round down (take the floor)
    * 
    * @param start start date
    * @param end end date
@@ -176,8 +176,6 @@ public class CalendarPeriod {
   public int subtract(CalendarDate start, CalendarDate end) {
     long diff = end.getDifferenceInMsecs(start);
     int thislen = millisecs();
-    if ((diff % thislen != 0))
-      log.warn("roundoff error");
     return (int) Math.floor(diff / (float) thislen);
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
+++ b/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
@@ -7,8 +7,6 @@ package ucar.nc2.time;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import org.joda.time.DurationFieldType;
-import org.joda.time.Period;
 import org.joda.time.PeriodType;
 import ucar.nc2.units.TimeDuration;
 import ucar.unidata.util.StringUtil2;
@@ -169,7 +167,7 @@ public class CalendarPeriod {
 
   /**
    * Subtract two dates, return difference in units of this period.
-   * If not even, will round down and log a warning
+   * If not even, will round down (floor) and log a warning
    * 
    * @param start start date
    * @param end end date
@@ -180,7 +178,7 @@ public class CalendarPeriod {
     int thislen = millisecs();
     if ((diff % thislen != 0))
       log.warn("roundoff error");
-    return (int) (diff / thislen);
+    return (int) Math.floor(diff / (float) thislen);
   }
 
   /**
@@ -238,20 +236,13 @@ public class CalendarPeriod {
 
   // offset from start to end, in these units
   // start + offset = end
+  // takes the floor when rounding
   public int getOffset(CalendarDate start, CalendarDate end) {
     if (start.equals(end)) {
       return 0;
     }
-    Period p = new Period(start.getMillis(), end.getMillis(), getPeriodType());
-    return p.get(getDurationFieldType());
-  }
 
-  PeriodType getPeriodType() {
-    return getField().p;
-  }
-
-  DurationFieldType getDurationFieldType() {
-    return getField().p.getFieldType(0);
+    return subtract(start, end);
   }
 
   @Override

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -564,7 +564,7 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
     if (wantPeriod == null) {
       return null;
     }
-    CalendarPeriod havePeriod = Grib2Utils.getCalendarPeriod(convertTimeUnit(intvu.timeUnitIntv));
+    CalendarPeriod havePeriod = Grib2Utils.getCalendarPeriod(intvu.timeUnitIntv);
     double fac2 = intvu.timeRange * wantPeriod.getConvertFactor(havePeriod);
     CalendarPeriod period = wantPeriod.multiply((int) fac2); // LOOK needs to be an int
 

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -38,6 +38,7 @@ import java.util.*;
  * @since 4/3/11
  */
 @Immutable
+// TODO version 6: remove implements TimeUnitConverter
 public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Grib2Tables.class);
   private static final Map<Grib2TablesId, Grib2Tables> tables = new HashMap<>();
@@ -460,12 +461,20 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
 
   private TimeUnitConverter timeUnitConverter; // LOOK not really immutable
 
+  /**
+   * @deprecated Remove in version 6, functionality moved to Grib2CollectionBuilder
+   */
+  @Deprecated
   public void setTimeUnitConverter(TimeUnitConverter timeUnitConverter) {
     if (this.timeUnitConverter != null)
       throw new RuntimeException("Cant modify timeUnitConverter once its been set");
     this.timeUnitConverter = timeUnitConverter;
   }
 
+  /**
+   * @deprecated Remove in version 6, functionality moved to Grib2CollectionBuilder
+   */
+  @Deprecated
   @Override
   public int convertTimeUnit(int timeUnit) {
     if (timeUnitConverter == null)

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -460,9 +460,8 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
 
   private TimeUnitConverter timeUnitConverter; // LOOK not really immutable
 
+  // Do not modify timeUnitConverter once it's been set
   public void setTimeUnitConverter(TimeUnitConverter timeUnitConverter) {
-    if (this.timeUnitConverter != null)
-      throw new RuntimeException("Cant modify timeUnitConverter once its been set");
     this.timeUnitConverter = timeUnitConverter;
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -491,7 +491,7 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
 
     } else {
       int val = pds.getForecastTime();
-      CalendarPeriod period = Grib2Utils.getCalendarPeriod(convertTimeUnit(pds.getTimeUnit()));
+      CalendarPeriod period = Grib2Utils.getCalendarPeriod(pds.getTimeUnit());
       if (period == null)
         return null;
       return gr.getReferenceDate().add(period.multiply(val));
@@ -569,7 +569,7 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
 
     // convert time "range" to units of pds timeUnits
     int timeUnitOrg = gr.getPDS().getTimeUnit();
-    CalendarPeriod wantPeriod = Grib2Utils.getCalendarPeriod(convertTimeUnit(timeUnitOrg));
+    CalendarPeriod wantPeriod = Grib2Utils.getCalendarPeriod(timeUnitOrg);
     if (wantPeriod == null) {
       return null;
     }
@@ -611,7 +611,7 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
     TimeIntervalAndUnits intvu = getForecastTimeInterval(pdsIntv);
 
     // convert that range to units of hours.
-    CalendarPeriod timeUnitPeriod = Grib2Utils.getCalendarPeriod(convertTimeUnit(intvu.timeUnitIntv));
+    CalendarPeriod timeUnitPeriod = Grib2Utils.getCalendarPeriod(intvu.timeUnitIntv);
     if (timeUnitPeriod == null)
       return GribNumbers.UNDEFINEDD;
     if (timeUnitPeriod.equals(CalendarPeriod.Hour))
@@ -725,7 +725,7 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
       return null;
 
     Grib2Pds pds = gr.getPDS();
-    int unit = convertTimeUnit(pds.getTimeUnit());
+    int unit = pds.getTimeUnit();
     TimeCoordIntvValue tinv = tinvd.convertReferenceDate(gr.getReferenceDate(), Grib2Utils.getCalendarPeriod(unit));
     if (tinv == null)
       return null;

--- a/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/table/Grib2Tables.java
@@ -460,8 +460,9 @@ public class Grib2Tables implements ucar.nc2.grib.GribTables, TimeUnitConverter 
 
   private TimeUnitConverter timeUnitConverter; // LOOK not really immutable
 
-  // Do not modify timeUnitConverter once it's been set
   public void setTimeUnitConverter(TimeUnitConverter timeUnitConverter) {
+    if (this.timeUnitConverter != null)
+      throw new RuntimeException("Cant modify timeUnitConverter once its been set");
     this.timeUnitConverter = timeUnitConverter;
   }
 

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
@@ -1,5 +1,6 @@
 package ucar.nc2.grib.coord;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,5 +27,34 @@ public class TestTimeCoord {
     assertEquals("2010-03-29T00:00:00Z", refDate.toString());
   }
 
+  @Test
+  public void shouldPreserveTimeIntervalLengthWithStartAfterRefDate() {
+    final CalendarDate start = CalendarDate.parseISOformat(null, "2022-08-16T01:00:00Z");
+    final CalendarDate end = CalendarDate.parseISOformat(null, "2022-08-16T12:00:00Z");
+    final TimeCoordIntvDateValue timeCoordIntvDateValue = new TimeCoordIntvDateValue(start, end);
+
+    final CalendarDate refDate = CalendarDate.parseISOformat(null, "2022-08-16T00:30:00Z");
+    final CalendarPeriod timeUnit = CalendarPeriod.of("Hour");
+
+    final TimeCoordIntvValue timeCoordIntvValue = timeCoordIntvDateValue.convertReferenceDate(refDate, timeUnit);
+    assertThat(timeCoordIntvValue.getBounds1()).isEqualTo(0);
+    assertThat(timeCoordIntvValue.getBounds2()).isEqualTo(11);
+    assertThat(timeCoordIntvValue.getIntervalSize()).isEqualTo(11);
+  }
+
+  @Test
+  public void shouldPreserveTimeIntervalLengthWithStartBeforeRefDate() {
+    final CalendarDate start = CalendarDate.parseISOformat(null, "2022-08-16T01:00:00Z");
+    final CalendarDate end = CalendarDate.parseISOformat(null, "2022-08-16T12:00:00Z");
+    final TimeCoordIntvDateValue timeCoordIntvDateValue = new TimeCoordIntvDateValue(start, end);
+
+    final CalendarDate refDate = CalendarDate.parseISOformat(null, "2022-08-16T01:30:00Z");
+    final CalendarPeriod timeUnit = CalendarPeriod.of("Hour");
+
+    final TimeCoordIntvValue timeCoordIntvValue = timeCoordIntvDateValue.convertReferenceDate(refDate, timeUnit);
+    assertThat(timeCoordIntvValue.getBounds1()).isEqualTo(-1);
+    assertThat(timeCoordIntvValue.getBounds2()).isEqualTo(10);
+    assertThat(timeCoordIntvValue.getIntervalSize()).isEqualTo(11);
+  }
 }
 

--- a/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
@@ -6,31 +6,14 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
-import java.util.List;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import thredds.featurecollection.FeatureCollectionConfig.TimeUnitConverterHash;
-import thredds.inventory.CollectionUpdateType;
-import thredds.inventory.MFile;
-import thredds.inventory.MFiles;
-import ucar.nc2.grib.GribIndex;
 import ucar.nc2.grib.GribTables;
-import ucar.nc2.grib.coord.TimeCoordIntvDateValue;
-import ucar.nc2.grib.grib2.Grib2Index;
-import ucar.nc2.grib.grib2.Grib2Record;
-import ucar.nc2.time.CalendarDate;
-import ucar.unidata.util.test.TestDir;
-import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 @RunWith(JUnit4.class)
 public class TestLocalTables {
-  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
   public void testLocalTables() throws IOException {
@@ -73,44 +56,5 @@ public class TestLocalTables {
         assertThat(ecmwfTable.getCodeTableValue(tableName, entry.getCode())).isEqualTo(entry.getName());
       }
     }
-  }
-
-  @Test
-  @Category(NeedsCdmUnitTest.class)
-  public void shouldUseUnitConverterWhenCreatingForecastInterval() throws IOException {
-    final MFile file =
-        MFiles.create(TestDir.cdmUnitTestDir + "/tds/ncep/NDFD_NWS_CONUS_conduit_2p5km_20220816_0030.grib2");
-    assertThat(file).isNotNull();
-
-    final Grib2Index gribIndex =
-        (Grib2Index) GribIndex.readOrCreateIndexFromSingleFile(false, file, CollectionUpdateType.always, logger);
-    final List<Grib2Record> records = gribIndex.getRecords();
-    assertThat(records).isNotEmpty();
-    final Grib2Record record = records.get(0);
-    final Grib2Tables tables = Grib2Tables.factory(record);
-
-    final CalendarDate start = CalendarDate.parseISOformat(null, "2022-08-18T00:00:00Z");
-    final CalendarDate end = CalendarDate.parseISOformat(null, "2022-08-18T12:00:00Z");
-    final TimeCoordIntvDateValue expectedInterval = new TimeCoordIntvDateValue(start, end);
-
-    // default units
-    final TimeCoordIntvDateValue interval = tables.getForecastTimeInterval(record);
-    assertThat(interval).isEqualTo(expectedInterval);
-
-    // convert hours to minutes
-    final TimeUnitConverterHash hoursToMinutesConverter = new TimeUnitConverterHash();
-    hoursToMinutesConverter.map.put(1, 0);
-    tables.setTimeUnitConverter(hoursToMinutesConverter);
-
-    final TimeCoordIntvDateValue intervalHoursToMinutes = tables.getForecastTimeInterval(record);
-    assertThat(intervalHoursToMinutes).isEqualTo(expectedInterval);
-
-    // convert minutes to hour
-    final TimeUnitConverterHash minutesToHoursConverter = new TimeUnitConverterHash();
-    minutesToHoursConverter.map.put(0, 1);
-    tables.setTimeUnitConverter(minutesToHoursConverter);
-
-    final TimeCoordIntvDateValue intervalMinutesToHours = tables.getForecastTimeInterval(record);
-    assertThat(intervalMinutesToHours).isEqualTo(expectedInterval);
   }
 }

--- a/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
+++ b/grib/src/test/java/ucar/nc2/grib/grib2/table/TestLocalTables.java
@@ -6,14 +6,31 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
+import java.util.List;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import thredds.featurecollection.FeatureCollectionConfig.TimeUnitConverterHash;
+import thredds.inventory.CollectionUpdateType;
+import thredds.inventory.MFile;
+import thredds.inventory.MFiles;
+import ucar.nc2.grib.GribIndex;
 import ucar.nc2.grib.GribTables;
+import ucar.nc2.grib.coord.TimeCoordIntvDateValue;
+import ucar.nc2.grib.grib2.Grib2Index;
+import ucar.nc2.grib.grib2.Grib2Record;
+import ucar.nc2.time.CalendarDate;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 @RunWith(JUnit4.class)
 public class TestLocalTables {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
   public void testLocalTables() throws IOException {
@@ -56,5 +73,44 @@ public class TestLocalTables {
         assertThat(ecmwfTable.getCodeTableValue(tableName, entry.getCode())).isEqualTo(entry.getName());
       }
     }
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void shouldUseUnitConverterWhenCreatingForecastInterval() throws IOException {
+    final MFile file =
+        MFiles.create(TestDir.cdmUnitTestDir + "/tds/ncep/NDFD_NWS_CONUS_conduit_2p5km_20220816_0030.grib2");
+    assertThat(file).isNotNull();
+
+    final Grib2Index gribIndex =
+        (Grib2Index) GribIndex.readOrCreateIndexFromSingleFile(false, file, CollectionUpdateType.always, logger);
+    final List<Grib2Record> records = gribIndex.getRecords();
+    assertThat(records).isNotEmpty();
+    final Grib2Record record = records.get(0);
+    final Grib2Tables tables = Grib2Tables.factory(record);
+
+    final CalendarDate start = CalendarDate.parseISOformat(null, "2022-08-18T00:00:00Z");
+    final CalendarDate end = CalendarDate.parseISOformat(null, "2022-08-18T12:00:00Z");
+    final TimeCoordIntvDateValue expectedInterval = new TimeCoordIntvDateValue(start, end);
+
+    // default units
+    final TimeCoordIntvDateValue interval = tables.getForecastTimeInterval(record);
+    assertThat(interval).isEqualTo(expectedInterval);
+
+    // convert hours to minutes
+    final TimeUnitConverterHash hoursToMinutesConverter = new TimeUnitConverterHash();
+    hoursToMinutesConverter.map.put(1, 0);
+    tables.setTimeUnitConverter(hoursToMinutesConverter);
+
+    final TimeCoordIntvDateValue intervalHoursToMinutes = tables.getForecastTimeInterval(record);
+    assertThat(intervalHoursToMinutes).isEqualTo(expectedInterval);
+
+    // convert minutes to hour
+    final TimeUnitConverterHash minutesToHoursConverter = new TimeUnitConverterHash();
+    minutesToHoursConverter.map.put(0, 1);
+    tables.setTimeUnitConverter(minutesToHoursConverter);
+
+    final TimeCoordIntvDateValue intervalMinutesToHours = tables.getForecastTimeInterval(record);
+    assertThat(intervalMinutesToHours).isEqualTo(expectedInterval);
   }
 }


### PR DESCRIPTION
## Description of Changes

Sometimes, like on our thredds server, a grib collection has some files/records with time units in minutes, and some in hours. Then variables that depend on that time coordinate will be labeled "mixed_intervals" even if the intervals are the same lengths but with different units. This PR addresses issues with unit conversion so that we can fix this issue on our thredds server by adding something like this to a grib collection we want to have units in hours:

```
    <gribConfig>
      <timeUnitConvert from="0" to="1"/>
    </gribConfig>
```

- Add tests for various changes. Also added two new files to the thredds-test-data on lead for these tests.
- Fix rounding of time interval offsets in `CalendarPeriod`: previously interval offsets (with respect to a reference) were rounded towards zero, which caused the intervals to be shorter if the reference date came after the start than if it came before the start.
- Fix bug in the logic of unit conversion in `getForecastTimeInterval`
- Allow `setTimeUnitConverter` to be modified after it is set. If you try to update a collection index, then it may already have a `timeUnitConverter` set and try to reset it, so will fail to update the index. Maybe users shouldn't call this and expect it to change the units after the index is created though, so I kept a comment here.
- I have not updated the documentation that says not to use the parameter `timeUnitConvert`. Perhaps we should first make sure this fix is working as we expect and that more cases are tested before telling users to use this.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
