### PR TITLE
Do not write internal attributes

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerWriter.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Formatter;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.IndexIterator;
@@ -215,7 +217,10 @@ class N3headerWriter extends N3headerNew {
 
   private void writeAtts(Iterable<Attribute> atts, Formatter fout) throws IOException {
 
-    int n = Iterables.size(atts);
+    final List<Attribute> attributesToWrite = StreamSupport.stream(atts.spliterator(), false)
+        .filter(att -> !Attribute.isspecial(att)).collect(Collectors.toList());
+
+    int n = Iterables.size(attributesToWrite);
     if (n == 0) {
       raf.writeInt(0);
       raf.writeInt(0);
@@ -225,7 +230,7 @@ class N3headerWriter extends N3headerNew {
     }
 
     int count = 0;
-    for (Attribute att : atts) {
+    for (Attribute att : attributesToWrite) {
       if (fout != null)
         fout.format("***att %d pos= %d%n", count, raf.getFilePointer());
 

--- a/cdm/core/src/test/java/ucar/nc2/write/TestWrite.java
+++ b/cdm/core/src/test/java/ucar/nc2/write/TestWrite.java
@@ -4,6 +4,8 @@
  */
 package ucar.nc2.write;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runners.MethodSorters;
@@ -19,6 +21,7 @@ import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
 import ucar.nc2.Variable;
+import ucar.nc2.constants.CDM;
 
 /** Test NetcdfFormatWriter */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -72,6 +75,7 @@ public class TestWrite {
     writerb.addAttribute(new Attribute("versionI", 1));
     writerb.addAttribute(new Attribute("versionS", (short) 2));
     writerb.addAttribute(new Attribute("versionB", (byte) 3));
+    writerb.addAttribute(new Attribute(CDM.NCPROPERTIES, "test internal attribute is removed when writing"));
 
     // test some errors
     try {
@@ -205,6 +209,13 @@ public class TestWrite {
         e.printStackTrace();
         assert (false);
       }
+    }
+  }
+
+  @Test
+  public void shouldRemoveInternalAttribute() throws IOException {
+    try (NetcdfFile netcdfFile = NetcdfFiles.open(writerLocation)) {
+      assertThat(netcdfFile.findGlobalAttributeIgnoreCase(CDM.NCPROPERTIES)).isNull();
     }
   }
 


### PR DESCRIPTION
## Description of Changes

Part of the fixes related to https://github.com/Unidata/tds/issues/284, the rest are in [this PR in the TDS repo.](https://github.com/Unidata/tds/pull/307)

Special attributes such as _NCProperties should not be written out, and this is already handled in some places like for netcdf4, just not for netcdf3. This PR fixes this for netcdf3 and adds a test.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
