### PR TITLE
Fix some misuses of substring(), with some unittests

### DIFF
--- a/cdm/core/src/main/java/thredds/inventory/CollectionGlob.java
+++ b/cdm/core/src/main/java/thredds/inventory/CollectionGlob.java
@@ -58,7 +58,7 @@ public class CollectionGlob extends CollectionAbstract {
 
     // lets suppose the first "*" indicates the top dir
     int pos = glob.indexOf("*");
-    this.root = glob.substring(0, pos - 1);
+    this.root = glob.substring(0, pos);
     String match = glob.substring(pos);
 
     // count how far to recurse. LAME!!! why doesnt java provide the right thing !!!!

--- a/cdm/core/src/test/java/thredds/inventory/TestCollectionGlob.java
+++ b/cdm/core/src/test/java/thredds/inventory/TestCollectionGlob.java
@@ -20,11 +20,17 @@ public class TestCollectionGlob {
     return Arrays.asList(new Object[][] {
 
         {"foo*.nc", "foo", 0},
+
         {"foo/*.nc", "foo/", 0},
+
         {"foo/*/bar.nc", "foo/", 1},
+
         {"**/bar.nc", "", 1},
+
         {"foo*/bar/baz.nc", "foo", 2},
+
         {"foo*/bar/**/baz.nc", "foo", Integer.MAX_VALUE},
+
     });
   }
 

--- a/cdm/core/src/test/java/thredds/inventory/TestCollectionGlob.java
+++ b/cdm/core/src/test/java/thredds/inventory/TestCollectionGlob.java
@@ -1,0 +1,48 @@
+package thredds.inventory;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.lang.invoke.MethodHandles;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Parameterized.class)
+public class TestCollectionGlob {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> getTestParameters() {
+    return Arrays.asList(new Object[][] {
+
+        {"foo*.nc", "foo", 0},
+        {"foo/*.nc", "foo/", 0},
+        {"foo/*/bar.nc", "foo/", 1},
+        {"**/bar.nc", "", 1},
+        {"foo*/bar/baz.nc", "foo", 2},
+        {"foo*/bar/**/baz.nc", "foo", Integer.MAX_VALUE},
+    });
+  }
+
+  private final String spec;
+  private final String root;
+  private final int depth;
+
+  public TestCollectionGlob(String spec, String root, int depth) {
+    this.spec = spec;
+    this.root = root;
+    this.depth = depth;
+  }
+
+  @Test
+  public void nominalGlobbing() {
+    CollectionGlob globber;
+    globber = new CollectionGlob("fooName", spec, logger);
+    assertThat(globber.root).isEqualTo(root);
+    assertThat(globber.depth).isEqualTo(depth);
+  }
+}

--- a/cdm/s3/src/main/java/ucar/unidata/io/s3/CdmS3Client.java
+++ b/cdm/s3/src/main/java/ucar/unidata/io/s3/CdmS3Client.java
@@ -114,6 +114,9 @@ public class CdmS3Client {
    */
   public static S3Client acquire(CdmS3Uri uri) throws IOException {
     CdmS3Uri key = makeKey(uri);
+    if (key == null) {
+      throw new IOException("Failed to make cache key from the given URI");
+    }
     S3Client s3Client;
     try {
       s3Client = useCache ? s3ClientCache.get(key) : createS3Client(uri);
@@ -137,7 +140,7 @@ public class CdmS3Client {
       int chop = bucketUriString.lastIndexOf("?" + cdmS3Uri.getKey().get());
       // remove everything after the ?key portion of the URI (retains authority and path (bucket) of URI)
       if (chop > 0) {
-        bucketUriString = bucketUriString.substring(0, chop - 1);
+        bucketUriString = bucketUriString.substring(0, chop);
       }
     }
 


### PR DESCRIPTION
## Description of Changes

Discovered truncated CdmS3Uri's while investigating another bug. Traced it down to a misuse of substring(). I also did a cursory search for other possible misuses of substring, and found it in CollectionGlob. Both classes have no tests. While I could write some rudimentary tests for CollectionGlob, I could not do the same for CdmS3Client since makeKey() is private.

I also make no guarantee that I interpreted things correctly, nor do I claim I found every misuse of substrings().

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
