### PR TITLE
fix s3 buffer size

### DIFF
--- a/cdm/s3/src/main/java/ucar/unidata/io/s3/S3RandomAccessFile.java
+++ b/cdm/s3/src/main/java/ucar/unidata/io/s3/S3RandomAccessFile.java
@@ -163,10 +163,5 @@ public final class S3RandomAccessFile extends RemoteRandomAccessFile implements 
     public RandomAccessFile open(String location) throws IOException {
       return new S3RandomAccessFile(location);
     }
-
-    @Override
-    public RandomAccessFile open(String location, int bufferSize) throws IOException {
-      return new S3RandomAccessFile(location, bufferSize);
-    }
   }
 }


### PR DESCRIPTION
Remove override of default function so that NetcdfFiles `default_buffersize` of 8 kB is not used for s3. Related to https://github.com/Unidata/tds/issues/311

When an ncml dataset is opened, it calls the `open(String location, int bufferSize)` rather than the `open(String location)`. NetcdfFiles passes in the `default_buffersize` of 8 kB. This PR removes the `open(String location, int bufferSize)` override from `S3RandomAccessFile` so that the `open(String location)` is always used (the default from the base class calls this). Then the `S3RandomAccessFile` will use `s3BufferSize` which is by default 256 kB, and can be overridden as a system setting.

I tested the number of S3 requests before and after this change for a request involving a WMS request to `S3ExampleNcML/Agg.nc` in our test catalog. The aggregation involves 4 files that are 878 kB. Previously it did 15 HEAD and 208 GET requests and now it does 15 HEAD and 33 GET requests. I am not sure exactly why it does this number of requests, so there could be further optimizations.

## Description of Changes

_Erase this and add a general description of changes, heads-up on any tricky parts, etc., here._

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
