### PR TITLE
Fix index location in tests

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionTimeUnits.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionTimeUnits.java
@@ -31,8 +31,6 @@ public class TestGribCollectionTimeUnits {
   private static final String NAME = "testCollectionUnits";
   private static final String MIXED_UNITS_SPEC =
       TestDir.cdmUnitTestDir + "/tds/ncep/NDFD_NWS_CONUS_conduit_2p5km_#yyyyMMdd_HHmm#\\.grib2$";
-  private static final String MIXED_UNITS_INDEX =
-      TestDir.cdmUnitTestDir + "/tds/ncep/testCollectionUnits" + GribCdmIndex.NCX_SUFFIX;
 
   @Test
   @Category(NeedsCdmUnitTest.class)
@@ -82,8 +80,9 @@ public class TestGribCollectionTimeUnits {
       String units, double[] values) throws IOException {
     final boolean changed = GribCdmIndex.updateGribCollection(config, CollectionUpdateType.always, logger);
     assertThat(changed).isTrue();
+    final String topLevelIndex = GribCdmIndex.getTopIndexFileFromConfig(config).getAbsolutePath();
 
-    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(MIXED_UNITS_INDEX)) {
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(topLevelIndex)) {
       final Variable variable =
           netcdfDataset.findVariable("Best/Total_precipitation_surface_" + intervalName + "_Accumulation");
       assertThat((Iterable<?>) variable).isNotNull();


### PR DESCRIPTION
## Description of Changes

The tests added with annotation `NeedsCdmUnitTest` in https://github.com/Unidata/netcdf-java/pull/1099 are failing on Jenkins because the index file cannot be found. They pass for me locally. Maybe on Jenkins the index files are created in the cache instead of the data location. I think this will fix them.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
