### PR TITLE
Fix last modified for s3

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/iosp/AbstractIOServiceProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/AbstractIOServiceProvider.java
@@ -6,6 +6,8 @@
 package ucar.nc2.iosp;
 
 import javax.annotation.Nullable;
+import thredds.inventory.MFile;
+import thredds.inventory.MFiles;
 import ucar.ma2.Array;
 import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Section;
@@ -161,8 +163,8 @@ public abstract class AbstractIOServiceProvider implements IOServiceProvider {
    */
   public long getLastModified() {
     if (location != null) {
-      File file = new File(location);
-      return file.lastModified();
+      MFile file = MFiles.create(location);
+      return file != null ? file.getLastModified() : 0;
     } else {
       return 0;
     }

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
@@ -1,0 +1,17 @@
+package ucar.nc2.dataset;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+
+public class TestNetcdfDataset {
+
+  @Test
+  public void shouldGetLastModified() throws IOException {
+    final String location = "src/test/data/ncml/nc/jan.nc";
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(location)) {
+      assertThat(netcdfDataset.getLastModified()).isGreaterThan(0);
+    }
+  }
+}

--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3NetcdfDataset.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3NetcdfDataset.java
@@ -1,0 +1,19 @@
+package ucar.unidata.io.s3;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+public class TestS3NetcdfDataset {
+
+  @Test
+  public void shouldGetLastModifiedForS3File() throws IOException {
+    final String location = "cdms3:thredds-test-data?testData.nc";
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(location)) {
+      assertThat(netcdfDataset.getLastModified()).isGreaterThan(0);
+    }
+  }
+}


### PR DESCRIPTION
## Description of Changes

Fix the getLastModified function called by `NetcdfDataset::getLastModified` to work S3 files. Test for local and s3 files.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
