### PR TITLE
Update JNA version

### DIFF
--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     // netcdf4, dap4:d4lib
     // Tricky dependency here. We need to make sure that we keep in-line with the version
     // that chronicle-map uses in the TDS, or else we see bad things happen on the TDS side.
-    api 'net.java.dev.jna:jna:5.4.0'
+    api 'net.java.dev.jna:jna:5.12.1'
 
     // Annotations: Nullable
     api 'com.google.code.findbugs:jsr305:3.0.2'

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     // netcdf4, dap4:d4lib
     // Tricky dependency here. We need to make sure that we keep in-line with the version
     // that chronicle-map uses in the TDS, or else we see bad things happen on the TDS side.
-    api 'net.java.dev.jna:jna:5.8.0'
+    api 'net.java.dev.jna:jna:5.12.1'
 
     // Annotations: Nullable
     api 'com.google.code.findbugs:jsr305:3.0.2'

--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     // netcdf4, dap4:d4lib
     // Tricky dependency here. We need to make sure that we keep in-line with the version
     // that chronicle-map uses in the TDS, or else we see bad things happen on the TDS side.
-    api 'net.java.dev.jna:jna:5.12.1'
+    api 'net.java.dev.jna:jna:5.8.0'
 
     // Annotations: Nullable
     api 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
## Description of Changes

For JNA before version 5.7.0, use of JNA fails at runtime on MacOS with M1 chip.

This PR updates to current JNA version 5.12.1.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
