### PR TITLE
Write compact xml when it doesn't need to be human readable

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/fmrc/GridDatasetInv.java
@@ -395,6 +395,16 @@ public class GridDatasetInv {
   //////////////////////////////////////////////////////////////
 
   /**
+   * Write the XML representation to a compact String.
+   *
+   * @return the compact XML representation to a String.
+   */
+  public String writeCompactXML(Date lastModified) {
+    XMLOutputter fmt = new XMLOutputter(Format.getCompactFormat());
+    return fmt.outputString(writeDocument(lastModified));
+  }
+
+  /**
    * Write the XML representation to a String.
    *
    * @return the XML representation to a String.


### PR DESCRIPTION
## Description of Changes

This is a small optimization for the FMRC cache. When writing to the cache, the xml doesn't need to be human readable so we can save a bit of space by not pretty printing the xml. For a large file I was testing with, the value size in the cache went from 18kB to 15kB with this change. We could decided to further improve the cache values (smaller attribute names or just don't use xml at all), but this seemed like an easy starting place.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
