### PR TITLE
Null file catch before trying to read RAF

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/io/RandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/RandomAccessFile.java
@@ -730,10 +730,14 @@ public class RandomAccessFile implements DataInput, DataOutput, FileCacheable, C
    * @param b put data into this buffer
    * @param offset buffer offset
    * @param len this number of bytes
-   * @return actual number of bytes read
+   * @return actual number of bytes read, -1 if underlying random access file was closed
    * @throws IOException on io error
    */
   protected int read_(long pos, byte[] b, int offset, int len) throws IOException {
+    if (file == null) {
+      return -1;
+    }
+
     file.seek(pos);
     int n = file.read(b, offset, len);
     if (debugAccess) {

--- a/cdm/core/src/test/java/ucar/unidata/io/TestRandomAccessFile.java
+++ b/cdm/core/src/test/java/ucar/unidata/io/TestRandomAccessFile.java
@@ -208,6 +208,22 @@ public class TestRandomAccessFile {
   }
 
   @Test
+  public void testReadClosedRaf() throws IOException {
+    RandomAccessFile closedTempFile = new RandomAccessFile(TEST_FILE_PATH, "r", TEST_BUFFER_SIZE);
+    int n = 1;
+    byte[] expected = new byte[TEST_BUFFER_SIZE + n];
+    System.arraycopy(UTF8_BYTES, 0, expected, 0, TEST_BUFFER_SIZE);
+    System.arraycopy(new byte[n], 0, expected, TEST_BUFFER_SIZE, n);
+
+    closedTempFile.seek(0);
+    closedTempFile.close();
+
+    byte[] actual = new byte[TEST_BUFFER_SIZE + n];
+    closedTempFile.read(actual, 0, TEST_BUFFER_SIZE + n);
+    assertThat(arraysMatch(expected, actual, 0, 0, TEST_BUFFER_SIZE + n)).isTrue();
+  }
+
+  @Test
   public void testReadFully() throws IOException {
     // read fully, buff < file length
     testFile.seek(0);


### PR DESCRIPTION
## Description of Changes

Addresses null pointer exception part of https://github.com/Unidata/netcdf-java/issues/1103

Add catch to check for a null file before trying to seek/read it which would raise a NullPointerException. Return -1 to match behavior of file.read when it's reached the end of the file and nothing is read.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
