### PR TITLE
Fix race condition in the h5iosps

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
@@ -161,7 +161,6 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
    * 3) all variables' dimensions have a dimension scale
    */
 
-  private final RandomAccessFile raf;
   private final Group.Builder root;
   private final H5iospNew h5iosp;
 
@@ -185,8 +184,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
 
   private final Charset valueCharset;
 
-  H5headerNew(RandomAccessFile myRaf, Group.Builder root, H5iospNew h5iosp) {
-    this.raf = myRaf;
+  H5headerNew(Group.Builder root, H5iospNew h5iosp) {
     this.root = root;
     this.h5iosp = h5iosp;
     valueCharset = h5iosp.getValueCharset().orElse(StandardCharsets.UTF_8);
@@ -212,7 +210,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     }
     h5objects = new H5objects(this, debugOut, memTracker);
 
-    long actualSize = raf.length();
+    long actualSize = getRandomAccessFile().length();
 
     if (debugTracker)
       memTracker = new MemTracker(actualSize);
@@ -221,8 +219,8 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     boolean ok = false;
     long filePos = 0;
     while ((filePos < actualSize - 8)) {
-      raf.seek(filePos);
-      String magic = raf.readString(8);
+      getRandomAccessFile().seek(filePos);
+      String magic = getRandomAccessFile().readString(8);
       if (magic.equals(magicString)) {
         ok = true;
         break;
@@ -233,19 +231,19 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       throw new IOException("Not a netCDF4/HDF5 file ");
     }
     if (debug1) {
-      log.debug("H5header opened file to read:'{}' size= {}", raf.getLocation(), actualSize);
+      log.debug("H5header opened file to read:'{}' size= {}", getRandomAccessFile().getLocation(), actualSize);
     }
     // now we are positioned right after the header
 
     // header information is in le byte order
-    raf.order(RandomAccessFile.LITTLE_ENDIAN);
+    getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
 
-    long superblockStart = raf.getFilePointer() - 8;
+    long superblockStart = getRandomAccessFile().getFilePointer() - 8;
     if (debugTracker)
       memTracker.add("header", 0, superblockStart);
 
     // superblock version
-    byte versionSB = raf.readByte();
+    byte versionSB = getRandomAccessFile().readByte();
 
     if (versionSB < 2) {
       readSuperBlock1(superblockStart, versionSB);
@@ -281,43 +279,43 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     long eofAddress;
     long driverBlockAddress;
 
-    versionFSS = raf.readByte();
-    versionGroup = raf.readByte();
-    raf.readByte(); // skip 1 byte
-    versionSHMF = raf.readByte();
+    versionFSS = getRandomAccessFile().readByte();
+    versionGroup = getRandomAccessFile().readByte();
+    getRandomAccessFile().readByte(); // skip 1 byte
+    versionSHMF = getRandomAccessFile().readByte();
     if (debugDetail) {
       log.debug(" versionSB= " + versionSB + " versionFSS= " + versionFSS + " versionGroup= " + versionGroup
           + " versionSHMF= " + versionSHMF);
     }
 
-    sizeOffsets = raf.readByte();
+    sizeOffsets = getRandomAccessFile().readByte();
     isOffsetLong = (sizeOffsets == 8);
 
-    sizeLengths = raf.readByte();
+    sizeLengths = getRandomAccessFile().readByte();
     isLengthLong = (sizeLengths == 8);
     if (debugDetail) {
       log.debug(" sizeOffsets= {} sizeLengths= {}", sizeOffsets, sizeLengths);
       log.debug(" isLengthLong= {} isOffsetLong= {}", isLengthLong, isOffsetLong);
     }
 
-    raf.read(); // skip 1 byte
+    getRandomAccessFile().read(); // skip 1 byte
     // log.debug(" position="+mapBuffer.position());
 
-    btreeLeafNodeSize = raf.readShort();
-    btreeInternalNodeSize = raf.readShort();
+    btreeLeafNodeSize = getRandomAccessFile().readShort();
+    btreeInternalNodeSize = getRandomAccessFile().readShort();
     if (debugDetail) {
       log.debug(" btreeLeafNodeSize= {} btreeInternalNodeSize= {}", btreeLeafNodeSize, btreeInternalNodeSize);
     }
     // log.debug(" position="+mapBuffer.position());
 
-    fileFlags = raf.readInt();
+    fileFlags = getRandomAccessFile().readInt();
     if (debugDetail) {
       log.debug(" fileFlags= 0x{}", Integer.toHexString(fileFlags));
     }
 
     if (versionSB == 1) {
-      short storageInternalNodeSize = raf.readShort();
-      raf.skipBytes(2);
+      short storageInternalNodeSize = getRandomAccessFile().readShort();
+      getRandomAccessFile().skipBytes(2);
     }
 
     baseAddress = readOffset();
@@ -337,36 +335,36 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       log.debug(" baseAddress= 0x{}", Long.toHexString(baseAddress));
       log.debug(" global free space heap Address= 0x{}", Long.toHexString(heapAddress));
       log.debug(" eof Address={}", eofAddress);
-      log.debug(" raf length= {}", raf.length());
+      log.debug(" raf length= {}", getRandomAccessFile().length());
       log.debug(" driver BlockAddress= 0x{}", Long.toHexString(driverBlockAddress));
       log.debug("");
     }
     if (debugTracker)
-      memTracker.add("superblock", superblockStart, raf.getFilePointer());
+      memTracker.add("superblock", superblockStart, getRandomAccessFile().getFilePointer());
 
     // look for file truncation
-    long fileSize = raf.length();
+    long fileSize = getRandomAccessFile().length();
     if (fileSize < eofAddress)
-      throw new IOException(
-          "File is truncated should be= " + eofAddress + " actual = " + fileSize + "%nlocation= " + raf.getLocation());
+      throw new IOException("File is truncated should be= " + eofAddress + " actual = " + fileSize + "%nlocation= "
+          + getRandomAccessFile().getLocation());
 
     // next comes the root object's SymbolTableEntry
     // extract the root group object, recursively read all objects
-    h5rootGroup = h5objects.readRootSymbolTable(raf.getFilePointer());
+    h5rootGroup = h5objects.readRootSymbolTable(getRandomAccessFile().getFilePointer());
   }
 
   private void readSuperBlock2(long superblockStart) throws IOException {
-    sizeOffsets = raf.readByte();
+    sizeOffsets = getRandomAccessFile().readByte();
     isOffsetLong = (sizeOffsets == 8);
 
-    sizeLengths = raf.readByte();
+    sizeLengths = getRandomAccessFile().readByte();
     isLengthLong = (sizeLengths == 8);
     if (debugDetail) {
       log.debug(" sizeOffsets= {} sizeLengths= {}", sizeOffsets, sizeLengths);
       log.debug(" isLengthLong= {} isOffsetLong= {}", isLengthLong, isOffsetLong);
     }
 
-    byte fileFlags = raf.readByte();
+    byte fileFlags = getRandomAccessFile().readByte();
     if (debugDetail) {
       log.debug(" fileFlags= 0x{}", Integer.toHexString(fileFlags));
     }
@@ -375,7 +373,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     long extensionAddress = readOffset();
     long eofAddress = readOffset();
     long rootObjectAddress = readOffset();
-    int checksum = raf.readInt();
+    int checksum = getRandomAccessFile().readInt();
 
     if (debugDetail) {
       log.debug(" baseAddress= 0x{}", Long.toHexString(baseAddress));
@@ -386,7 +384,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     }
 
     if (debugTracker)
-      memTracker.add("superblock", superblockStart, raf.getFilePointer());
+      memTracker.add("superblock", superblockStart, getRandomAccessFile().getFilePointer());
 
     if (baseAddress != superblockStart) {
       baseAddress = superblockStart;
@@ -397,7 +395,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     }
 
     // look for file truncation
-    long fileSize = raf.length();
+    long fileSize = getRandomAccessFile().length();
     if (fileSize < eofAddress) {
       throw new IOException("File is truncated should be= " + eofAddress + " actual = " + fileSize);
     }
@@ -981,7 +979,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
 
     // reading attribute values might change byte order during a read
     // put back to little endian for further header processing
-    raf.order(RandomAccessFile.LITTLE_ENDIAN);
+    getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
   }
 
   private Attribute makeAttribute(MessageAttribute matt) throws IOException {
@@ -1001,7 +999,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       attData = readAttributeData(matt, vinfo, dtype);
 
     } catch (InvalidRangeException e) {
-      log.warn("failed to read Attribute " + matt.name + " HDF5 file=" + raf.getLocation());
+      log.warn("failed to read Attribute " + matt.name + " HDF5 file=" + getRandomAccessFile().getLocation());
       return null;
     }
 
@@ -1019,7 +1017,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       result = new Attribute(matt.name, attData);
     }
 
-    raf.order(RandomAccessFile.LITTLE_ENDIAN);
+    getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
     return result;
   }
 
@@ -1082,8 +1080,8 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
         }
 
         // copy bytes directly into the underlying byte[]
-        raf.seek(chunk.getSrcPos());
-        raf.readFully(byteArray, (int) chunk.getDestElem() * recsize, chunk.getNelems() * recsize);
+        getRandomAccessFile().seek(chunk.getSrcPos());
+        getRandomAccessFile().readFully(byteArray, (int) chunk.getDestElem() * recsize, chunk.getNelems() * recsize);
       }
 
       // strings are stored on the heap, and must be read separately
@@ -1683,7 +1681,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
 
       isvlen = this.mdt.isVlen();
       if (!facade.dobj.mdt.isOK && warnings) {
-        log.debug("WARNING HDF5 file " + raf.getLocation() + " not handling " + facade.dobj.mdt);
+        log.debug("WARNING HDF5 file " + getRandomAccessFile().getLocation() + " not handling " + facade.dobj.mdt);
         return; // not a supported datatype
       }
 
@@ -1711,7 +1709,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       this.dataPos = dataPos;
 
       if (!mdt.isOK && warnings) {
-        log.debug("WARNING HDF5 file " + raf.getLocation() + " not handling " + mdt);
+        log.debug("WARNING HDF5 file " + getRandomAccessFile().getLocation() + " not handling " + mdt);
         return; // not a supported datatype
       }
 
@@ -1912,7 +1910,8 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
         // cant happen because we use null for wantSection
         throw new IllegalStateException();
       }
-      Object data = IospHelper.readDataFill(raf, layout, dataType, getFillValue(), typeInfo.endian, false);
+      Object data =
+          IospHelper.readDataFill(getRandomAccessFile(), layout, dataType, getFillValue(), typeInfo.endian, false);
       return Array.factory(dataType, shape, data);
     }
 
@@ -1931,7 +1930,8 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
         // cant happen because we use null for wantSection
         throw new IllegalStateException();
       }
-      Object data = IospHelper.readDataFill(raf, layout, dataType, getFillValue(), typeInfo.endian, true);
+      Object data =
+          IospHelper.readDataFill(getRandomAccessFile(), layout, dataType, getFillValue(), typeInfo.endian, true);
 
       String result = "";
       if (data instanceof String) {
@@ -1970,10 +1970,10 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       else if (size == 8)
         return DataType.LONG.withSignedness(signedness);
       else if (warnings) {
-        log.debug("WARNING HDF5 file " + raf.getLocation() + " not handling hdf integer type (" + hdfType
+        log.debug("WARNING HDF5 file " + getRandomAccessFile().getLocation() + " not handling hdf integer type ("
+            + hdfType + ") with size= " + size);
+        log.warn("HDF5 file " + getRandomAccessFile().getLocation() + " not handling hdf integer type (" + hdfType
             + ") with size= " + size);
-        log.warn(
-            "HDF5 file " + raf.getLocation() + " not handling hdf integer type (" + hdfType + ") with size= " + size);
         return null;
       }
 
@@ -1983,8 +1983,10 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       else if (size == 8)
         return DataType.DOUBLE;
       else if (warnings) {
-        log.debug("WARNING HDF5 file " + raf.getLocation() + " not handling hdf float type with size= " + size);
-        log.warn("HDF5 file " + raf.getLocation() + " not handling hdf float type with size= " + size);
+        log.debug("WARNING HDF5 file " + getRandomAccessFile().getLocation()
+            + " not handling hdf float type with size= " + size);
+        log.warn(
+            "HDF5 file " + getRandomAccessFile().getLocation() + " not handling hdf float type with size= " + size);
         return null;
       }
 
@@ -2001,9 +2003,11 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       return null; // dunno
 
     } else if (warnings) {
-      log.warn("HDF5 file " + raf.getLocation() + " not handling hdf type = " + hdfType + " size= " + size);
+      log.warn("HDF5 file " + getRandomAccessFile().getLocation() + " not handling hdf type = " + hdfType + " size= "
+          + size);
     } else {
-      log.debug("HDF5 file " + raf.getLocation() + " not handling hdf type = " + hdfType + " size= " + size);
+      log.debug("HDF5 file " + getRandomAccessFile().getLocation() + " not handling hdf type = " + hdfType + " size= "
+          + size);
     }
     return null;
   }
@@ -2068,43 +2072,43 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       log.debug(" HeapObject= {}", ho);
     }
     if (endian >= 0) {
-      raf.order(endian);
+      getRandomAccessFile().order(endian);
     }
 
     if (DataType.FLOAT == dataType) {
       float[] pa = new float[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readFloat(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readFloat(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (DataType.DOUBLE == dataType) {
       double[] pa = new double[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readDouble(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readDouble(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == byte.class) {
       byte[] pa = new byte[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readFully(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readFully(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == short.class) {
       short[] pa = new short[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readShort(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readShort(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == int.class) {
       int[] pa = new int[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readInt(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readInt(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == long.class) {
       long[] pa = new long[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readLong(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readLong(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
     }
 
@@ -2128,8 +2132,8 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
       throw new IllegalStateException("Cant find Heap Object,heapId=" + heapId);
     if (ho.dataSize > 1000 * 1000)
       return String.format("Bad HeapObject.dataSize=%s", ho);
-    raf.seek(ho.dataPos);
-    return raf.readString((int) ho.dataSize, valueCharset);
+    getRandomAccessFile().seek(ho.dataPos);
+    return getRandomAccessFile().readString((int) ho.dataSize, valueCharset);
   }
 
   /**
@@ -2148,8 +2152,8 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     GlobalHeap.HeapObject ho = heapId.getHeapObject();
     if (ho == null)
       throw new IllegalStateException("Cant find Heap Object,heapId=" + heapId);
-    raf.seek(ho.dataPos);
-    return raf.readString((int) ho.dataSize, valueCharset);
+    getRandomAccessFile().seek(ho.dataPos);
+    return getRandomAccessFile().readString((int) ho.dataSize, valueCharset);
   }
 
   Array readHeapVlen(ByteBuffer bb, int pos, DataType dataType, int endian) throws IOException, InvalidRangeException {
@@ -2226,12 +2230,12 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
 
   @Override
   public long readLength() throws IOException {
-    return isLengthLong ? raf.readLong() : (long) raf.readInt();
+    return isLengthLong ? getRandomAccessFile().readLong() : (long) getRandomAccessFile().readInt();
   }
 
   @Override
   public long readOffset() throws IOException {
-    return isOffsetLong ? raf.readLong() : (long) raf.readInt();
+    return isOffsetLong ? getRandomAccessFile().readLong() : (long) getRandomAccessFile().readInt();
   }
 
   @Override
@@ -2259,17 +2263,17 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
   public long readVariableSizeUnsigned(int size) throws IOException {
     long vv;
     if (size == 1) {
-      vv = DataType.unsignedByteToShort(raf.readByte());
+      vv = DataType.unsignedByteToShort(getRandomAccessFile().readByte());
     } else if (size == 2) {
       if (debugPos) {
-        log.debug("position={}", raf.getFilePointer());
+        log.debug("position={}", getRandomAccessFile().getFilePointer());
       }
-      short s = raf.readShort();
+      short s = getRandomAccessFile().readShort();
       vv = DataType.unsignedShortToInt(s);
     } else if (size == 4) {
-      vv = DataType.unsignedIntToLong(raf.readInt());
+      vv = DataType.unsignedIntToLong(getRandomAccessFile().readInt());
     } else if (size == 8) {
-      vv = raf.readLong();
+      vv = getRandomAccessFile().readLong();
     } else {
       vv = readVariableSizeN(size);
     }
@@ -2280,7 +2284,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
   private long readVariableSizeN(int nbytes) throws IOException {
     int[] ch = new int[nbytes];
     for (int i = 0; i < nbytes; i++)
-      ch[i] = raf.read();
+      ch[i] = getRandomAccessFile().read();
 
     long result = ch[nbytes - 1];
     for (int i = nbytes - 2; i >= 0; i--) {
@@ -2293,7 +2297,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
 
   @Override
   public RandomAccessFile getRandomAccessFile() {
-    return raf;
+    return h5iosp.getRandomAccessFile();
   }
 
   @Override
@@ -2327,7 +2331,7 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
   }
 
   public void getEosInfo(Formatter f) throws IOException {
-    HdfEos.getEosInfo(raf.getLocation(), this, root, f);
+    HdfEos.getEosInfo(getRandomAccessFile().getLocation(), this, root, f);
   }
 
   // debug - hdf5Table

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5headerNew.java
@@ -2306,6 +2306,10 @@ public class H5headerNew implements H5headerIF, HdfHeaderIF {
     return sizeOffsets;
   }
 
+  H5objects getH5objects() {
+    return h5objects;
+  }
+
   boolean isNetcdf4() {
     return isNetcdf4;
   }

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5iospNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5iospNew.java
@@ -122,7 +122,7 @@ public class H5iospNew extends AbstractIOServiceProvider {
     super.open(raf, rootGroup.getNcfile(), cancelTask);
 
     raf.order(RandomAccessFile.BIG_ENDIAN);
-    header = new H5headerNew(raf, rootGroup, this);
+    header = new H5headerNew(rootGroup, this);
     header.read(null);
 
     // check if its an HDF5-EOS file
@@ -175,7 +175,7 @@ public class H5iospNew extends AbstractIOServiceProvider {
   public void open(RandomAccessFile raf, NetcdfFile ncfile, CancelTask cancelTask) throws IOException {
     super.open(raf, ncfile, cancelTask);
     Group.Builder rootGroup = Group.builder().setName("").setNcfile(ncfile);
-    header = new H5headerNew(raf, rootGroup, this);
+    header = new H5headerNew(rootGroup, this);
     header.read(null);
     ncfile.setRootGroup(rootGroup.build());
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5iospNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5iospNew.java
@@ -97,6 +97,10 @@ public class H5iospNew extends AbstractIOServiceProvider {
     return "Hierarchical Data Format, version 5";
   }
 
+  RandomAccessFile getRandomAccessFile() {
+    return raf;
+  }
+
   public static void useHdfEos(boolean val) {
     useHdfEos = val;
   }

--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5objects.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/hdf5/H5objects.java
@@ -50,6 +50,10 @@ public class H5objects {
     this.memTracker = memTracker;
   }
 
+  RandomAccessFile getRandomAccessFile() {
+    return raf;
+  }
+
   H5Group readRootSymbolTable(long pos) throws IOException {
     // The root object's SymbolTableEntry
     SymbolTableEntry rootEntry = new SymbolTableEntry(pos);

--- a/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/DataBTree.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/DataBTree.java
@@ -58,6 +58,10 @@ public class DataBTree {
     wantType = 1;
   }
 
+  RandomAccessFile getRandomAccessFile() {
+    return raf;
+  }
+
   public void setOwner(Object owner) {
     this.owner = owner;
   }

--- a/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5header.java
@@ -96,7 +96,6 @@ public class H5header extends NCheader implements H5headerIF {
 
   ////////////////////////////////////////////////////////////////////////////////
 
-  RandomAccessFile raf;
   ucar.nc2.NetcdfFile ncfile;
   private H5iosp h5iosp;
 
@@ -121,9 +120,8 @@ public class H5header extends NCheader implements H5headerIF {
   private java.io.PrintWriter debugOut;
   private MemTracker memTracker;
 
-  H5header(RandomAccessFile myRaf, ucar.nc2.NetcdfFile ncfile, H5iosp h5iosp) {
+  H5header(ucar.nc2.NetcdfFile ncfile, H5iosp h5iosp) {
     this.ncfile = ncfile;
-    this.raf = myRaf;
     this.h5iosp = h5iosp;
   }
 
@@ -154,7 +152,7 @@ public class H5header extends NCheader implements H5headerIF {
       debugOut = new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8));
     }
 
-    long actualSize = raf.length();
+    long actualSize = getRandomAccessFile().length();
 
     if (debugTracker)
       memTracker = new MemTracker(actualSize);
@@ -163,8 +161,8 @@ public class H5header extends NCheader implements H5headerIF {
     boolean ok = false;
     long filePos = 0;
     while ((filePos < actualSize - 8)) {
-      raf.seek(filePos);
-      String magic = raf.readString(8);
+      getRandomAccessFile().seek(filePos);
+      String magic = getRandomAccessFile().readString(8);
       if (magic.equals(hdf5magic)) {
         ok = true;
         break;
@@ -175,19 +173,19 @@ public class H5header extends NCheader implements H5headerIF {
       throw new IOException("Not a netCDF4/HDF5 file ");
     }
     if (debug1) {
-      log.debug("H5header opened file to read:'{}' size= {}", raf.getLocation(), actualSize);
+      log.debug("H5header opened file to read:'{}' size= {}", getRandomAccessFile().getLocation(), actualSize);
     }
     // now we are positioned right after the header
 
     // header information is in le byte order
-    raf.order(RandomAccessFile.LITTLE_ENDIAN);
+    getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
 
-    long superblockStart = raf.getFilePointer() - 8;
+    long superblockStart = getRandomAccessFile().getFilePointer() - 8;
     if (debugTracker)
       memTracker.add("header", 0, superblockStart);
 
     // superblock version
-    byte versionSB = raf.readByte();
+    byte versionSB = getRandomAccessFile().readByte();
 
     if (versionSB < 2) {
       readSuperBlock1(superblockStart, versionSB);
@@ -223,43 +221,43 @@ public class H5header extends NCheader implements H5headerIF {
     long eofAddress;
     long driverBlockAddress;
 
-    versionFSS = raf.readByte();
-    versionGroup = raf.readByte();
-    raf.readByte(); // skip 1 byte
-    versionSHMF = raf.readByte();
+    versionFSS = getRandomAccessFile().readByte();
+    versionGroup = getRandomAccessFile().readByte();
+    getRandomAccessFile().readByte(); // skip 1 byte
+    versionSHMF = getRandomAccessFile().readByte();
     if (debugDetail) {
       log.debug(" versionSB= " + versionSB + " versionFSS= " + versionFSS + " versionGroup= " + versionGroup
           + " versionSHMF= " + versionSHMF);
     }
 
-    sizeOffsets = raf.readByte();
+    sizeOffsets = getRandomAccessFile().readByte();
     isOffsetLong = (sizeOffsets == 8);
 
-    sizeLengths = raf.readByte();
+    sizeLengths = getRandomAccessFile().readByte();
     isLengthLong = (sizeLengths == 8);
     if (debugDetail) {
       log.debug(" sizeOffsets= {} sizeLengths= {}", sizeOffsets, sizeLengths);
       log.debug(" isLengthLong= {} isOffsetLong= {}", isLengthLong, isOffsetLong);
     }
 
-    raf.read(); // skip 1 byte
+    getRandomAccessFile().read(); // skip 1 byte
     // log.debug(" position="+mapBuffer.position());
 
-    btreeLeafNodeSize = raf.readShort();
-    btreeInternalNodeSize = raf.readShort();
+    btreeLeafNodeSize = getRandomAccessFile().readShort();
+    btreeInternalNodeSize = getRandomAccessFile().readShort();
     if (debugDetail) {
       log.debug(" btreeLeafNodeSize= {} btreeInternalNodeSize= {}", btreeLeafNodeSize, btreeInternalNodeSize);
     }
     // log.debug(" position="+mapBuffer.position());
 
-    fileFlags = raf.readInt();
+    fileFlags = getRandomAccessFile().readInt();
     if (debugDetail) {
       log.debug(" fileFlags= 0x{}", Integer.toHexString(fileFlags));
     }
 
     if (versionSB == 1) {
-      short storageInternalNodeSize = raf.readShort();
-      raf.skipBytes(2);
+      short storageInternalNodeSize = getRandomAccessFile().readShort();
+      getRandomAccessFile().skipBytes(2);
     }
 
     baseAddress = readOffset();
@@ -279,21 +277,21 @@ public class H5header extends NCheader implements H5headerIF {
       log.debug(" baseAddress= 0x{}", Long.toHexString(baseAddress));
       log.debug(" global free space heap Address= 0x{}", Long.toHexString(heapAddress));
       log.debug(" eof Address={}", eofAddress);
-      log.debug(" raf length= {}", raf.length());
+      log.debug(" raf length= {}", getRandomAccessFile().length());
       log.debug(" driver BlockAddress= 0x{}", Long.toHexString(driverBlockAddress));
       log.debug("");
     }
     if (debugTracker)
-      memTracker.add("superblock", superblockStart, raf.getFilePointer());
+      memTracker.add("superblock", superblockStart, getRandomAccessFile().getFilePointer());
 
     // look for file truncation
-    long fileSize = raf.length();
+    long fileSize = getRandomAccessFile().length();
     if (fileSize < eofAddress)
-      throw new IOException(
-          "File is truncated should be= " + eofAddress + " actual = " + fileSize + "%nlocation= " + raf.getLocation());
+      throw new IOException("File is truncated should be= " + eofAddress + " actual = " + fileSize + "%nlocation= "
+          + getRandomAccessFile().getLocation());
 
     // next comes the root objext's SymbolTableEntry
-    SymbolTableEntry rootEntry = new SymbolTableEntry(raf.getFilePointer());
+    SymbolTableEntry rootEntry = new SymbolTableEntry(getRandomAccessFile().getFilePointer());
 
     // extract the root group object, recursively read all objects
     long rootObjectAddress = rootEntry.getObjectAddress();
@@ -314,17 +312,17 @@ public class H5header extends NCheader implements H5headerIF {
   }
 
   private void readSuperBlock2(long superblockStart) throws IOException {
-    sizeOffsets = raf.readByte();
+    sizeOffsets = getRandomAccessFile().readByte();
     isOffsetLong = (sizeOffsets == 8);
 
-    sizeLengths = raf.readByte();
+    sizeLengths = getRandomAccessFile().readByte();
     isLengthLong = (sizeLengths == 8);
     if (debugDetail) {
       log.debug(" sizeOffsets= {} sizeLengths= {}", sizeOffsets, sizeLengths);
       log.debug(" isLengthLong= {} isOffsetLong= {}", isLengthLong, isOffsetLong);
     }
 
-    byte fileFlags = raf.readByte();
+    byte fileFlags = getRandomAccessFile().readByte();
     if (debugDetail) {
       log.debug(" fileFlags= 0x{}", Integer.toHexString(fileFlags));
     }
@@ -333,7 +331,7 @@ public class H5header extends NCheader implements H5headerIF {
     long extensionAddress = readOffset();
     long eofAddress = readOffset();
     long rootObjectAddress = readOffset();
-    int checksum = raf.readInt();
+    int checksum = getRandomAccessFile().readInt();
 
     if (debugDetail) {
       log.debug(" baseAddress= 0x{}", Long.toHexString(baseAddress));
@@ -344,7 +342,7 @@ public class H5header extends NCheader implements H5headerIF {
     }
 
     if (debugTracker)
-      memTracker.add("superblock", superblockStart, raf.getFilePointer());
+      memTracker.add("superblock", superblockStart, getRandomAccessFile().getFilePointer());
 
     if (baseAddress != superblockStart) {
       baseAddress = superblockStart;
@@ -355,7 +353,7 @@ public class H5header extends NCheader implements H5headerIF {
     }
 
     // look for file truncation
-    long fileSize = raf.length();
+    long fileSize = getRandomAccessFile().length();
     if (fileSize < eofAddress) {
       throw new IOException("File is truncated should be= " + eofAddress + " actual = " + fileSize);
     }
@@ -993,7 +991,7 @@ public class H5header extends NCheader implements H5headerIF {
 
     // reading attribute values might change byte order during a read
     // put back to little endian for further header processing
-    raf.order(RandomAccessFile.LITTLE_ENDIAN);
+    getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
   }
 
   private Attribute makeAttribute(MessageAttribute matt) throws IOException {
@@ -1013,7 +1011,7 @@ public class H5header extends NCheader implements H5headerIF {
       attData = readAttributeData(matt, vinfo, dtype);
 
     } catch (InvalidRangeException e) {
-      log.warn("failed to read Attribute " + matt.name + " HDF5 file=" + raf.getLocation());
+      log.warn("failed to read Attribute " + matt.name + " HDF5 file=" + getRandomAccessFile().getLocation());
       return null;
     }
 
@@ -1031,7 +1029,7 @@ public class H5header extends NCheader implements H5headerIF {
       result = new Attribute(matt.name, attData);
     }
 
-    raf.order(RandomAccessFile.LITTLE_ENDIAN);
+    getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
     return result;
   }
 
@@ -1093,8 +1091,8 @@ public class H5header extends NCheader implements H5headerIF {
         }
 
         // copy bytes directly into the underlying byte[]
-        raf.seek(chunk.getSrcPos());
-        raf.readFully(byteArray, (int) chunk.getDestElem() * recsize, chunk.getNelems() * recsize);
+        getRandomAccessFile().seek(chunk.getSrcPos());
+        getRandomAccessFile().readFully(byteArray, (int) chunk.getDestElem() * recsize, chunk.getNelems() * recsize);
       }
 
       // strings are stored on the heap, and must be read separately
@@ -2458,63 +2456,63 @@ public class H5header extends NCheader implements H5headerIF {
         log.debug("\n--> DataObject.read parsing <" + who + "> object ID/address=" + address);
       }
       if (debugPos) {
-        log.debug("      DataObject.read now at position=" + raf.getFilePointer() + " for <" + who + "> reposition to "
-            + getFileOffset(address));
+        log.debug("      DataObject.read now at position=" + getRandomAccessFile().getFilePointer() + " for <" + who
+            + "> reposition to " + getFileOffset(address));
       }
       // if (offset < 0) return null;
-      raf.seek(getFileOffset(address));
+      getRandomAccessFile().seek(getFileOffset(address));
 
-      version = raf.readByte();
+      version = getRandomAccessFile().readByte();
       if (version == 1) { // Level 2A1 (first part, before the messages)
-        raf.readByte(); // skip byte
-        short nmess = raf.readShort();
+        getRandomAccessFile().readByte(); // skip byte
+        short nmess = getRandomAccessFile().readShort();
         if (debugDetail) {
           log.debug(" version=" + version + " nmess=" + nmess);
         }
 
-        int referenceCount = raf.readInt();
-        int headerSize = raf.readInt();
+        int referenceCount = getRandomAccessFile().readInt();
+        int headerSize = getRandomAccessFile().readInt();
         if (debugDetail) {
           log.debug(" referenceCount=" + referenceCount + " headerSize=" + headerSize);
         }
 
         // if (referenceCount > 1)
         // log.debug("WARNING referenceCount="+referenceCount);
-        raf.skipBytes(4); // header messages multiples of 8
+        getRandomAccessFile().skipBytes(4); // header messages multiples of 8
 
-        long posMess = raf.getFilePointer();
+        long posMess = getRandomAccessFile().getFilePointer();
         int count = readMessagesVersion1(posMess, nmess, Integer.MAX_VALUE, this.who);
         if (debugContinueMessage) {
           log.debug(" nmessages read = {}", count);
         }
         if (debugPos) {
-          log.debug("<--done reading messages for <" + who + ">; position=" + raf.getFilePointer());
+          log.debug("<--done reading messages for <" + who + ">; position=" + getRandomAccessFile().getFilePointer());
         }
         if (debugTracker)
           memTracker.addByLen("Object " + who, getFileOffset(address), headerSize + 16);
 
       } else { // level 2A2 (first part, before the messages)
         // first byte was already read
-        String magic = raf.readString(3);
+        String magic = getRandomAccessFile().readString(3);
         if (!magic.equals("HDR"))
           throw new IllegalStateException("DataObject doesnt start with OHDR");
 
-        version = raf.readByte();
-        byte flags = raf.readByte(); // data object header flags (version 2)
+        version = getRandomAccessFile().readByte();
+        byte flags = getRandomAccessFile().readByte(); // data object header flags (version 2)
         if (debugDetail) {
           log.debug(" version=" + version + " flags=" + Integer.toBinaryString(flags));
         }
 
         // raf.skipBytes(2);
         if (((flags >> 5) & 1) == 1) {
-          int accessTime = raf.readInt();
-          int modTime = raf.readInt();
-          int changeTime = raf.readInt();
-          int birthTime = raf.readInt();
+          int accessTime = getRandomAccessFile().readInt();
+          int modTime = getRandomAccessFile().readInt();
+          int changeTime = getRandomAccessFile().readInt();
+          int birthTime = getRandomAccessFile().readInt();
         }
         if (((flags >> 4) & 1) == 1) {
-          short maxCompactAttributes = raf.readShort();
-          short minDenseAttributes = raf.readShort();
+          short maxCompactAttributes = getRandomAccessFile().readShort();
+          short minDenseAttributes = getRandomAccessFile().readShort();
         }
 
         long sizeOfChunk = readVariableSizeFactor(flags & 3);
@@ -2522,13 +2520,13 @@ public class H5header extends NCheader implements H5headerIF {
           log.debug(" sizeOfChunk=" + sizeOfChunk);
         }
 
-        long posMess = raf.getFilePointer();
+        long posMess = getRandomAccessFile().getFilePointer();
         int count = readMessagesVersion2(posMess, sizeOfChunk, (flags & 4) != 0, this.who);
         if (debugContinueMessage) {
           log.debug(" nmessages read = {}", count);
         }
         if (debugPos) {
-          log.debug("<--done reading messages for <" + who + ">; position=" + raf.getFilePointer());
+          log.debug("<--done reading messages for <" + who + ">; position=" + getRandomAccessFile().getFilePointer());
         }
       }
 
@@ -2670,7 +2668,7 @@ public class H5header extends NCheader implements H5headerIF {
           if (debugContinueMessage)
             debugOut.println(" ---ObjectHeaderContinuation filePos= " + continuationBlockFilePos);
 
-          raf.seek(continuationBlockFilePos);
+          getRandomAccessFile().seek(continuationBlockFilePos);
           String sig = readStringFixedLength(4);
           if (!sig.equals("OCHK"))
             throw new IllegalStateException(" ObjectHeaderContinuation Missing signature");
@@ -2831,28 +2829,28 @@ public class H5header extends NCheader implements H5headerIF {
      */
     int read(long filePos, int version, boolean creationOrderPresent, String objectName) throws IOException {
       this.start = filePos;
-      raf.seek(filePos);
+      getRandomAccessFile().seek(filePos);
       if (debugPos) {
-        log.debug("  --> Message Header starts at =" + raf.getFilePointer());
+        log.debug("  --> Message Header starts at =" + getRandomAccessFile().getFilePointer());
       }
 
       if (version == 1) {
-        type = raf.readShort();
-        size = DataType.unsignedShortToInt(raf.readShort());
-        headerMessageFlags = raf.readByte();
-        raf.skipBytes(3);
+        type = getRandomAccessFile().readShort();
+        size = DataType.unsignedShortToInt(getRandomAccessFile().readShort());
+        headerMessageFlags = getRandomAccessFile().readByte();
+        getRandomAccessFile().skipBytes(3);
         header_length = 8;
 
       } else {
-        type = (short) raf.readByte();
-        size = DataType.unsignedShortToInt(raf.readShort());
+        type = (short) getRandomAccessFile().readByte();
+        size = DataType.unsignedShortToInt(getRandomAccessFile().readShort());
         // if (size > Short.MAX_VALUE)
         // log.debug("HEY");
 
-        headerMessageFlags = raf.readByte();
+        headerMessageFlags = getRandomAccessFile().readByte();
         header_length = 4;
         if (creationOrderPresent) {
-          creationOrder = raf.readShort();
+          creationOrder = getRandomAccessFile().readShort();
           header_length += 2;
         }
       }
@@ -2864,7 +2862,7 @@ public class H5header extends NCheader implements H5headerIF {
         }
       }
       if (debugPos) {
-        log.debug("  --> Message Data starts at=" + raf.getFilePointer());
+        log.debug("  --> Message Data starts at=" + getRandomAccessFile().getFilePointer());
       }
 
       if ((headerMessageFlags & 2) != 0) { // shared
@@ -2922,7 +2920,7 @@ public class H5header extends NCheader implements H5headerIF {
 
       } else if (mtype == MessageType.Attribute) { // 12
         MessageAttribute data = new MessageAttribute();
-        data.read(raf.getFilePointer());
+        data.read(getRandomAccessFile().getFilePointer());
         messData = data;
 
       } else if (mtype == MessageType.Comment) { // 13
@@ -3002,17 +3000,17 @@ public class H5header extends NCheader implements H5headerIF {
   }
 
   private DataObject getSharedDataObject(MessageType mtype) throws IOException {
-    byte sharedVersion = raf.readByte();
-    byte sharedType = raf.readByte();
+    byte sharedVersion = getRandomAccessFile().readByte();
+    byte sharedType = getRandomAccessFile().readByte();
     if (sharedVersion == 1)
-      raf.skipBytes(6);
+      getRandomAccessFile().skipBytes(6);
     if ((sharedVersion == 3) && (sharedType == 1)) {
-      long heapId = raf.readLong();
+      long heapId = getRandomAccessFile().readLong();
       if (debug1) {
         log.debug("     Shared Message " + sharedVersion + " type=" + sharedType + " heapId = " + heapId);
       }
       if (debugPos) {
-        log.debug("  --> Shared Message reposition to =" + raf.getFilePointer());
+        log.debug("  --> Shared Message reposition to =" + getRandomAccessFile().getFilePointer());
       }
       // dunno where is the file's shared object header heap ??
       throw new UnsupportedOperationException("****SHARED MESSAGE type = " + mtype + " heapId = " + heapId);
@@ -3074,20 +3072,20 @@ public class H5header extends NCheader implements H5headerIF {
 
     void read() throws IOException {
       if (debugPos) {
-        log.debug("   *MessageSimpleDataspace start pos= " + raf.getFilePointer());
+        log.debug("   *MessageSimpleDataspace start pos= " + getRandomAccessFile().getFilePointer());
       }
 
-      byte version = raf.readByte();
+      byte version = getRandomAccessFile().readByte();
       if (version == 1) {
-        ndims = raf.readByte();
-        flags = raf.readByte();
+        ndims = getRandomAccessFile().readByte();
+        flags = getRandomAccessFile().readByte();
         type = (byte) ((ndims == 0) ? 0 : 1);
-        raf.skipBytes(5); // skip 5 bytes
+        getRandomAccessFile().skipBytes(5); // skip 5 bytes
 
       } else if (version == 2) {
-        ndims = raf.readByte();
-        flags = raf.readByte();
-        type = raf.readByte();
+        ndims = getRandomAccessFile().readByte();
+        flags = getRandomAccessFile().readByte();
+        type = getRandomAccessFile().readByte();
 
       } else {
         throw new IllegalStateException("MessageDataspace: unknown version= " + version);
@@ -3177,12 +3175,12 @@ public class H5header extends NCheader implements H5headerIF {
 
     void read() throws IOException {
       if (debugPos) {
-        log.debug("   *MessageGroupNew start pos= " + raf.getFilePointer());
+        log.debug("   *MessageGroupNew start pos= " + getRandomAccessFile().getFilePointer());
       }
-      byte version = raf.readByte();
-      byte flags = raf.readByte();
+      byte version = getRandomAccessFile().readByte();
+      byte flags = getRandomAccessFile().readByte();
       if ((flags & 1) != 0) {
-        maxCreationIndex = raf.readLong();
+        maxCreationIndex = getRandomAccessFile().readLong();
       }
 
       fractalHeapAddress = readOffset();
@@ -3220,19 +3218,19 @@ public class H5header extends NCheader implements H5headerIF {
 
     void read() throws IOException {
       if (debugPos) {
-        log.debug("   *MessageGroupInfo start pos= " + raf.getFilePointer());
+        log.debug("   *MessageGroupInfo start pos= " + getRandomAccessFile().getFilePointer());
       }
-      byte version = raf.readByte();
-      flags = raf.readByte();
+      byte version = getRandomAccessFile().readByte();
+      flags = getRandomAccessFile().readByte();
 
       if ((flags & 1) != 0) {
-        maxCompactValue = raf.readShort();
-        minDenseValue = raf.readShort();
+        maxCompactValue = getRandomAccessFile().readShort();
+        minDenseValue = getRandomAccessFile().readShort();
       }
 
       if ((flags & 2) != 0) {
-        estNumEntries = raf.readShort();
-        estLengthEntryName = raf.readShort();
+        estNumEntries = getRandomAccessFile().readShort();
+        estLengthEntryName = getRandomAccessFile().readShort();
       }
 
       if (debug1) {
@@ -3271,19 +3269,19 @@ public class H5header extends NCheader implements H5headerIF {
 
     void read() throws IOException {
       if (debugPos) {
-        log.debug("   *MessageLink start pos= {}", raf.getFilePointer());
+        log.debug("   *MessageLink start pos= {}", getRandomAccessFile().getFilePointer());
       }
-      version = raf.readByte();
-      flags = raf.readByte();
+      version = getRandomAccessFile().readByte();
+      flags = getRandomAccessFile().readByte();
 
       if ((flags & 8) != 0)
-        linkType = raf.readByte();
+        linkType = getRandomAccessFile().readByte();
 
       if ((flags & 4) != 0)
-        creationOrder = raf.readLong();
+        creationOrder = getRandomAccessFile().readLong();
 
       if ((flags & 0x10) != 0)
-        encoding = raf.readByte();
+        encoding = getRandomAccessFile().readByte();
 
       int linkNameLength = (int) readVariableSizeFactor(flags & 3);
       linkName = readStringFixedLength(linkNameLength);
@@ -3292,11 +3290,11 @@ public class H5header extends NCheader implements H5headerIF {
         linkAddress = readOffset();
 
       } else if (linkType == 1) {
-        short len = raf.readShort();
+        short len = getRandomAccessFile().readShort();
         link = readStringFixedLength(len);
 
       } else if (linkType == 64) {
-        short len = raf.readShort();
+        short len = getRandomAccessFile().readShort();
         link = readStringFixedLength(len); // actually 2 strings - see docs
       }
 
@@ -3389,15 +3387,15 @@ public class H5header extends NCheader implements H5headerIF {
 
     void read(String objectName) throws IOException {
       if (debugPos) {
-        log.debug("   *MessageDatatype start pos= {}", raf.getFilePointer());
+        log.debug("   *MessageDatatype start pos= {}", getRandomAccessFile().getFilePointer());
       }
 
-      byte tandv = raf.readByte();
+      byte tandv = getRandomAccessFile().readByte();
       type = (tandv & 0xf);
       version = ((tandv & 0xf0) >> 4);
 
-      raf.readFully(flags);
-      byteSize = raf.readInt();
+      getRandomAccessFile().readFully(flags);
+      byteSize = getRandomAccessFile().readInt();
       endian = ((flags[0] & 1) == 0) ? RandomAccessFile.LITTLE_ENDIAN : RandomAccessFile.BIG_ENDIAN;
 
       if (debug1) {
@@ -3408,8 +3406,8 @@ public class H5header extends NCheader implements H5headerIF {
 
       if (type == 0) { // fixed point
         unsigned = ((flags[0] & 8) == 0);
-        short bitOffset = raf.readShort();
-        short bitPrecision = raf.readShort();
+        short bitOffset = getRandomAccessFile().readShort();
+        short bitPrecision = getRandomAccessFile().readShort();
         if (debug1) {
           log.debug("   type 0 (fixed point): bitOffset= " + bitOffset + " bitPrecision= " + bitPrecision
               + " unsigned= " + unsigned);
@@ -3417,20 +3415,20 @@ public class H5header extends NCheader implements H5headerIF {
         isOK = (bitOffset == 0) && (bitPrecision % 8 == 0);
 
       } else if (type == 1) { // floating point
-        short bitOffset = raf.readShort();
-        short bitPrecision = raf.readShort();
-        byte expLocation = raf.readByte();
-        byte expSize = raf.readByte();
-        byte manLocation = raf.readByte();
-        byte manSize = raf.readByte();
-        int expBias = raf.readInt();
+        short bitOffset = getRandomAccessFile().readShort();
+        short bitPrecision = getRandomAccessFile().readShort();
+        byte expLocation = getRandomAccessFile().readByte();
+        byte expSize = getRandomAccessFile().readByte();
+        byte manLocation = getRandomAccessFile().readByte();
+        byte manSize = getRandomAccessFile().readByte();
+        int expBias = getRandomAccessFile().readInt();
         if (debug1) {
           log.debug("   type 1 (floating point): bitOffset= " + bitOffset + " bitPrecision= " + bitPrecision
               + " expLocation= " + expLocation + " expSize= " + expSize + " manLocation= " + manLocation + " manSize= "
               + manSize + " expBias= " + expBias);
         }
       } else if (type == 2) { // time
-        short bitPrecision = raf.readShort();
+        short bitPrecision = getRandomAccessFile().readShort();
         if (bitPrecision == 16)
           timeType = DataType.SHORT;
         else if (bitPrecision == 32)
@@ -3449,8 +3447,8 @@ public class H5header extends NCheader implements H5headerIF {
         }
 
       } else if (type == 4) { // bit field
-        short bitOffset = raf.readShort();
-        short bitPrecision = raf.readShort();
+        short bitOffset = getRandomAccessFile().readShort();
+        short bitPrecision = getRandomAccessFile().readShort();
         if (debug1) {
           log.debug("   type 4 (bit field): bitOffset= " + bitOffset + " bitPrecision= " + bitPrecision);
         }
@@ -3458,7 +3456,7 @@ public class H5header extends NCheader implements H5headerIF {
 
       } else if (type == 5) { // opaque
         byte len = flags[0];
-        opaque_desc = (len > 0) ? readString(raf).trim() : null;
+        opaque_desc = (len > 0) ? readString(getRandomAccessFile()).trim() : null;
         if (debug1) {
           log.debug("   type 5 (opaque): len= " + len + " desc= " + opaque_desc);
         }
@@ -3498,20 +3496,20 @@ public class H5header extends NCheader implements H5headerIF {
         String[] enumName = new String[nmembers];
         for (int i = 0; i < nmembers; i++) {
           if (version < 3)
-            enumName[i] = readString8(raf); // padding
+            enumName[i] = readString8(getRandomAccessFile()); // padding
           else
-            enumName[i] = readString(raf); // no padding
+            enumName[i] = readString(getRandomAccessFile()); // no padding
         }
 
         // read the values; must switch to base byte order (!)
         if (base.endian >= 0) {
-          raf.order(base.endian);
+          getRandomAccessFile().order(base.endian);
         }
         int[] enumValue = new int[nmembers];
         for (int i = 0; i < nmembers; i++) {
           enumValue[i] = (int) readVariableSizeUnsigned(base.byteSize); // assume size is 1, 2, or 4
         }
-        raf.order(RandomAccessFile.LITTLE_ENDIAN);
+        getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
 
         enumTypeName = objectName;
         map = new TreeMap<>();
@@ -3540,14 +3538,14 @@ public class H5header extends NCheader implements H5headerIF {
         if (debug1) {
           debugOut.print("   type 10(array) lengths= ");
         }
-        int ndims = (int) raf.readByte();
+        int ndims = (int) getRandomAccessFile().readByte();
         if (version < 3) {
-          raf.skipBytes(3);
+          getRandomAccessFile().skipBytes(3);
         }
 
         dim = new int[ndims];
         for (int i = 0; i < ndims; i++) {
-          dim[i] = raf.readInt();
+          dim[i] = getRandomAccessFile().readInt();
           if (debug1) {
             debugOut.print(" " + dim[i]);
           }
@@ -3556,7 +3554,7 @@ public class H5header extends NCheader implements H5headerIF {
         if (version < 3) { // not present in version 3, never used anyway
           int[] pdim = new int[ndims];
           for (int i = 0; i < ndims; i++)
-            pdim[i] = raf.readInt();
+            pdim[i] = getRandomAccessFile().readInt();
         }
         if (debug1) {
           log.debug("");
@@ -3599,13 +3597,13 @@ public class H5header extends NCheader implements H5headerIF {
 
     StructureMember(int version, int byteSize) throws IOException {
       if (debugPos) {
-        log.debug("   *StructureMember now at position={}", raf.getFilePointer());
+        log.debug("   *StructureMember now at position={}", getRandomAccessFile().getFilePointer());
       }
 
-      name = readString(raf);
+      name = readString(getRandomAccessFile());
       if (version < 3) {
-        raf.skipBytes(padding(name.length() + 1, 8));
-        offset = raf.readInt();
+        getRandomAccessFile().skipBytes(padding(name.length() + 1, 8));
+        offset = getRandomAccessFile().readInt();
       } else {
         offset = (int) readVariableSizeMax(byteSize);
       }
@@ -3615,9 +3613,9 @@ public class H5header extends NCheader implements H5headerIF {
       }
 
       if (version == 1) {
-        dims = raf.readByte();
-        raf.skipBytes(3);
-        raf.skipBytes(24); // ignore dimension info for now
+        dims = getRandomAccessFile().readByte();
+        getRandomAccessFile().skipBytes(3);
+        getRandomAccessFile().skipBytes(24); // ignore dimension info for now
       }
 
       // HDFdumpWithCount(buffer, raf.getFilePointer(), 16);
@@ -3649,9 +3647,9 @@ public class H5header extends NCheader implements H5headerIF {
     int size;
 
     void read() throws IOException {
-      size = raf.readInt();
+      size = getRandomAccessFile().readInt();
       value = new byte[size];
-      raf.readFully(value);
+      getRandomAccessFile().readFully(value);
 
       if (debug1) {
         log.debug("{}", this);
@@ -3686,25 +3684,25 @@ public class H5header extends NCheader implements H5headerIF {
     byte flags;
 
     void read() throws IOException {
-      version = raf.readByte();
+      version = getRandomAccessFile().readByte();
 
       if (version < 3) {
-        spaceAllocateTime = raf.readByte();
-        fillWriteTime = raf.readByte();
-        hasFillValue = raf.readByte() != 0;
+        spaceAllocateTime = getRandomAccessFile().readByte();
+        fillWriteTime = getRandomAccessFile().readByte();
+        hasFillValue = getRandomAccessFile().readByte() != 0;
 
       } else {
-        flags = raf.readByte();
+        flags = getRandomAccessFile().readByte();
         spaceAllocateTime = (byte) (flags & 3);
         fillWriteTime = (byte) ((flags >> 2) & 3);
         hasFillValue = (flags & 32) != 0;
       }
 
       if (hasFillValue) {
-        size = raf.readInt();
+        size = getRandomAccessFile().readInt();
         if (size > 0) {
           value = new byte[size];
-          raf.readFully(value);
+          getRandomAccessFile().readFully(value);
           hasFillValue = true;
         } else {
           hasFillValue = false;
@@ -3808,41 +3806,41 @@ public class H5header extends NCheader implements H5headerIF {
     void read() throws IOException {
       int ndims;
 
-      byte version = raf.readByte();
+      byte version = getRandomAccessFile().readByte();
       if (version < 3) {
-        ndims = raf.readByte();
-        type = raf.readByte();
-        raf.skipBytes(5); // skip 5 bytes
+        ndims = getRandomAccessFile().readByte();
+        type = getRandomAccessFile().readByte();
+        getRandomAccessFile().skipBytes(5); // skip 5 bytes
 
         boolean isCompact = (type == 0);
         if (!isCompact)
           dataAddress = readOffset();
         chunkSize = new int[ndims];
         for (int i = 0; i < ndims; i++)
-          chunkSize[i] = raf.readInt();
+          chunkSize[i] = getRandomAccessFile().readInt();
 
         if (isCompact) {
-          dataSize = raf.readInt();
-          dataAddress = raf.getFilePointer();
+          dataSize = getRandomAccessFile().readInt();
+          dataAddress = getRandomAccessFile().getFilePointer();
         }
 
       } else {
-        type = raf.readByte();
+        type = getRandomAccessFile().readByte();
 
         if (type == 0) {
-          dataSize = raf.readShort();
-          dataAddress = raf.getFilePointer();
+          dataSize = getRandomAccessFile().readShort();
+          dataAddress = getRandomAccessFile().getFilePointer();
 
         } else if (type == 1) {
           dataAddress = readOffset();
           contiguousSize = readLength();
 
         } else if (type == 2) {
-          ndims = raf.readByte();
+          ndims = getRandomAccessFile().readByte();
           dataAddress = readOffset();
           chunkSize = new int[ndims];
           for (int i = 0; i < ndims; i++)
-            chunkSize[i] = raf.readInt();
+            chunkSize[i] = getRandomAccessFile().readInt();
         }
       }
 
@@ -3857,10 +3855,10 @@ public class H5header extends NCheader implements H5headerIF {
     Filter[] filters;
 
     void read() throws IOException {
-      byte version = raf.readByte();
-      byte nfilters = raf.readByte();
+      byte version = getRandomAccessFile().readByte();
+      byte nfilters = getRandomAccessFile().readByte();
       if (version == 1)
-        raf.skipBytes(6);
+        getRandomAccessFile().skipBytes(6);
 
       filters = new Filter[nfilters];
       for (int i = 0; i < nfilters; i++)
@@ -3902,21 +3900,22 @@ public class H5header extends NCheader implements H5headerIF {
     int[] data;
 
     Filter(byte version) throws IOException {
-      this.id = raf.readShort();
-      short nameSize = ((version > 1) && (id < 256)) ? 0 : raf.readShort(); // if the filter id < 256 then this field is
-                                                                            // not stored
-      this.flags = raf.readShort();
-      nValues = raf.readShort();
+      this.id = getRandomAccessFile().readShort();
+      // if the filter id < 256 then this field is not stored
+      short nameSize = ((version > 1) && (id < 256)) ? 0 : getRandomAccessFile().readShort();
+      this.flags = getRandomAccessFile().readShort();
+      nValues = getRandomAccessFile().readShort();
       if (version == 1)
-        this.name = (nameSize > 0) ? readString8(raf) : getFilterName(id); // null terminated, pad to 8 bytes
+        this.name = (nameSize > 0) ? readString8(getRandomAccessFile()) : getFilterName(id); // null terminated, pad to
+                                                                                             // 8 bytes
       else
         this.name = (nameSize > 0) ? readStringFixedLength(nameSize) : getFilterName(id); // non-null terminated
 
       data = new int[nValues];
       for (int i = 0; i < nValues; i++)
-        data[i] = raf.readInt();
+        data[i] = getRandomAccessFile().readInt();
       if ((version == 1) && (nValues & 1) != 0) // check if odd
-        raf.skipBytes(4);
+        getRandomAccessFile().skipBytes(4);
 
       if (debug1) {
         log.debug("{}", this);
@@ -3987,51 +3986,52 @@ public class H5header extends NCheader implements H5headerIF {
     }
 
     boolean read(long pos) throws IOException {
-      raf.seek(pos);
+      getRandomAccessFile().seek(pos);
       if (debugPos) {
-        log.debug("   *MessageAttribute start pos= {}", raf.getFilePointer());
+        log.debug("   *MessageAttribute start pos= {}", getRandomAccessFile().getFilePointer());
       }
       short nameSize, typeSize, spaceSize;
       byte flags = 0;
       byte encoding = 0; // 0 = ascii, 1 = UTF-8
 
-      version = raf.readByte();
+      version = getRandomAccessFile().readByte();
       if (version == 1) {
-        raf.read(); // skip byte
-        nameSize = raf.readShort();
-        typeSize = raf.readShort();
-        spaceSize = raf.readShort();
+        getRandomAccessFile().read(); // skip byte
+        nameSize = getRandomAccessFile().readShort();
+        typeSize = getRandomAccessFile().readShort();
+        spaceSize = getRandomAccessFile().readShort();
 
       } else if ((version == 2) || (version == 3)) {
-        flags = raf.readByte();
-        nameSize = raf.readShort();
-        typeSize = raf.readShort();
-        spaceSize = raf.readShort();
+        flags = getRandomAccessFile().readByte();
+        nameSize = getRandomAccessFile().readShort();
+        typeSize = getRandomAccessFile().readShort();
+        spaceSize = getRandomAccessFile().readShort();
         if (version == 3)
-          encoding = raf.readByte();
+          encoding = getRandomAccessFile().readByte();
 
       } else if (version == 72) {
-        flags = raf.readByte();
-        nameSize = raf.readShort();
-        typeSize = raf.readShort();
-        spaceSize = raf.readShort();
-        log.error("HDF5 MessageAttribute found bad version " + version + " at filePos " + raf.getFilePointer());
+        flags = getRandomAccessFile().readByte();
+        nameSize = getRandomAccessFile().readShort();
+        typeSize = getRandomAccessFile().readShort();
+        spaceSize = getRandomAccessFile().readShort();
+        log.error("HDF5 MessageAttribute found bad version " + version + " at filePos "
+            + getRandomAccessFile().getFilePointer());
         // G:/work/galibert/IMOS_ANMN-NSW_AETVZ_20131127T230000Z_PH100_FV01_PH100-1311-Workhorse-ADCP-109.5_END-20140306T010000Z_C-20140521T053527Z.nc
         // E:/work/antonio/2014_ch.nc
         // return false;
       } else {
-        log.error("bad version " + version + " at filePos " + raf.getFilePointer()); // buggery, may be HDF5 "more than
-                                                                                     // 8 attributes" error
+        // buggery, maybe HDF5 "more than 8 attributes" error
+        log.error("bad version " + version + " at filePos " + getRandomAccessFile().getFilePointer());
         return false;
         // throw new IllegalStateException("MessageAttribute unknown version " + version);
       }
 
       // read the attribute name
-      long filePos = raf.getFilePointer();
-      name = readString(raf); // read at current pos
+      long filePos = getRandomAccessFile().getFilePointer();
+      name = readString(getRandomAccessFile()); // read at current pos
       if (version == 1)
         nameSize += padding(nameSize, 8);
-      raf.seek(filePos + nameSize); // make it more robust for errors
+      getRandomAccessFile().seek(filePos + nameSize); // make it more robust for errors
 
       if (debug1) {
         log.debug("   MessageAttribute version= " + version + " flags = " + Integer.toBinaryString(flags)
@@ -4039,7 +4039,7 @@ public class H5header extends NCheader implements H5headerIF {
       }
 
       // read the datatype
-      filePos = raf.getFilePointer();
+      filePos = getRandomAccessFile().getFilePointer();
       if (debugPos) {
         log.debug("   *MessageAttribute before mdt pos= {}", filePos);
       }
@@ -4054,20 +4054,20 @@ public class H5header extends NCheader implements H5headerIF {
         if (version == 1)
           typeSize += padding(typeSize, 8);
       }
-      raf.seek(filePos + typeSize); // make it more robust for errors
+      getRandomAccessFile().seek(filePos + typeSize); // make it more robust for errors
 
       // read the dataspace
-      filePos = raf.getFilePointer();
+      filePos = getRandomAccessFile().getFilePointer();
       if (debugPos) {
         log.debug("   *MessageAttribute before mds = {}", filePos);
       }
       mds.read();
       if (version == 1)
         spaceSize += padding(spaceSize, 8);
-      raf.seek(filePos + spaceSize); // make it more robust for errors
+      getRandomAccessFile().seek(filePos + spaceSize); // make it more robust for errors
 
       // the data starts immediately afterward - ie in the message
-      dataPos = raf.getFilePointer(); // note this is absolute position (no offset needed)
+      dataPos = getRandomAccessFile().getFilePointer(); // note this is absolute position (no offset needed)
       if (debug1) {
         log.debug("   *MessageAttribute dataPos= {}", dataPos);
       }
@@ -4152,12 +4152,12 @@ public class H5header extends NCheader implements H5headerIF {
 
     void read() throws IOException {
       if (debugPos) {
-        log.debug("   *MessageAttributeInfo start pos= {}", raf.getFilePointer());
+        log.debug("   *MessageAttributeInfo start pos= {}", getRandomAccessFile().getFilePointer());
       }
-      byte version = raf.readByte();
-      byte flags = raf.readByte();
+      byte version = getRandomAccessFile().readByte();
+      byte flags = getRandomAccessFile().readByte();
       if ((flags & 1) != 0)
-        maxCreationIndex = raf.readShort();
+        maxCreationIndex = getRandomAccessFile().readShort();
 
       fractalHeapAddress = readOffset();
       v2BtreeAddress = readOffset();
@@ -4176,7 +4176,7 @@ public class H5header extends NCheader implements H5headerIF {
     String comment;
 
     void read() throws IOException {
-      comment = readString(raf);
+      comment = readString(getRandomAccessFile());
     }
 
     public String toString() {
@@ -4195,9 +4195,9 @@ public class H5header extends NCheader implements H5headerIF {
     int secs;
 
     void read() throws IOException {
-      version = raf.readByte();
-      raf.skipBytes(3); // skip byte
-      secs = raf.readInt();
+      version = getRandomAccessFile().readByte();
+      getRandomAccessFile().skipBytes(3); // skip byte
+      secs = getRandomAccessFile().readInt();
     }
 
     public String toString() {
@@ -4215,7 +4215,7 @@ public class H5header extends NCheader implements H5headerIF {
     String datemod;
 
     void read() throws IOException {
-      datemod = raf.readString(14);
+      datemod = getRandomAccessFile().readString(14);
       if (debug1) {
         log.debug("   MessageLastModifiedOld={}", datemod);
       }
@@ -4252,8 +4252,8 @@ public class H5header extends NCheader implements H5headerIF {
     int refCount;
 
     void read() throws IOException {
-      int version = raf.readByte();
-      refCount = raf.readInt();
+      int version = getRandomAccessFile().readByte();
+      refCount = getRandomAccessFile().readInt();
       if (debug1) {
         log.debug("   ObjectReferenceCount={}", refCount);
       }
@@ -4302,7 +4302,7 @@ public class H5header extends NCheader implements H5headerIF {
         long pos = fractalHeapId.getPos();
         if (pos < 0)
           continue;
-        raf.seek(pos);
+        getRandomAccessFile().seek(pos);
         MessageLink linkMessage = new MessageLink();
         linkMessage.read();
         if (debugBtree2) {
@@ -4413,18 +4413,18 @@ public class H5header extends NCheader implements H5headerIF {
 
     // recursively read all entries, place them in order in list
     protected void readAllEntries(long address, List<Entry> entryList) throws IOException {
-      raf.seek(getFileOffset(address));
+      getRandomAccessFile().seek(getFileOffset(address));
       if (debugGroupBtree) {
-        log.debug("\n--> GroupBTree read tree at position={}", raf.getFilePointer());
+        log.debug("\n--> GroupBTree read tree at position={}", getRandomAccessFile().getFilePointer());
       }
 
-      String magic = raf.readString(4);
+      String magic = getRandomAccessFile().readString(4);
       if (!magic.equals("TREE"))
         throw new IllegalStateException("BtreeGroup doesnt start with TREE");
 
-      int type = raf.readByte();
-      int level = raf.readByte();
-      int nentries = raf.readShort();
+      int type = getRandomAccessFile().readByte();
+      int level = getRandomAccessFile().readByte();
+      int nentries = getRandomAccessFile().readShort();
       if (debugGroupBtree) {
         log.debug("    type=" + type + " level=" + level + " nentries=" + nentries);
       }
@@ -4485,25 +4485,25 @@ public class H5header extends NCheader implements H5headerIF {
       GroupNode(long address) throws IOException {
         this.address = address;
 
-        raf.seek(getFileOffset(address));
+        getRandomAccessFile().seek(getFileOffset(address));
         if (debugDetail) {
-          log.debug("--Group Node position={}", raf.getFilePointer());
+          log.debug("--Group Node position={}", getRandomAccessFile().getFilePointer());
         }
 
         // header
-        String magic = raf.readString(4);
+        String magic = getRandomAccessFile().readString(4);
         if (!magic.equals("SNOD")) {
           throw new IllegalStateException(magic + " should equal SNOD");
         }
 
-        version = raf.readByte();
-        raf.readByte(); // skip byte
-        nentries = raf.readShort();
+        version = getRandomAccessFile().readByte();
+        getRandomAccessFile().readByte(); // skip byte
+        nentries = getRandomAccessFile().readShort();
         if (debugDetail) {
           log.debug("   version={} nentries={}", version, nentries);
         }
 
-        long posEntry = raf.getFilePointer();
+        long posEntry = getRandomAccessFile().getFilePointer();
         for (int i = 0; i < nentries; i++) {
           SymbolTableEntry entry = new SymbolTableEntry(posEntry);
           posEntry += entry.getSize();
@@ -4519,7 +4519,7 @@ public class H5header extends NCheader implements H5headerIF {
           }
         }
         if (debugDetail) {
-          log.debug("-- Group Node end position={}", raf.getFilePointer());
+          log.debug("-- Group Node end position={}", getRandomAccessFile().getFilePointer());
         }
         long size = 8 + nentries * 40;
         if (debugTracker)
@@ -4544,22 +4544,22 @@ public class H5header extends NCheader implements H5headerIF {
     boolean isSymbolicLink;
 
     SymbolTableEntry(long filePos) throws IOException {
-      raf.seek(filePos);
+      getRandomAccessFile().seek(filePos);
       if (debugSymbolTable) {
-        log.debug("--> readSymbolTableEntry position={}", raf.getFilePointer());
+        log.debug("--> readSymbolTableEntry position={}", getRandomAccessFile().getFilePointer());
       }
 
       nameOffset = readOffset();
       objectHeaderAddress = readOffset();
-      cacheType = raf.readInt();
-      raf.skipBytes(4);
+      cacheType = getRandomAccessFile().readInt();
+      getRandomAccessFile().skipBytes(4);
 
       if (debugSymbolTable) {
         log.debug(" nameOffset={} objectHeaderAddress={} cacheType={}", nameOffset, objectHeaderAddress, cacheType);
       }
 
       // "scratch pad"
-      posData = raf.getFilePointer();
+      posData = getRandomAccessFile().getFilePointer();
       if (debugSymbolTable)
         dump("Group Entry scratch pad", posData, 16, false);
 
@@ -4573,7 +4573,7 @@ public class H5header extends NCheader implements H5headerIF {
 
       // check for symbolic link
       if (cacheType == 2) {
-        linkOffset = raf.readInt(); // offset in local heap
+        linkOffset = getRandomAccessFile().readInt(); // offset in local heap
         if (debugSymbolTable) {
           log.debug("WARNING Symbolic Link linkOffset={}", linkOffset);
         }
@@ -4602,7 +4602,7 @@ public class H5header extends NCheader implements H5headerIF {
        */
 
       if (debugSymbolTable) {
-        log.debug("<-- end readSymbolTableEntry position={}", raf.getFilePointer());
+        log.debug("<-- end readSymbolTableEntry position={}", getRandomAccessFile().getFilePointer());
       }
 
       if (debugTracker)
@@ -4662,43 +4662,43 @@ public class H5header extends NCheader implements H5headerIF {
       log.debug(" HeapObject= {}", ho);
     }
     if (endian >= 0) {
-      raf.order(endian);
+      getRandomAccessFile().order(endian);
     }
 
     if (DataType.FLOAT == dataType) {
       float[] pa = new float[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readFloat(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readFloat(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (DataType.DOUBLE == dataType) {
       double[] pa = new double[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readDouble(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readDouble(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == byte.class) {
       byte[] pa = new byte[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readFully(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readFully(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == short.class) {
       short[] pa = new short[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readShort(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readShort(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == int.class) {
       int[] pa = new int[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readInt(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readInt(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
 
     } else if (dataType.getPrimitiveClassType() == long.class) {
       long[] pa = new long[heapId.nelems];
-      raf.seek(ho.dataPos);
-      raf.readLong(pa, 0, pa.length);
+      getRandomAccessFile().seek(ho.dataPos);
+      getRandomAccessFile().readLong(pa, 0, pa.length);
       return Array.factory(dataType, new int[] {pa.length}, pa);
     }
 
@@ -4722,7 +4722,7 @@ public class H5header extends NCheader implements H5headerIF {
       throw new IllegalStateException("Cant find Heap Object,heapId=" + heapId);
     if (ho.dataSize > 1000 * 1000)
       return String.format("Bad HeapObject.dataSize=%s", ho);
-    raf.seek(ho.dataPos);
+    getRandomAccessFile().seek(ho.dataPos);
     return readStringFixedLength((int) ho.dataSize);
   }
 
@@ -4742,7 +4742,7 @@ public class H5header extends NCheader implements H5headerIF {
     H5header.GlobalHeap.HeapObject ho = heapId.getHeapObject();
     if (ho == null)
       throw new IllegalStateException("Cant find Heap Object,heapId=" + heapId);
-    raf.seek(ho.dataPos);
+    getRandomAccessFile().seek(ho.dataPos);
     return readStringFixedLength((int) ho.dataSize);
   }
 
@@ -4787,11 +4787,11 @@ public class H5header extends NCheader implements H5headerIF {
     // address must be absolute, getFileOffset already added
     HeapIdentifier(long address) throws IOException {
       // header information is in le byte order
-      raf.order(RandomAccessFile.LITTLE_ENDIAN);
-      raf.seek(address);
-      nelems = raf.readInt();
+      getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
+      getRandomAccessFile().seek(address);
+      nelems = getRandomAccessFile().readInt();
       heapAddress = readOffset();
-      index = raf.readInt();
+      index = getRandomAccessFile().readInt();
       if (debugDetail) {
         log.debug("   read HeapIdentifier address=" + address + this);
       }
@@ -4842,10 +4842,10 @@ public class H5header extends NCheader implements H5headerIF {
 
     RegionReference(long filePos) throws IOException {
       // header information is in le byte order
-      raf.order(RandomAccessFile.LITTLE_ENDIAN);
-      raf.seek(filePos);
+      getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
+      getRandomAccessFile().seek(filePos);
       heapAddress = readOffset();
-      index = raf.readInt();
+      index = getRandomAccessFile().readInt();
 
       GlobalHeap gheap;
       if (null == (gheap = heapMap.get(heapAddress))) {
@@ -4865,8 +4865,8 @@ public class H5header extends NCheader implements H5headerIF {
        * src/H5S<foo>.c, where foo = {all, hyper, point, none}.
        * There is _no_ datatype information stored for these kind of selections currently.
        */
-      raf.seek(want.dataPos);
-      long objId = raf.readLong();
+      getRandomAccessFile().seek(want.dataPos);
+      long objId = getRandomAccessFile().readLong();
       DataObject ndo = getDataObject(objId, null);
       // String what = (ndo == null) ? "none" : ndo.getName();
       if (debugRegionReference) {
@@ -4886,35 +4886,35 @@ public class H5header extends NCheader implements H5headerIF {
 
     GlobalHeap(long address) throws IOException {
       // header information is in le byte order
-      raf.order(RandomAccessFile.LITTLE_ENDIAN);
-      raf.seek(getFileOffset(address));
+      getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
+      getRandomAccessFile().seek(getFileOffset(address));
 
       // header
-      String magic = raf.readString(4);
+      String magic = getRandomAccessFile().readString(4);
       if (!magic.equals("GCOL"))
         throw new IllegalStateException(magic + " should equal GCOL");
 
-      version = raf.readByte();
-      raf.skipBytes(3);
-      sizeBytes = raf.readInt();
+      version = getRandomAccessFile().readByte();
+      getRandomAccessFile().skipBytes(3);
+      sizeBytes = getRandomAccessFile().readInt();
       if (debugDetail) {
         log.debug("-- readGlobalHeap address=" + address + " version= " + version + " size = " + sizeBytes);
         // log.debug("-- readGlobalHeap address=" + address + " version= " + version + " size = " + sizeBytes);
       }
-      raf.skipBytes(4); // pad to 8
+      getRandomAccessFile().skipBytes(4); // pad to 8
 
       int count = 0;
       int countBytes = 0;
       while (true) {
-        long startPos = raf.getFilePointer();
+        long startPos = getRandomAccessFile().getFilePointer();
         HeapObject o = new HeapObject();
-        o.id = raf.readShort();
+        o.id = getRandomAccessFile().readShort();
         if (o.id == 0)
           break; // ?? look
-        o.refCount = raf.readShort();
-        raf.skipBytes(4);
+        o.refCount = getRandomAccessFile().readShort();
+        getRandomAccessFile().skipBytes(4);
         o.dataSize = readLength();
-        o.dataPos = raf.getFilePointer();
+        o.dataPos = getRandomAccessFile().getFilePointer();
 
         int dsize = ((int) o.dataSize) + padding((int) o.dataSize, 8);
         countBytes += dsize + 16;
@@ -4931,7 +4931,7 @@ public class H5header extends NCheader implements H5headerIF {
               + o.dataSize + " dataPos = " + o.dataPos + " count= " + count + " countBytes= " + countBytes);
         }
 
-        raf.skipBytes(dsize);
+        getRandomAccessFile().skipBytes(dsize);
         hos.put(o.id, o);
         count++;
 
@@ -4940,7 +4940,7 @@ public class H5header extends NCheader implements H5headerIF {
       }
 
       if (debugDetail) {
-        log.debug("-- endGlobalHeap position=" + raf.getFilePointer());
+        log.debug("-- endGlobalHeap position=" + getRandomAccessFile().getFilePointer());
       }
       if (debugTracker)
         memTracker.addByLen("GlobalHeap", address, sizeBytes);
@@ -4975,21 +4975,21 @@ public class H5header extends NCheader implements H5headerIF {
       this.group = group;
 
       // header information is in le byte order
-      raf.order(RandomAccessFile.LITTLE_ENDIAN);
-      raf.seek(getFileOffset(address));
+      getRandomAccessFile().order(RandomAccessFile.LITTLE_ENDIAN);
+      getRandomAccessFile().seek(getFileOffset(address));
 
       if (debugDetail) {
-        log.debug("-- readLocalHeap position={}", raf.getFilePointer());
+        log.debug("-- readLocalHeap position={}", getRandomAccessFile().getFilePointer());
       }
 
       // header
-      String magic = raf.readString(4);
+      String magic = getRandomAccessFile().readString(4);
       if (!magic.equals("HEAP")) {
         throw new IllegalStateException(magic + " should equal HEAP");
       }
 
-      version = raf.readByte();
-      raf.skipBytes(3);
+      version = getRandomAccessFile().readByte();
+      getRandomAccessFile().skipBytes(3);
       size = (int) readLength();
       freelistOffset = readLength();
       dataAddress = readOffset();
@@ -4998,17 +4998,17 @@ public class H5header extends NCheader implements H5headerIF {
             + " heap starts at dataAddress=" + dataAddress);
       }
       if (debugPos) {
-        log.debug("    *now at position={}", raf.getFilePointer());
+        log.debug("    *now at position={}", getRandomAccessFile().getFilePointer());
       }
 
       // data
-      raf.seek(getFileOffset(dataAddress));
+      getRandomAccessFile().seek(getFileOffset(dataAddress));
       heap = new byte[size];
-      raf.readFully(heap);
+      getRandomAccessFile().readFully(heap);
       // if (debugHeap) printBytes( out, "heap", heap, size, true);
 
       if (debugDetail) {
-        log.debug("-- endLocalHeap position={}", raf.getFilePointer());
+        log.debug("-- endLocalHeap position={}", getRandomAccessFile().getFilePointer());
       }
       int hsize = 8 + 2 * sizeLengths + sizeOffsets;
       if (debugTracker)
@@ -5099,17 +5099,17 @@ public class H5header extends NCheader implements H5headerIF {
    * @throws java.io.IOException on io error
    */
   private String readStringFixedLength(int size) throws IOException {
-    return raf.readString(size);
+    return getRandomAccessFile().readString(size);
   }
 
   @Override
   public long readLength() throws IOException {
-    return isLengthLong ? raf.readLong() : (long) raf.readInt();
+    return isLengthLong ? getRandomAccessFile().readLong() : (long) getRandomAccessFile().readInt();
   }
 
   @Override
   public long readOffset() throws IOException {
-    return isOffsetLong ? raf.readLong() : (long) raf.readInt();
+    return isOffsetLong ? getRandomAccessFile().readLong() : (long) getRandomAccessFile().readInt();
   }
 
   @Override
@@ -5143,17 +5143,17 @@ public class H5header extends NCheader implements H5headerIF {
   public long readVariableSizeUnsigned(int size) throws IOException {
     long vv;
     if (size == 1) {
-      vv = DataType.unsignedByteToShort(raf.readByte());
+      vv = DataType.unsignedByteToShort(getRandomAccessFile().readByte());
     } else if (size == 2) {
       if (debugPos) {
-        log.debug("position={}", raf.getFilePointer());
+        log.debug("position={}", getRandomAccessFile().getFilePointer());
       }
-      short s = raf.readShort();
+      short s = getRandomAccessFile().readShort();
       vv = DataType.unsignedShortToInt(s);
     } else if (size == 4) {
-      vv = DataType.unsignedIntToLong(raf.readInt());
+      vv = DataType.unsignedIntToLong(getRandomAccessFile().readInt());
     } else if (size == 8) {
-      vv = raf.readLong();
+      vv = getRandomAccessFile().readLong();
     } else {
       vv = readVariableSizeN(size);
     }
@@ -5163,11 +5163,11 @@ public class H5header extends NCheader implements H5headerIF {
   private int readVariableSize(int size) throws IOException {
     long vv;
     if (size == 1) {
-      return raf.readByte();
+      return getRandomAccessFile().readByte();
     } else if (size == 2) {
-      return raf.readShort();
+      return getRandomAccessFile().readShort();
     } else if (size == 4) {
-      return raf.readInt();
+      return getRandomAccessFile().readInt();
     }
     throw new IllegalArgumentException("Dont support int size == " + size);
   }
@@ -5176,7 +5176,7 @@ public class H5header extends NCheader implements H5headerIF {
   private long readVariableSizeN(int nbytes) throws IOException {
     int[] ch = new int[nbytes];
     for (int i = 0; i < nbytes; i++)
-      ch[i] = raf.read();
+      ch[i] = getRandomAccessFile().read();
 
     long result = ch[nbytes - 1];
     for (int i = nbytes - 2; i >= 0; i--) {
@@ -5189,7 +5189,7 @@ public class H5header extends NCheader implements H5headerIF {
 
   @Override
   public RandomAccessFile getRandomAccessFile() {
-    return raf;
+    return h5iosp.getRandomAccessFile();
   }
 
   @Override
@@ -5212,13 +5212,13 @@ public class H5header extends NCheader implements H5headerIF {
   void dump(String head, long filePos, int nbytes, boolean count) throws IOException {
     if (debugOut == null)
       return;
-    long savePos = raf.getFilePointer();
+    long savePos = getRandomAccessFile().getFilePointer();
     if (filePos >= 0)
-      raf.seek(filePos);
+      getRandomAccessFile().seek(filePos);
     byte[] mess = new byte[nbytes];
-    raf.readFully(mess);
+    getRandomAccessFile().readFully(mess);
     printBytes(head, mess, nbytes, false, debugOut);
-    raf.seek(savePos);
+    getRandomAccessFile().seek(savePos);
   }
 
   static void printBytes(String head, byte[] buff, int n, boolean count, java.io.PrintWriter ps) {

--- a/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
@@ -90,6 +90,14 @@ public class H5iosp extends AbstractIOServiceProvider {
     }
   }
 
+  RandomAccessFile getRandomAccessFile() {
+    return raf;
+  }
+
+  H5header getHeader() {
+    return headerParser;
+  }
+
   public static void useHdfEos(boolean val) {
     useHdfEos = val;
   }

--- a/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5iosp.java
@@ -115,7 +115,7 @@ public class H5iosp extends AbstractIOServiceProvider {
   public void open(RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile, ucar.nc2.util.CancelTask cancelTask)
       throws IOException {
     super.open(raf, ncfile, cancelTask);
-    headerParser = new H5header(this.raf, ncfile, this);
+    headerParser = new H5header(ncfile, this);
     headerParser.read(null);
 
     // check if its an HDF5-EOS file
@@ -613,7 +613,6 @@ public class H5iosp extends AbstractIOServiceProvider {
   @Override
   public void reacquire() throws IOException {
     super.reacquire();
-    headerParser.raf = this.raf;
   }
 
   @Override
@@ -634,7 +633,7 @@ public class H5iosp extends AbstractIOServiceProvider {
 
     try {
       NetcdfFile ncfile = new NetcdfFileSubclass();
-      H5header detailParser = new H5header(raf, ncfile, this);
+      H5header detailParser = new H5header(ncfile, this);
       detailParser.read(pw);
       f.format("%s", super.getDetailInfo());
       f.format("%s", os.toString(CDM.UTF8));
@@ -658,7 +657,7 @@ public class H5iosp extends AbstractIOServiceProvider {
 
     if (message.toString().equals("headerEmpty")) {
       NetcdfFile ncfile = new NetcdfFileSubclass();
-      return new H5header(raf, ncfile, this);
+      return new H5header(ncfile, this);
     }
 
     if (message.equals(IOSP_MESSAGE_GET_NETCDF_FILE_FORMAT)) {

--- a/cdm/core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5iospNew.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5iospNew.java
@@ -1,0 +1,63 @@
+package ucar.nc2.internal.iosp.hdf5;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.iosp.IOServiceProvider;
+import ucar.unidata.util.test.TestDir;
+
+public class TestH5iospNew {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final String TEST_FILE = TestDir.cdmLocalTestDataDir + "hdf5/structmetadata_eos.h5";
+
+  private NetcdfFile netcdfFile;
+  private H5iospNew h5iospNew;
+
+  @Before
+  public void open() throws Exception {
+    netcdfFile = NetcdfFiles.open(TEST_FILE);
+    final IOServiceProvider iosp = netcdfFile.getIosp();
+    assertThat(iosp).isInstanceOf(H5iospNew.class);
+    h5iospNew = (H5iospNew) iosp;
+    assertThat(h5iospNew).isNotNull();
+  }
+
+  @After
+  public void close() throws Exception {
+    netcdfFile.close();
+  }
+
+  @Test
+  public void shouldReleaseRafs() throws IOException {
+    assertThat(h5iospNew.getRandomAccessFile()).isNotNull();
+    assertThat(h5iospNew.getHeader().getRandomAccessFile()).isNotNull();
+    assertThat(h5iospNew.getHeader().getH5objects().getRandomAccessFile()).isNotNull();
+
+    netcdfFile.release();
+
+    assertThat(h5iospNew.getRandomAccessFile()).isNull();
+    assertThat(h5iospNew.getHeader().getRandomAccessFile()).isNull();
+    assertThat(h5iospNew.getHeader().getH5objects().getRandomAccessFile()).isNull();
+  }
+
+  @Test
+  public void shouldCloseRafs() throws IOException {
+    assertThat(h5iospNew.getRandomAccessFile()).isNotNull();
+    assertThat(h5iospNew.getHeader().getRandomAccessFile()).isNotNull();
+    assertThat(h5iospNew.getHeader().getH5objects().getRandomAccessFile()).isNotNull();
+
+    netcdfFile.close();
+
+    assertThat(h5iospNew.getRandomAccessFile()).isNull();
+    assertThat(h5iospNew.getHeader().getRandomAccessFile()).isNull();
+    assertThat(h5iospNew.getHeader().getH5objects().getRandomAccessFile()).isNull();
+  }
+}

--- a/cdm/core/src/test/java/ucar/nc2/iosp/hdf5/TestDataBTree.java
+++ b/cdm/core/src/test/java/ucar/nc2/iosp/hdf5/TestDataBTree.java
@@ -1,0 +1,54 @@
+package ucar.nc2.iosp.hdf5;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.iosp.hdf5.H5header.Vinfo;
+import ucar.unidata.util.test.TestDir;
+
+public class TestDataBTree {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final String TEST_FILE = TestDir.cdmLocalTestDataDir + "chunked.h5";
+
+  private NetcdfFile netcdfFile;
+
+  @Before
+  public void open() throws Exception {
+    netcdfFile = NetcdfFile.open(TEST_FILE);
+  }
+
+  @After
+  public void close() throws Exception {
+    netcdfFile.close();
+  }
+
+  @Test
+  public void shouldReleaseRafs() throws IOException {
+    final Variable variable = netcdfFile.findVariable("data");
+    assertThat((Object) variable).isNotNull();
+    final DataBTree bTree = ((Vinfo) variable.getSPobject()).btree;
+
+    assertThat(bTree.getRandomAccessFile()).isNotNull();
+    netcdfFile.release();
+    assertThat(bTree.getRandomAccessFile()).isNull();
+  }
+
+  @Test
+  public void shouldCloseRafs() throws IOException {
+    final Variable variable = netcdfFile.findVariable("data");
+    assertThat((Object) variable).isNotNull();
+    final DataBTree bTree = ((Vinfo) variable.getSPobject()).btree;
+
+    assertThat(bTree.getRandomAccessFile()).isNotNull();
+    netcdfFile.close();
+    assertThat(bTree.getRandomAccessFile()).isNull();
+  }
+}

--- a/cdm/core/src/test/java/ucar/nc2/iosp/hdf5/TestH5iosp.java
+++ b/cdm/core/src/test/java/ucar/nc2/iosp/hdf5/TestH5iosp.java
@@ -1,0 +1,58 @@
+package ucar.nc2.iosp.hdf5;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.iosp.IOServiceProvider;
+import ucar.unidata.util.test.TestDir;
+
+public class TestH5iosp {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final String TEST_FILE = TestDir.cdmLocalTestDataDir + "hdf5/structmetadata_eos.h5";
+
+  private NetcdfFile netcdfFile;
+  private H5iosp h5iosp;
+
+  @Before
+  public void open() throws Exception {
+    netcdfFile = NetcdfFile.open(TEST_FILE);
+    final IOServiceProvider iosp = netcdfFile.getIosp();
+    assertThat(iosp).isInstanceOf(H5iosp.class);
+    h5iosp = (H5iosp) iosp;
+    assertThat(h5iosp).isNotNull();
+  }
+
+  @After
+  public void close() throws Exception {
+    netcdfFile.close();
+  }
+
+  @Test
+  public void shouldReleaseRafs() throws IOException {
+    assertThat(h5iosp.getRandomAccessFile()).isNotNull();
+    assertThat(h5iosp.getHeader().getRandomAccessFile()).isNotNull();
+
+    netcdfFile.release();
+
+    assertThat(h5iosp.getRandomAccessFile()).isNull();
+    assertThat(h5iosp.getHeader().getRandomAccessFile()).isNull();
+  }
+
+  @Test
+  public void shouldCloseRafs() throws IOException {
+    assertThat(h5iosp.getRandomAccessFile()).isNotNull();
+    assertThat(h5iosp.getHeader().getRandomAccessFile()).isNotNull();
+
+    netcdfFile.close();
+
+    assertThat(h5iosp.getRandomAccessFile()).isNull();
+    assertThat(h5iosp.getHeader().getRandomAccessFile()).isNull();
+  }
+}


### PR DESCRIPTION
## Description of Changes

This is related to the support issue that with high traffic of opendap requests, errors occurred that were clearly related to the RandomAccessFile reading at the wrong location. Possibly also related to https://github.com/Unidata/tds/issues/293 and https://github.com/Unidata/tds/issues/325.

The problem is that the certain objects in the H5iosp and H5iospNew are retaining their own RAF, which never gets closed or reset when the IOSP's RAF does. This only rarely causes issues, because normally the NetcdfFile from the cache reacquires the same RAF from the cache that it previously had. However, when there are many requests it may reacquire a new RAF but the underlying objects still reference the old RAF.

This PR removes the RAF members from H5HeaderNew, H5Objects, H5Header, and DataBTree. Instead they now use the RAF from the IOSP. In addition, I made tests that the RAFs in these objects get closed.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
