### PR TITLE
Use enum for cache state

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/io/RandomAccessFile.java
+++ b/cdm/core/src/main/java/ucar/unidata/io/RandomAccessFile.java
@@ -213,6 +213,10 @@ public class RandomAccessFile implements DataInput, DataOutput, FileCacheable, C
   protected String location;
   private int cacheState; // 0 - not in cache, 1 = in cache && in use, 2 = in cache but not in use
 
+  int getCacheState() {
+    return cacheState;
+  }
+
   /**
    * The underlying java.io.RandomAccessFile.
    */

--- a/cdm/core/src/test/java/ucar/unidata/io/TestRandomAccessFileCache.java
+++ b/cdm/core/src/test/java/ucar/unidata/io/TestRandomAccessFileCache.java
@@ -1,0 +1,84 @@
+package ucar.unidata.io;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestRandomAccessFileCache {
+
+  @ClassRule
+  public static final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static RandomAccessFile testFile;
+  private static final String TEST_FILE_PATH = "src/test/data/preserveLineEndings/testUTF8.txt";
+
+  @BeforeClass
+  public static void enableCache() {
+    RandomAccessFile.enableDefaultGlobalFileCache();
+  }
+
+  @AfterClass
+  public static void shutdownCache() {
+    RandomAccessFile.setGlobalFileCache(null);
+  }
+
+  @Before
+  public void setUpTestFile() throws IOException {
+    testFile = RandomAccessFile.acquire(TEST_FILE_PATH);
+  }
+
+  @After
+  public void cleanUpTestFile() throws IOException {
+    testFile.close();
+  }
+
+  @Test
+  public void shouldReturnInUseWhenFileIsAcquired() {
+    assertThat(testFile.getCacheState()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReturnNotInUseWhenFileIsClosed() throws IOException {
+    testFile.close();
+    assertThat(testFile.getCacheState()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldReturnNotInCacheWhenFileNotInCacheIsClosed() throws IOException {
+    testFile.setFileCache(null);
+    testFile.close();
+    assertThat(testFile.getCacheState()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReturnNotInUseWhenFileIsClosedTwice() throws IOException {
+    testFile.close();
+    testFile.close();
+    assertThat(testFile.getCacheState()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldReturnNotInUseWhenFileIsReleased() {
+    testFile.release();
+    assertThat(testFile.getCacheState()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldReturnInUseWhenFileIsReacquired() {
+    testFile.reacquire();
+    assertThat(testFile.getCacheState()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReturnNotInCacheWhenFileCacheIsReset() {
+    testFile.setFileCache(null);
+    assertThat(testFile.getCacheState()).isEqualTo(0);
+  }
+}

--- a/cdm/core/src/test/java/ucar/unidata/io/TestRandomAccessFileCache.java
+++ b/cdm/core/src/test/java/ucar/unidata/io/TestRandomAccessFileCache.java
@@ -10,6 +10,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import ucar.unidata.io.RandomAccessFile.CacheState;
 
 public class TestRandomAccessFileCache {
 
@@ -41,44 +42,50 @@ public class TestRandomAccessFileCache {
 
   @Test
   public void shouldReturnInUseWhenFileIsAcquired() {
-    assertThat(testFile.getCacheState()).isEqualTo(1);
+    assertThat(testFile.getCacheState()).isEqualTo(CacheState.IN_USE);
   }
 
   @Test
   public void shouldReturnNotInUseWhenFileIsClosed() throws IOException {
     testFile.close();
-    assertThat(testFile.getCacheState()).isEqualTo(2);
+    assertThat(testFile.getCacheState()).isEqualTo(CacheState.NOT_IN_USE);
   }
 
   @Test
   public void shouldReturnNotInCacheWhenFileNotInCacheIsClosed() throws IOException {
     testFile.setFileCache(null);
     testFile.close();
-    assertThat(testFile.getCacheState()).isEqualTo(0);
+    assertThat(testFile.getCacheState()).isEqualTo(CacheState.NOT_IN_CACHE);
   }
 
   @Test
   public void shouldReturnNotInUseWhenFileIsClosedTwice() throws IOException {
     testFile.close();
     testFile.close();
-    assertThat(testFile.getCacheState()).isEqualTo(2);
+    assertThat(testFile.getCacheState()).isEqualTo(CacheState.NOT_IN_USE);
   }
 
   @Test
   public void shouldReturnNotInUseWhenFileIsReleased() {
     testFile.release();
-    assertThat(testFile.getCacheState()).isEqualTo(2);
+    assertThat(testFile.getCacheState()).isEqualTo(CacheState.NOT_IN_USE);
   }
 
   @Test
   public void shouldReturnInUseWhenFileIsReacquired() {
     testFile.reacquire();
-    assertThat(testFile.getCacheState()).isEqualTo(1);
+    assertThat(testFile.getCacheState()).isEqualTo(CacheState.IN_USE);
   }
 
   @Test
   public void shouldReturnNotInCacheWhenFileCacheIsReset() {
     testFile.setFileCache(null);
-    assertThat(testFile.getCacheState()).isEqualTo(0);
+    assertThat(testFile.getCacheState()).isEqualTo(CacheState.NOT_IN_CACHE);
+  }
+
+  @Test
+  public void shouldReturnNotInCacheForNewRaf() throws IOException {
+    final RandomAccessFile raf = new RandomAccessFile(tempFolder.newFile().getAbsolutePath(), "r", 0);
+    assertThat(raf.getCacheState()).isEqualTo(CacheState.NOT_IN_CACHE);
   }
 }


### PR DESCRIPTION
## Description of Changes

Small style improvement-- use an enum instead of an int to represent the `cacheState` in `RandomAccessFile`. Add tests for this.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
