### PR TITLE
Fix for Jenkins TDS test failures for GRIB with unusual mixed time intervals

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIosp.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIosp.java
@@ -786,40 +786,41 @@ public abstract class GribIosp extends AbstractIOServiceProvider {
 
       case intvU:
         // data[nruns*ntimes]
+        int dataIndex = 0;
         double[] currentBounds = new double[2];
         double[] prevBounds = new double[2];
         for (int runIdx = 0; runIdx < nruns; runIdx++) {
           CoordinateTimeIntv timeIntv = (CoordinateTimeIntv) time2D.getTimeCoordinate(runIdx);
+          int runOffsetIndex = runIdx * ntimes;
           int timeUnitValue = timeUnit.getValue();
           int time2D_Offset = time2D.getOffset(runIdx);
-          int timeIndex = 0;
           for (TimeCoordIntvValue tinv : timeIntv.getTimeIntervals()) {
             currentBounds[0] = timeUnitValue * tinv.getBounds1() + time2D_Offset;
             currentBounds[1] = timeUnitValue * tinv.getBounds2() + time2D_Offset;
             // Use end-point of current interval as initial guess for current time coordinate value
-            data[timeIndex] = currentBounds[1];
-            if (timeIndex >= 1) {
+            data[dataIndex] = currentBounds[1];
+            if (dataIndex >= runOffsetIndex + 1) {
               // Check that time coordinate values are increasing in a strictly-monotonic manner
               // (as required by CF conventions). If not strictly-monotonic ...
-              if (data[timeIndex] <= data[timeIndex - 1]) {
-                if (timeIndex >= 2) {
-                  if (data[timeIndex - 2] <= currentBounds[0]) {
+              if (data[dataIndex] <= data[dataIndex - 1]) {
+                if (dataIndex >= runOffsetIndex + 2) {
+                  if (data[dataIndex - 2] <= currentBounds[0]) {
                     // Change previous time coordinate value to mid-point between
                     // current time interval start and end values.
-                    data[timeIndex - 1] = (currentBounds[1] - currentBounds[0]) / 2.0 + currentBounds[0];
+                    data[dataIndex - 1] = (currentBounds[1] - currentBounds[0]) / 2.0 + currentBounds[0];
                   } else {
                     // Or change previous time coordinate value to mid-point between
                     // current time interval end value and the time coord value from two steps back.
-                    data[timeIndex - 1] = (currentBounds[1] - data[timeIndex - 2]) / 2.0 + data[timeIndex - 2];
+                    data[dataIndex - 1] = (currentBounds[1] - data[dataIndex - 2]) / 2.0 + data[dataIndex - 2];
                   }
                 } else {
-                  data[timeIndex - 1] = (prevBounds[1] - prevBounds[0]) / 2.0 + prevBounds[0];
+                  data[dataIndex - 1] = (prevBounds[1] - prevBounds[0]) / 2.0 + prevBounds[0];
                 }
               }
             }
             prevBounds[0] = currentBounds[0];
             prevBounds[1] = currentBounds[1];
-            timeIndex++;
+            dataIndex++;
           }
         }
         // The above assumes that sets of intervals are always sorted by

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestDiscontiguousInterval.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestDiscontiguousInterval.java
@@ -2,8 +2,11 @@ package ucar.nc2.grib.coord;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import ucar.ma2.Array;
 import ucar.nc2.*;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 
@@ -18,10 +21,44 @@ public class TestDiscontiguousInterval {
    * @throws IOException
    */
   @Test
-  public void testTimeCoordinate1D_isStrictlyMonotonicallyIncreasing() throws IOException {
+  public void testTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing_Dataset1() throws IOException {
     String testfile = "../grib/src/test/data/GFS_Global_onedeg_20220627_0000.TotalPrecip.Out48hrs.grib2";
+    String varName = "Total_precipitation_surface_Mixed_intervals_Accumulation";
+
+    checkTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing(testfile, varName);
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing_Dataset2() throws IOException {
+    String testfile = TestDir.cdmUnitTestDir + "formats/grib1/wrf-em.wmo";
+    String varName = "Total_precipitation_surface_Mixed_intervals_Accumulation";
+
+    checkTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing(testfile, varName);
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing_Dataset3() throws IOException {
+    String testfile = TestDir.cdmUnitTestDir + "formats/grib1/nomads/ruc2_252_20110830_2300_008.grb";
+    String varName = "Convective_precipitation_surface_Mixed_intervals_Accumulation";
+
+    checkTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing(testfile, varName);
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing_Dataset4() throws IOException {
+    String testfile = TestDir.cdmUnitTestDir + "formats/grib2/cosmo_de_eps_m001_2009051100.grib2";
+    String varName = "Total_precipitation_rate_surface_Mixed_intervals_Accumulation_ens";
+
+    checkTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing(testfile, varName);
+  }
+
+  private void checkTimeCoord1D_fromIntervals_isStrictlyMonotonicallyIncreasing(String testfile, String varName)
+      throws IOException {
     try (NetcdfFile nc = NetcdfFiles.open(testfile)) {
-      Variable dataVar = nc.findVariable("Total_precipitation_surface_Mixed_intervals_Accumulation");
+      Variable dataVar = nc.findVariable(varName);
       Assert.assertNotNull(dataVar);
 
       Dimension timeDim = null;


### PR DESCRIPTION
## Description of Changes

Fix failure in Jenkins TDS tests on some GRIB files with interesting mixed time intervals. Code to generate time coordinate variables from  time intervals wasn't handling case where strict-monotinicity adjustments needed to be made in first timestep.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [ ] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
