### PR TITLE
Fix VariableDS issue in mergeNcml

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
@@ -1626,6 +1626,10 @@ public class NetcdfDataset extends ucar.nc2.NetcdfFile {
     return addLocalFieldsToBuilder(builder());
   }
 
+  /**
+   * @deprecated Use NetcdfDataset.builder()
+   */
+  @Deprecated
   public NetcdfDataset(NetcdfFile.Builder<?> builder) {
     super(builder);
     // LOOK this.orgFile = builder.orgFile;

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -283,7 +283,7 @@ public class NcmlReader {
    * @throws IOException on read error
    */
   public static NetcdfDataset.Builder mergeNcml(NetcdfFile ref, @Nullable Element ncmlElem) throws IOException {
-    NetcdfDataset.Builder targetDS = new NetcdfDataset(ref.toBuilder()).toBuilder(); // no enhance
+    NetcdfDataset.Builder targetDS = NetcdfDataset.builder(ref); // no enhance
 
     if (ncmlElem != null) {
       NcmlReader reader = new NcmlReader();

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
@@ -3,15 +3,74 @@ package ucar.nc2.dataset;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
+import java.io.StringReader;
 import org.junit.Test;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.unidata.util.test.TestDir;
 
 public class TestNetcdfDataset {
+  private static final String TEST_FILE = TestDir.cdmLocalTestDataDir + "ncml/nc/jan.nc";
 
   @Test
   public void shouldGetLastModified() throws IOException {
-    final String location = "src/test/data/ncml/nc/jan.nc";
-    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(location)) {
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(TEST_FILE)) {
       assertThat(netcdfDataset.getLastModified()).isGreaterThan(0);
+    }
+  }
+
+  @Test
+  public void shouldContainVariableDsWhenOpeningDataset() throws IOException {
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(TEST_FILE)) {
+      final Variable datasetVariable = netcdfDataset.findVariable("lat");
+      assertThat((Object) datasetVariable).isInstanceOf(VariableDS.class);
+    }
+  }
+
+  @Test
+  public void shouldContainVariableDsWhenBuildingFromNetcdfFile() throws IOException {
+    try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(TEST_FILE, null)) {
+      final Variable fileVariable = netcdfFile.findVariable("lat");
+      assertThat((Object) fileVariable).isNotInstanceOf(VariableDS.class);
+
+      final NetcdfDataset netcdfDataset = NetcdfDataset.builder(netcdfFile).build();
+      final Variable datasetVariable = netcdfDataset.findVariable("lat");
+      assertThat((Object) datasetVariable).isInstanceOf(VariableDS.class);
+    }
+  }
+
+  @Test
+  public void shouldContainVariableDsWhenEnhancingNetcdfFile() throws IOException {
+    try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(TEST_FILE, null)) {
+      final NetcdfDataset netcdfDataset =
+          NetcdfDatasets.enhance(netcdfFile, NetcdfDataset.getDefaultEnhanceMode(), null);
+      final Variable datasetVariable = netcdfDataset.findVariable("lat");
+      assertThat((Object) datasetVariable).isInstanceOf(VariableDS.class);
+    }
+  }
+
+  @Test
+  public void shouldContainVariableDsWhenEnhancingNetcdfDataset() throws IOException {
+    try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(TEST_FILE, null)) {
+      final NetcdfDataset netcdfDataset = NetcdfDataset.builder(netcdfFile).build();
+      final NetcdfDataset enhancedDataset =
+          NetcdfDatasets.enhance(netcdfDataset, NetcdfDataset.getDefaultEnhanceMode(), null);
+      final Variable datasetVariable = enhancedDataset.findVariable("lat");
+      assertThat((Object) datasetVariable).isInstanceOf(VariableDS.class);
+    }
+  }
+
+  @Test
+  public void shouldContainVariableDsWhenOpenNcmlDataset() throws IOException {
+    String ncml = "<?xml version='1.0' encoding='UTF-8'?>\n" //
+        + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2' enhance='All'>\n" //
+        + "  <dimension name='lat' length='3' />\n" //
+        + "  <variable name='var' shape='lat' type='int'/>\n" //
+        + "</netcdf>"; //
+
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), null, null)) {
+      final Variable datasetVariable = netcdfDataset.findVariable("var");
+      assertThat((Object) datasetVariable).isInstanceOf(VariableDS.class);
     }
   }
 }

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDatasetBuilder.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDatasetBuilder.java
@@ -15,9 +15,10 @@ public class TestNetcdfDatasetBuilder {
     Attribute att = new Attribute("attName", "value");
     Dimension dim = new Dimension("dimName", 42);
     Group.Builder nested = Group.builder().setName("child");
-    VariableDS.Builder<?> vb = VariableDS.builder().setName("varName").setDataType(DataType.STRING);
-    Group.Builder groupb =
-        Group.builder().setName("name").addAttribute(att).addDimension(dim).addGroup(nested).addVariable(vb);
+    Variable.Builder<?> variableBuilder = Variable.builder().setName("varName").setDataType(DataType.STRING);
+    VariableDS.Builder<?> variableDSBuilder = VariableDS.builder().setName("varDSName").setDataType(DataType.STRING);
+    Group.Builder groupb = Group.builder().setName("name").addAttribute(att).addDimension(dim).addGroup(nested)
+        .addVariable(variableBuilder).addVariable(variableDSBuilder);
     nested.setParentGroup(groupb);
 
     NetcdfDataset.Builder builder =
@@ -47,10 +48,18 @@ public class TestNetcdfDatasetBuilder {
     assertThat(child.getParentGroup()).isEqualTo(group);
 
     assertThat(group.getVariables()).isNotEmpty();
-    assertThat(group.getVariables()).hasSize(1);
-    Variable v = group.findVariableLocal("varName");
-    assertThat(v.getParentGroup()).isEqualTo(group);
-    assertThat(v.getNetcdfFile()).isEqualTo(ncfile);
+    assertThat(group.getVariables()).hasSize(2);
+
+    Variable variable = group.findVariableLocal("varName");
+    // TODO is this correct behavior that a NetcdfDataset is allowed to have a Variable that is not a VariableDS?
+    assertThat((Object) variable).isNotInstanceOf(VariableDS.class);
+    assertThat(variable.getParentGroup()).isEqualTo(group);
+    assertThat(variable.getNetcdfFile()).isEqualTo(ncfile);
+
+    Variable variableDS = group.findVariableLocal("varDSName");
+    assertThat((Object) variableDS).isInstanceOf(VariableDS.class);
+    assertThat(variableDS.getParentGroup()).isEqualTo(group);
+    assertThat(variableDS.getNetcdfFile()).isEqualTo(ncfile);
   }
 
 }

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReader.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReader.java
@@ -20,7 +20,7 @@ import ucar.unidata.util.test.TestDir;
 public class TestNcmlReader {
 
   @Test
-  public void shouldMergeNcml() throws IOException {
+  public void shouldMergeNcml() throws IOException, JDOMException {
     final String filename = TestDir.cdmLocalTestDataDir + "example1.nc";
 
     try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(filename, null)) {
@@ -34,18 +34,12 @@ public class TestNcmlReader {
     }
   }
 
-  private static Element getNcmlElement() {
+  private static Element getNcmlElement() throws IOException, JDOMException {
     final String ncml = TestNcmlRead.topDir + "modifyVars.xml";
 
-    try {
-      SAXBuilder saxBuilder = new SAXBuilder();
-      saxBuilder.setExpandEntities(false);
-      Document jdomDoc = saxBuilder.build(ncml);
-      return jdomDoc.getRootElement();
-    } catch (JDOMException | IOException e) {
-      Assert.fail();
-      e.printStackTrace();
-      return null;
-    }
+    SAXBuilder saxBuilder = new SAXBuilder();
+    saxBuilder.setExpandEntities(false);
+    Document jdomDoc = saxBuilder.build(ncml);
+    return jdomDoc.getRootElement();
   }
 }

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReader.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReader.java
@@ -1,0 +1,51 @@
+package ucar.nc2.internal.ncml;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.dataset.VariableDS;
+import ucar.nc2.ncml.TestNcmlRead;
+import ucar.unidata.util.test.TestDir;
+
+public class TestNcmlReader {
+
+  @Test
+  public void shouldMergeNcml() throws IOException {
+    final String filename = TestDir.cdmLocalTestDataDir + "example1.nc";
+
+    try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(filename, null)) {
+      final NetcdfDataset netcdfDataset = NcmlReader.mergeNcml(netcdfFile, getNcmlElement()).build();
+
+      final Variable ncmlVariable = netcdfDataset.findVariable("deltaLat");
+      assertThat((Object) ncmlVariable).isInstanceOf(VariableDS.class);
+
+      final Variable originalVariable = netcdfDataset.findVariable("lat");
+      assertThat((Object) originalVariable).isInstanceOf(VariableDS.class);
+    }
+  }
+
+  private static Element getNcmlElement() {
+    final String ncml = TestNcmlRead.topDir + "modifyVars.xml";
+
+    try {
+      SAXBuilder saxBuilder = new SAXBuilder();
+      saxBuilder.setExpandEntities(false);
+      Document jdomDoc = saxBuilder.build(ncml);
+      return jdomDoc.getRootElement();
+    } catch (JDOMException | IOException e) {
+      Assert.fail();
+      e.printStackTrace();
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Description of Changes

With a datasetScan with ncml, errors due to `Variable`s in a `NetcdfDataset` not being instances of `VariableDS` occurred. My fix for this is to use a different constructor for `NetcdfDataset` in `mergeNcml`. In addition, I deprecated the constructor previously used there, it basically just constructs the parent class `NetcdfFile` and isn't used anywhere else.

In addition to testing `mergeNcml`, I added a few tests for the other constructors of `NetcdfDataset`. I also added a couple of tests in the [TDS](https://github.com/Unidata/tds/pull/335).

A lingering additional question I have is if we should fix the `NetcdfDataset` builder to not allow `Variable`s that are not `VariableDS` (see TODO in TestNetcdfDatasetBuilder.java). This situation can cause similar errors when a dataset is enhanced but I am not sure if/how we should fix this.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
