### PR TITLE
Fix dap tests

### DIFF
--- a/opendap/src/test/java/ucar/nc2/dods/TestUserProblems.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestUserProblems.java
@@ -6,6 +6,7 @@ package ucar.nc2.dods;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -36,6 +37,11 @@ import java.util.List;
 public class TestUserProblems {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  @After
+  public void resetSystemProperty() {
+    System.setProperty("httpservices.urlencode", "true");
+  }
+
   @Test
   public void testGrid() throws IOException, InvalidRangeException {
     System.setProperty("httpservices.urlencode", "false");
@@ -57,7 +63,6 @@ public class TestUserProblems {
       Array data = dataV.read("0, 0:72:1, 0:143:1");
       assertThat(data).isNotNull();
     }
-    System.setProperty("httpservices.urlencode", "true");
   }
 
   // ucar.nc2.dods.TestUserProblems > testNomads STANDARD_ERROR
@@ -97,12 +102,10 @@ public class TestUserProblems {
       ArrayFloat.D4 Temperature = (ArrayFloat.D4) V2.read(origin, shape).reduce();
 
     } catch (IOException ioe) {
-      System.setProperty("httpservices.urlencode", "true");
       System.out.println("trying to open " + testfile + " " + ioe);
       // getting 403 on 2 GB request
       assert true;
     }
-    System.setProperty("httpservices.urlencode", "true");
     System.out.println("---- End of File ----");
   }
 }

--- a/opendap/src/test/java/ucar/nc2/dods/TestUserProblems.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestUserProblems.java
@@ -9,6 +9,7 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
@@ -22,6 +23,7 @@ import ucar.nc2.util.DebugFlagsImpl;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
+import ucar.unidata.util.test.category.NeedsExternalResource;
 
 /**
  * Test nc2 dods in the JUnit framework.
@@ -42,6 +44,7 @@ public class TestUserProblems {
     System.setProperty("httpservices.urlencode", "true");
   }
 
+  @Category(NeedsExternalResource.class)
   @Test
   public void testGrid() throws IOException, InvalidRangeException {
     System.setProperty("httpservices.urlencode", "false");
@@ -68,6 +71,7 @@ public class TestUserProblems {
   // ucar.nc2.dods.TestUserProblems > testNomads STANDARD_ERROR
   // opendap.dap.DAP2Exception: Method failed:HTTP/1.1 403 Forbidden on URL=
   // http://nomads.ncdc.noaa.gov/thredds/dodsC/cfsr1hr/200912/tmp2m.gdas.200912.grb2.dods?Temperature[0:1:744][0:1:0][0:1:575][0:1:1151]
+  @Category(NeedsExternalResource.class)
   @Ignore
   @Test
   public void testNomads() throws InvalidRangeException {


### PR DESCRIPTION
## Description of Changes

Some tests were failing on GitHub unrelated to our PRs. I believe it was because `testGrid` was failing due to a dependence on an external resource and then not resetting a system property related to the URL encoding, and so was causing other tests to fail.

This PR adds a cleanup step for that test and also a NeedsExternalResource tag so that it won't be run on PRs.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
