### PR TITLE
Fix time interval test

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/grib/TestIntervalsTimeCoords2D.java
@@ -57,7 +57,6 @@ import java.util.Collection;
 @Category(NeedsCdmUnitTest.class)
 public class TestIntervalsTimeCoords2D {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private static final double TOLERANCE = 1e-6;
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> getTestParameters() throws IOException {
@@ -133,7 +132,8 @@ public class TestIntervalsTimeCoords2D {
         }
         assertThat(start).isEqualTo(bounds[idx][0]);
         assertThat(end).isEqualTo(bounds[idx][1]);
-        assertThat(coordinateValue).isWithin(TOLERANCE).of(end);
+        assertThat(coordinateValue).isAtMost(end);
+        assertThat(coordinateValue).isAtLeast(start);
         idx++;
       }
 


### PR DESCRIPTION
## Description of Changes

As a consequence of https://github.com/Unidata/netcdf-java/pull/1072, the coordinate is not always equal to the end time bound if this would result in the coordinates not being strictly monotonic. This PR updates a failing test to check that coordinate value is within bounds instead of equal to end bound.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
