### PR TITLE
Close/reacquire raf in gempak file reader

### DIFF
--- a/visad/mcidas/src/main/java/ucar/nc2/iosp/gempak/GempakFileReader.java
+++ b/visad/mcidas/src/main/java/ucar/nc2/iosp/gempak/GempakFileReader.java
@@ -26,6 +26,16 @@ public class GempakFileReader implements GempakConstants {
   protected RandomAccessFile rf;
 
   /**
+   * Close any resources like file handles
+   *
+   * @throws IOException problem reading file
+   */
+  void close() throws IOException {
+    rf.close();
+    rf = null;
+  }
+
+  /**
    * An error message
    */
   private String errorMessage;

--- a/visad/mcidas/src/main/java/ucar/nc2/iosp/gempak/GempakStationFileIOSP.java
+++ b/visad/mcidas/src/main/java/ucar/nc2/iosp/gempak/GempakStationFileIOSP.java
@@ -133,6 +133,39 @@ public abstract class GempakStationFileIOSP extends AbstractIOServiceProvider {
   }
 
   /**
+   * Close any resources like file handles
+   *
+   * @throws IOException problem reading file
+   */
+  @Override
+  public void close() throws IOException {
+    super.close();
+    gemreader.close();
+  }
+
+  /**
+   * Release any resources like file handles
+   *
+   * @throws IOException problem reading file
+   */
+  @Override
+  public void release() throws IOException {
+    super.release();
+    gemreader.close();
+  }
+
+  /**
+   * Reacquire any resources like file handles
+   *
+   * @throws IOException problem reading file
+   */
+  @Override
+  public void reacquire() throws IOException {
+    super.reacquire();
+    gemreader.init(raf, false);
+  }
+
+  /**
    * Initialize the parameter tables.
    */
   private void initTables() throws IOException {

--- a/visad/mcidas/src/test/java/ucar/nc2/iosp/gempak/TestGempakFileReader.java
+++ b/visad/mcidas/src/test/java/ucar/nc2/iosp/gempak/TestGempakFileReader.java
@@ -1,0 +1,48 @@
+package ucar.nc2.iosp.gempak;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ucar.nc2.NetcdfFile;
+import ucar.unidata.io.RandomAccessFile;
+
+public class TestGempakFileReader {
+
+  @ClassRule
+  public static final TemporaryFolder tempFolder = new TemporaryFolder();
+  GempakStationFileIOSP gempakStationFileIOSP;
+
+  @Before
+  public void createGempakIosp() throws IOException {
+    final File tempFile = tempFolder.newFile();
+    final RandomAccessFile randomAccessFile = new RandomAccessFile(tempFile.getAbsolutePath(), "r");
+
+    gempakStationFileIOSP = new GempakSurfaceIOSP();
+    // This also initializes a GempakFileReader which stores this RandomAccessFile
+    gempakStationFileIOSP.open(randomAccessFile, NetcdfFile.builder().build(), null);
+    assertThat(gempakStationFileIOSP.gemreader.rf).isNotNull();
+  }
+
+  @Test
+  public void shouldCloseResources() throws IOException {
+    gempakStationFileIOSP.close();
+    assertThat(gempakStationFileIOSP.gemreader.rf).isNull();
+  }
+
+  @Test
+  public void shouldReleaseResources() throws IOException {
+    gempakStationFileIOSP.release();
+    assertThat(gempakStationFileIOSP.gemreader.rf).isNull();
+  }
+
+  @Test
+  public void shouldReacquireResources() throws IOException {
+    gempakStationFileIOSP.reacquire();
+    assertThat(gempakStationFileIOSP.gemreader.rf).isNotNull();
+  }
+}


### PR DESCRIPTION
## Description of Changes

This PR fixes the failing TDS test `TestStationFcOpenFiles::checkFeatureTypePointWithMissing`. This test fails when run after another test that uses the same file, since the `GempakFileReader` has its own copy of a `RandomAccessFile` which does not get properly closed and reacquired when the cache is cleared between the tests.

This PR closes/reaquires the `GempakFileReader`'s `RandomAccessFile`. Another solution would be for it to not have its own `RandomAccessFile` member, but refer to that of the IOSP-- let me know if you prefer that one. It is probably not hard but I think there need to be new constructors for the `GempakFileReader` and so it seemed to require a few more changes in different places.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
