### PR TITLE
Port validate for CatalogBuilder

### DIFF
--- a/cdm/core/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
@@ -59,12 +59,28 @@ public class CatalogBuilder {
     }
 
     this.baseURI = baseURI;
+    try {
+      validatePort(baseURI);
+    } catch (IllegalArgumentException e) {
+      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      fatalError = true;
+      return null;
+    }
     readXML(location);
     return fatalError ? null : makeCatalog();
   }
 
   public Catalog buildFromURI(URI uri) {
     this.baseURI = uri;
+    try {
+      validatePort(baseURI);
+    } catch (IllegalArgumentException e) {
+      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      fatalError = true;
+      return null;
+    }
     readXML(uri);
     return fatalError ? null : makeCatalog();
   }
@@ -78,6 +94,14 @@ public class CatalogBuilder {
       return null;
     }
     this.baseURI = catrefURI;
+    try {
+      validatePort(baseURI);
+    } catch (IllegalArgumentException e) {
+      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      fatalError = true;
+      return null;
+    }
     Catalog result = buildFromURI(catrefURI);
     catref.setRead(!fatalError);
     return fatalError ? null : result;
@@ -85,20 +109,65 @@ public class CatalogBuilder {
 
   public Catalog buildFromString(String catalogAsString, URI docBaseUri) {
     this.baseURI = docBaseUri;
+    try {
+      validatePort(baseURI);
+    } catch (IllegalArgumentException e) {
+      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      fatalError = true;
+      return null;
+    }
     readXMLfromString(catalogAsString);
     return fatalError ? null : makeCatalog();
   }
 
   public Catalog buildFromStream(InputStream stream, URI docBaseUri) {
     this.baseURI = docBaseUri;
+    try {
+      validatePort(baseURI);
+    } catch (IllegalArgumentException e) {
+      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      fatalError = true;
+      return null;
+    }
     readXML(stream);
     return fatalError ? null : makeCatalog();
   }
 
   public Catalog buildFromJdom(Element root, URI docBaseUri) {
     this.baseURI = docBaseUri;
+    try {
+      validatePort(baseURI);
+    } catch (IllegalArgumentException e) {
+      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      fatalError = true;
+      return null;
+    }
     readCatalog(root);
     return fatalError ? null : makeCatalog();
+  }
+
+  /*
+   * Validates port number of given URI.
+   * URI already meets RFC 2396 to pass creation.
+   * We are checking to make sure port # isn't something nefarious.
+   *
+   * @param   baseURI  java.net.URI to validate
+   * @throws  IllegalArgumentException  if URI port number if
+   * @see <https://github.com/Unidata/netcdf-java/pull/1131>
+   */
+  public void validatePort(URI baseURI) throws IllegalArgumentException {
+    int port = baseURI.getPort();
+    // -1 means port undefined, so request will default to port 80
+    if (port != -1) {
+      // TCP/IP port numbers below 1024 are only for root user.
+      if (port < 1024 && (port != 80 || port != 443)) {
+        throw new IllegalArgumentException("User requesting access to catalog on non-valid root-privileged port: " +
+            new Integer(port).toString());
+      }
+    }
   }
 
   public String getErrorMessage() {

--- a/cdm/core/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
@@ -62,8 +62,8 @@ public class CatalogBuilder {
     try {
       validatePort(baseURI);
     } catch (IllegalArgumentException e) {
-      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
-      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      errlog.format("Invalid port number = '%s' err='%s'%n ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number = '{}' err='{}}'", baseURI.toASCIIString(), e.getMessage());
       fatalError = true;
       return null;
     }
@@ -76,8 +76,8 @@ public class CatalogBuilder {
     try {
       validatePort(baseURI);
     } catch (IllegalArgumentException e) {
-      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
-      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      errlog.format("Invalid port number = '%s' err='%s'%n ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number = '{}' err='{}}'", baseURI.toASCIIString(), e.getMessage());
       fatalError = true;
       return null;
     }
@@ -97,8 +97,8 @@ public class CatalogBuilder {
     try {
       validatePort(baseURI);
     } catch (IllegalArgumentException e) {
-      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
-      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      errlog.format("Invalid port number = '%s' err='%s'%n ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number = '{}' err='{}}'", baseURI.toASCIIString(), e.getMessage());
       fatalError = true;
       return null;
     }
@@ -112,8 +112,8 @@ public class CatalogBuilder {
     try {
       validatePort(baseURI);
     } catch (IllegalArgumentException e) {
-      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
-      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      errlog.format("Invalid port number = '%s' err='%s'%n ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number = '{}' err='{}}'", baseURI.toASCIIString(), e.getMessage());
       fatalError = true;
       return null;
     }
@@ -126,8 +126,8 @@ public class CatalogBuilder {
     try {
       validatePort(baseURI);
     } catch (IllegalArgumentException e) {
-      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
-      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      errlog.format("Invalid port number = '%s' err='%s'%n ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number = '{}' err='{}}'", baseURI.toASCIIString(), e.getMessage());
       fatalError = true;
       return null;
     }
@@ -140,8 +140,8 @@ public class CatalogBuilder {
     try {
       validatePort(baseURI);
     } catch (IllegalArgumentException e) {
-      errlog.format("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
-      logger.error("Invalid port number: ", baseURI.toASCIIString(), e.getMessage());
+      errlog.format("Invalid port number = '%s' err='%s'%n ", baseURI.toASCIIString(), e.getMessage());
+      logger.error("Invalid port number = '{}' err='{}}'", baseURI.toASCIIString(), e.getMessage());
       fatalError = true;
       return null;
     }
@@ -158,14 +158,16 @@ public class CatalogBuilder {
    * @throws  IllegalArgumentException  if URI port number if
    * @see <https://github.com/Unidata/netcdf-java/pull/1131>
    */
-  public void validatePort(URI baseURI) throws IllegalArgumentException {
+  private void validatePort(URI baseURI) throws IllegalArgumentException {
     int port = baseURI.getPort();
-    // -1 means port undefined, so request will default to port 80
+    // -1 means port undefined
     if (port != -1) {
       // TCP/IP port numbers below 1024 are only for root user.
-      if (port < 1024 && (port != 80 || port != 443)) {
-        throw new IllegalArgumentException("User requesting access to catalog on non-valid root-privileged port: " +
-            new Integer(port).toString());
+      if (port < 1024) {
+        if (port != 80 && port != 443) {
+          throw new IllegalArgumentException("User requesting access to catalog on non-valid root-privileged port: " +
+              Integer.toString(port));
+        }
       }
     }
   }

--- a/cdm/core/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
+++ b/cdm/core/src/main/java/thredds/client/catalog/builder/CatalogBuilder.java
@@ -154,8 +154,10 @@ public class CatalogBuilder {
    * URI already meets RFC 2396 to pass creation.
    * We are checking to make sure port # isn't something nefarious.
    *
-   * @param   baseURI  java.net.URI to validate
-   * @throws  IllegalArgumentException  if URI port number if
+   * @param baseURI java.net.URI to validate
+   * 
+   * @throws IllegalArgumentException if URI port number if
+   * 
    * @see <https://github.com/Unidata/netcdf-java/pull/1131>
    */
   private void validatePort(URI baseURI) throws IllegalArgumentException {
@@ -165,8 +167,8 @@ public class CatalogBuilder {
       // TCP/IP port numbers below 1024 are only for root user.
       if (port < 1024) {
         if (port != 80 && port != 443) {
-          throw new IllegalArgumentException("User requesting access to catalog on non-valid root-privileged port: " +
-              Integer.toString(port));
+          throw new IllegalArgumentException(
+              "User requesting access to catalog on non-valid root-privileged port: " + Integer.toString(port));
         }
       }
     }

--- a/cdm/core/src/test/java/thredds/client/catalog/builder/TestCatalogBuilder.java
+++ b/cdm/core/src/test/java/thredds/client/catalog/builder/TestCatalogBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 1998-2023 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+package thredds.client.catalog.builder;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URISyntaxException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.net.URI;
+
+
+/**
+ * Unit tests for catalog builder port validation
+ */
+public class TestCatalogBuilder {
+
+  public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  CatalogBuilder catalogBuilder = new CatalogBuilder();
+  String host = "https://thredds-test.unidata.ucar.edu";
+  String catalog = "/thredds/catalog/grib/NCEP/GFS/Global_0p25deg_ana/latest.xml";
+
+  @Test
+  public void testValidationNoPort() throws URISyntaxException {
+    // no port specified; should be -1
+    URI testURI = new URI(host + catalog);
+    Assert.assertEquals(Long.valueOf(-1), Long.valueOf(testURI.getPort()));
+
+    // no port specified; -1 is OK for port validation
+    catalogBuilder.buildFromURI(testURI);
+    Assert.assertFalse(catalogBuilder.hasFatalError());
+  }
+
+  @Test
+  public void testValidationValidRootPort() throws URISyntaxException {
+    String port = "443";
+    // valid root privileged port specified
+    URI testURI = new URI(host + ":" + port + catalog);
+    Assert.assertEquals(Long.valueOf(port), Long.valueOf(testURI.getPort()));
+
+    // 443 is OK for port validation
+    catalogBuilder.buildFromURI(testURI);
+    Assert.assertFalse(catalogBuilder.hasFatalError());
+  }
+
+  @Test
+  public void testValidationInvalidRootPort() throws URISyntaxException {
+    String port = "22";
+    // invalid root privileged port specified
+    URI testURI = new URI(host + ":" + port + catalog);
+    Assert.assertEquals(Long.valueOf(port), Long.valueOf(testURI.getPort()));
+
+    // fails port validation
+    catalogBuilder.buildFromURI(testURI);
+    Assert.assertTrue(catalogBuilder.hasFatalError());
+  }
+
+  @Test
+  public void testValidationInvalidNonRootPort() throws URISyntaxException {
+    String port = "8081";
+    // valid non-root privileged port specified
+    URI testURI = new URI(host + ":" + port + catalog);
+    Assert.assertEquals(Long.valueOf(port), Long.valueOf(testURI.getPort()));
+
+    // non-root privileged port is OK for port validation, but will fail against Unidata TDS server
+    catalogBuilder.buildFromURI(testURI);
+    Assert.assertTrue(catalogBuilder.hasFatalError());
+  }
+ }

--- a/cdm/core/src/test/java/thredds/client/catalog/builder/TestCatalogBuilder.java
+++ b/cdm/core/src/test/java/thredds/client/catalog/builder/TestCatalogBuilder.java
@@ -70,4 +70,4 @@ public class TestCatalogBuilder {
     catalogBuilder.buildFromURI(testURI);
     Assert.assertTrue(catalogBuilder.hasFatalError());
   }
- }
+}


### PR DESCRIPTION
Added port validation in CatalogBuilder:
- root-privileged ports under 1024 not allowed unless 80 or 443

Added unit tests for aforementioned port validation
