### PR TITLE
Fix deprecations of overrides

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/Structure.java
+++ b/cdm/core/src/main/java/ucar/nc2/Structure.java
@@ -135,6 +135,8 @@ public class Structure extends Variable {
   }
 
   // for section and slice
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected Structure copy() {
     return new Structure(this);

--- a/cdm/core/src/main/java/ucar/nc2/Variable.java
+++ b/cdm/core/src/main/java/ucar/nc2/Variable.java
@@ -454,7 +454,7 @@ public class Variable extends CDMNode implements VariableSimpleIF, ProxyReader, 
     return sliceV.build(getParentGroupOrRoot());
   }
 
-  /** @deprecated Use Variable.toBuilder() */
+  /** @deprecated Use {@link #toBuilder()} */
   @Deprecated
   protected Variable copy() {
     return new Variable(this);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis.java
@@ -146,7 +146,8 @@ public class CoordinateAxis extends VariableDS {
   }
 
   // for section and slice
-
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected CoordinateAxis copy() {
     return new CoordinateAxis(this.ncd, this);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1D.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1D.java
@@ -181,7 +181,8 @@ public class CoordinateAxis1D extends CoordinateAxis {
   }
 
   // for section and slice
-
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected CoordinateAxis1D copy() {
     return new CoordinateAxis1D(this.ncd, this);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1DTime.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis1DTime.java
@@ -65,6 +65,8 @@ public class CoordinateAxis1DTime extends CoordinateAxis1D {
   ////////////////////////////////////////////////////////////////
 
   // for section and slice
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected CoordinateAxis1DTime copy() {
     return new CoordinateAxis1DTime(this.ncd, this);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis2D.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateAxis2D.java
@@ -40,6 +40,8 @@ public class CoordinateAxis2D extends CoordinateAxis {
   }
 
   // for section and slice
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected CoordinateAxis2D copy() {
     return new CoordinateAxis2D(this.ncd, this);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/StructureDS.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/StructureDS.java
@@ -127,7 +127,8 @@ public class StructureDS extends ucar.nc2.Structure implements VariableEnhanced 
   }
 
   // for section and slice and select
-
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected StructureDS copy() {
     return new StructureDS(getParentGroupOrRoot(), this);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/StructurePseudoDS.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/StructurePseudoDS.java
@@ -108,6 +108,8 @@ public class StructurePseudoDS extends StructureDS {
     calcElementSize();
   }
 
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected StructureDS copy() {
     throw new UnsupportedOperationException();

--- a/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
@@ -183,6 +183,8 @@ public class VariableDS extends Variable implements VariableEnhanced, EnhanceSca
   }
 
   // for section and slice
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected VariableDS copy() {
     return new VariableDS(this, true);

--- a/opendap/src/main/java/ucar/nc2/dods/DODSGrid.java
+++ b/opendap/src/main/java/ucar/nc2/dods/DODSGrid.java
@@ -61,6 +61,8 @@ public class DODSGrid extends DODSVariable {
   }
 
   // for section, slice
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected Variable copy() {
     return new DODSGrid(this);

--- a/opendap/src/main/java/ucar/nc2/dods/DODSStructure.java
+++ b/opendap/src/main/java/ucar/nc2/dods/DODSStructure.java
@@ -71,6 +71,8 @@ public class DODSStructure extends ucar.nc2.Structure implements DODSNode {
   }
 
   // for section and slice
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected DODSStructure copy() {
     return new DODSStructure(this); // dont need to reparent

--- a/opendap/src/main/java/ucar/nc2/dods/DODSVariable.java
+++ b/opendap/src/main/java/ucar/nc2/dods/DODSVariable.java
@@ -95,6 +95,8 @@ public class DODSVariable extends ucar.nc2.Variable implements DODSNode {
   }
 
   // for section, slice
+  /** @deprecated Use {@link #toBuilder()} */
+  @Deprecated
   @Override
   protected Variable copy() {
     return new DODSVariable(this);


### PR DESCRIPTION
## Description of Changes

Add deprecation annotations to overrides of the deprecated method `Variable::copy`

As described [here](https://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/deprecation/deprecation.html#:~:text=It%20is%20possible%20for%20a%20non%2Ddeprecated%20property%20to%20hide,fact%20they%20should%20be%20deprecated.)

>  It is possible for a non-deprecated property to hide or override a deprecated one, which removes deprecation. As developer of an API, it is your responsibility to deprecate overrides of a deprecated method, if in fact they should be deprecated.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
