### PR TITLE
GEOSTransform better test if past limb

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
@@ -170,8 +170,8 @@ public class GEOSTransform {
     double theta_sat = Double.NaN;
 
     if (scan_geom.equals(GEOS)) { // GEOS (eg. SEVIRI, MSG) CGMS 03, 4.4.3.2, Normalized Geostationary Projection
-       if (h * (h - r_1) < r_3 * r_3 + r_eq * r_eq * r_2 * r_2 / (r_pol * r_pol)) {
-         return new double[] {Double.NaN, Double.NaN};
+      if (h * (h - r_1) < r_3 * r_3 + r_eq * r_eq * r_2 * r_2 / (r_pol * r_pol)) {
+        return new double[] {Double.NaN, Double.NaN};
       }
       lamda_sat = Math.atan(-r_2 / r_1);
       theta_sat = Math.asin(r_3 / Math.sqrt(r_1 * r_1 + r_2 * r_2 + r_3 * r_3));

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/GEOSTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2023 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -170,9 +170,15 @@ public class GEOSTransform {
     double theta_sat = Double.NaN;
 
     if (scan_geom.equals(GEOS)) { // GEOS (eg. SEVIRI, MSG) CGMS 03, 4.4.3.2, Normalized Geostationary Projection
+       if (h * (h - r_1) < r_3 * r_3 + r_eq * r_eq * r_2 * r_2 / (r_pol * r_pol)) {
+         return new double[] {Double.NaN, Double.NaN};
+      }
       lamda_sat = Math.atan(-r_2 / r_1);
       theta_sat = Math.asin(r_3 / Math.sqrt(r_1 * r_1 + r_2 * r_2 + r_3 * r_3));
     } else if (scan_geom.equals(GOES)) { // GOES (eg. GOES-R ABI)
+      if (h * (h - r_1) < r_2 * r_2 + r_eq * r_eq * r_3 * r_3 / (r_pol * r_pol)) {
+        return new double[] {Double.NaN, Double.NaN};
+      }
       lamda_sat = Math.asin(-r_2 / Math.sqrt(r_1 * r_1 + r_2 * r_2 + r_3 * r_3));
       theta_sat = Math.atan(r_3 / r_1);
     }

--- a/cdm/core/src/test/java/ucar/unidata/geoloc/projection/sat/TestGEOSTransform.java
+++ b/cdm/core/src/test/java/ucar/unidata/geoloc/projection/sat/TestGEOSTransform.java
@@ -1,0 +1,108 @@
+package ucar.unidata.geoloc.projection.sat;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.unidata.geoloc.LatLonPoint;
+import ucar.unidata.geoloc.Projection;
+import ucar.unidata.geoloc.ProjectionPoint;
+
+public class TestGEOSTransform {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final double subLonDegrees = -75.0;
+  private final boolean isSweepX = true; // GOES
+  private final Projection projection = new Geostationary(subLonDegrees, isSweepX);
+
+  private static final double TOLERANCE = 1e-6;
+
+  @Test
+  public void shouldConvertProjectionPoint() {
+    final double[] xValues = new double[] {-0.1, 0, 0.1};
+    final double[] yValues = new double[] {-0.1, 0, 0.1};
+
+    for (double x : xValues) {
+      for (double y : yValues) {
+        final ProjectionPoint projectionPoint = ProjectionPoint.create(x, y);
+        final LatLonPoint computedLatLonPoint = projection.projToLatLon(projectionPoint);
+        final ProjectionPoint computedProjectionPoint = projection.latLonToProj(computedLatLonPoint);
+        assertThat(computedProjectionPoint.getX()).isWithin(TOLERANCE).of(projectionPoint.getX());
+        assertThat(computedProjectionPoint.getY()).isWithin(TOLERANCE).of(projectionPoint.getY());
+      }
+    }
+  }
+
+  @Test
+  public void shouldConvertProjectionPointToExpectedLatLon() {
+    // Values taken from GOES-R product definition and users guide
+    final double x = -0.024052;
+    final double y = 0.095340;
+    final double expectedLat = 33.846162;
+    final double expectedLon = -84.690932;
+
+    final ProjectionPoint projectionPoint = ProjectionPoint.create(x, y);
+
+    final LatLonPoint computedLatLonPoint = projection.projToLatLon(projectionPoint);
+    assertThat(computedLatLonPoint.getLatitude()).isWithin(TOLERANCE).of(expectedLat);
+    assertThat(computedLatLonPoint.getLongitude()).isWithin(TOLERANCE).of(expectedLon);
+
+    final ProjectionPoint computedProjectionPoint = projection.latLonToProj(computedLatLonPoint);
+    assertThat(computedProjectionPoint.getX()).isWithin(TOLERANCE).of(projectionPoint.getX());
+    assertThat(computedProjectionPoint.getY()).isWithin(TOLERANCE).of(projectionPoint.getY());
+  }
+
+  @Test
+  public void shouldReturnNanForNotVisibleProjectionPoints() {
+    // Approximately the corners of the box containing full disk
+    final List<ProjectionPoint> projectionPoints = Arrays.asList(ProjectionPoint.create(-0.15, -0.15),
+        ProjectionPoint.create(-0.15, 0.15), ProjectionPoint.create(0.15, -0.15), ProjectionPoint.create(0.15, 0.15));
+
+    for (ProjectionPoint projectionPoint : projectionPoints) {
+      final LatLonPoint computedLatLonPoint = projection.projToLatLon(projectionPoint);
+      assertThat(computedLatLonPoint.getLatitude()).isNaN();
+      assertThat(computedLatLonPoint.getLongitude()).isNaN();
+    }
+  }
+
+  @Test
+  public void shouldNotReturnNanForVisibleProjectionPoints() {
+    // Approximately the edges of the full disk
+    final List<ProjectionPoint> projectionPoints = Arrays.asList(ProjectionPoint.create(0, -0.1512),
+        ProjectionPoint.create(0, 0.1512), ProjectionPoint.create(-0.1518, 0), ProjectionPoint.create(0.1518, 0));
+
+    for (ProjectionPoint projectionPoint : projectionPoints) {
+      final LatLonPoint computedLatLonPoint = projection.projToLatLon(projectionPoint);
+      assertThat(computedLatLonPoint.getLatitude()).isNotNaN();
+      assertThat(computedLatLonPoint.getLongitude()).isNotNaN();
+    }
+  }
+
+  @Test
+  public void shouldReturnNanForNotVisibleLatLonPoints() {
+    final List<LatLonPoint> latLonPoints = Arrays.asList(LatLonPoint.create(50, 5), LatLonPoint.create(-50, 5),
+        LatLonPoint.create(50, -160), LatLonPoint.create(-50, -160));
+
+    for (LatLonPoint latLonPoint : latLonPoints) {
+      final ProjectionPoint computedProjectionPoint = projection.latLonToProj(latLonPoint);
+      assertThat(computedProjectionPoint.getX()).isNaN();
+      assertThat(computedProjectionPoint.getY()).isNaN();
+    }
+  }
+
+  @Test
+  public void shouldNotReturnNanForVisibleLatLonPoints() {
+    final List<LatLonPoint> latLonPoints = Arrays.asList(LatLonPoint.create(-78, -75), LatLonPoint.create(78, -75),
+        LatLonPoint.create(0, -154), LatLonPoint.create(0, 4));
+
+    for (LatLonPoint latLonPoint : latLonPoints) {
+      final ProjectionPoint computedProjectionPoint = projection.latLonToProj(latLonPoint);
+      assertThat(computedProjectionPoint.getX()).isNotNaN();
+      assertThat(computedProjectionPoint.getY()).isNotNaN();
+    }
+  }
+}


### PR DESCRIPTION
As previously coded, GEOSTransform was providing non-null results for locations that were just past the visible limb of the planet but not more than 90° away from the below-satellite point.

## Description of Changes

I have added a better test to determine if such lon-lat points should be ignored based on the "GOES R SERIES PRODUCT DEFINITION AND USERS’ GUIDE (PUG)", sects. 5.1.2.8.1-5.1.2.8.2 (pp. 21-24) which can be dowloaded at https://www.goes-r.gov/resources/docs.html

I have tested this for the GOES orientation but not the GEOS, as I do not have sample datasets for the latter.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
