### PR TITLE
Improve exception

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/iosp/IospHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/IospHelper.java
@@ -281,8 +281,9 @@ public class IospHelper {
    */
   public static Object readDataFill(LayoutBB layout, DataType dataType, Object fillValue) {
     long size = layout.getTotalNelems();
-    if (dataType == DataType.STRUCTURE)
+    if (dataType == DataType.STRUCTURE) {
       size *= layout.getElemSize();
+    }
     Object arr = (fillValue == null) ? makePrimitiveArray((int) size, dataType)
         : makePrimitiveArray((int) size, dataType, fillValue);
     return readData(layout, dataType, arr);

--- a/cdm/core/src/main/java/ucar/nc2/iosp/IospHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/IospHelper.java
@@ -284,6 +284,9 @@ public class IospHelper {
     if (dataType == DataType.STRUCTURE) {
       size *= layout.getElemSize();
     }
+    if (size > Integer.MAX_VALUE) {
+      throw new RuntimeException("Read request size of " + size + " is too large.");
+    }
     Object arr = (fillValue == null) ? makePrimitiveArray((int) size, dataType)
         : makePrimitiveArray((int) size, dataType, fillValue);
     return readData(layout, dataType, arr);

--- a/cdm/core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5iospNew.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/iosp/hdf5/TestH5iospNew.java
@@ -1,18 +1,23 @@
 package ucar.nc2.internal.iosp.hdf5;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.iosp.IOServiceProvider;
 import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 public class TestH5iospNew {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -59,5 +64,19 @@ public class TestH5iospNew {
     assertThat(h5iospNew.getRandomAccessFile()).isNull();
     assertThat(h5iospNew.getHeader().getRandomAccessFile()).isNull();
     assertThat(h5iospNew.getHeader().getH5objects().getRandomAccessFile()).isNull();
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void shouldThrowWhenReadingTooLargeVariable() throws IOException {
+    final String filename = TestDir.cdmUnitTestDir + "formats/netcdf4/UpperDeschutes_t4p10_swemelt.nc";
+
+    try (NetcdfFile ncfile = NetcdfDatasets.openFile(filename, null)) {
+      final Variable variable = ncfile.findVariable("UpperDeschutes_t4p10_swemelt");
+      assertThat((Object) variable).isNotNull();
+      assertThat(variable.getSize()).isAtLeast(Integer.MAX_VALUE);
+      final RuntimeException exception = assertThrows(RuntimeException.class, variable::read);
+      assertThat(exception.getMessage()).isEqualTo("Read request size of 2524250575 is too large.");
+    }
   }
 }


### PR DESCRIPTION
## Description of Changes

This PR would improve the exception you get when trying to read a variable's data that is too large. Previously, the `long size` would get narrowed to an `int` and overflow so you'd end up with a `NegativeArraySizeException`. I think an exception saying the request is too large is slightly nicer than the `NegativeArraySizeException`.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
