### PR TITLE
Add method to combine Arrays

### DIFF
--- a/cdm/core/src/main/java/ucar/ma2/Array.java
+++ b/cdm/core/src/main/java/ucar/ma2/Array.java
@@ -388,7 +388,8 @@ public abstract class Array {
   public static Array factoryCopy(DataType dataType, int[] shape, List<Array> arrays) {
     if (arrays.isEmpty()) {
       throw new IllegalArgumentException("Expected a non-empty list of Arrays to combine");
-    } else if (arrays.size() == 1) {
+    }
+    if (arrays.size() == 1) {
       return factory(dataType, shape, arrays.get(0).getStorage());
     }
     final long size = Index.computeSize(shape);

--- a/cdm/core/src/main/java/ucar/ma2/Array.java
+++ b/cdm/core/src/main/java/ucar/ma2/Array.java
@@ -382,8 +382,9 @@ public abstract class Array {
    *
    * @param dataType the DataType
    * @param shape the shape of the combined array
-   * @param arrays non-empty list of arrays of dataType to combine
+   * @param arrays non-empty list of arrays of the same dataType to combine
    * @return a new Array containing data from the arrays
+   * @throws IllegalArgumentException if arrays is empty or if it contains ArrayStructures with different Members
    */
   public static Array factoryCopy(DataType dataType, int[] shape, List<Array> arrays) {
     if (arrays.isEmpty()) {
@@ -416,6 +417,10 @@ public abstract class Array {
   private static Array combineArrayStructures(long size, List<Array> arrays) {
     final StructureData[] combinedStructureData = new StructureData[(int) size];
     final StructureMembers members = ((ArrayStructure) arrays.get(0)).getStructureMembers();
+
+    if (arrays.stream().anyMatch(array -> !((ArrayStructure) array).getStructureMembers().equals(members))) {
+      throw new IllegalArgumentException("Expected ArrayStructures to be combined to have the same members");
+    }
 
     int count = 0;
     for (Array array : arrays) {

--- a/cdm/core/src/main/java/ucar/ma2/DataType.java
+++ b/cdm/core/src/main/java/ucar/ma2/DataType.java
@@ -35,6 +35,7 @@ public enum DataType {
 
   OPAQUE("opaque", 1, ByteBuffer.class, false), // byte blobs
 
+  // TODO deprecate and remove in v6?
   OBJECT("object", 1, Object.class, false), // added for use with Array
 
   UBYTE("ubyte", 1, byte.class, true), // unsigned byte

--- a/cdm/core/src/main/java/ucar/ma2/StructureMembers.java
+++ b/cdm/core/src/main/java/ucar/ma2/StructureMembers.java
@@ -360,8 +360,8 @@ public final class StructureMembers {
         return false;
       }
       Member other = (Member) o;
-      return getFullName().equals(other.getName()) && getDescription().equals(other.getDescription())
-          && getUnitsString().equals(other.getUnitsString()) && getDataType() == other.getDataType()
+      return getFullName().equals(other.getName()) && Objects.equals(getDescription(), other.getDescription())
+          && Objects.equals(getUnitsString(), other.getUnitsString()) && getDataType() == other.getDataType()
           && getSize() == other.getSize() && Arrays.equals(getShape(), other.getShape())
           && Objects.equals(getStructureMembers(), other.getStructureMembers());
     }

--- a/cdm/core/src/main/java/ucar/ma2/StructureMembers.java
+++ b/cdm/core/src/main/java/ucar/ma2/StructureMembers.java
@@ -8,8 +8,10 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import ucar.nc2.util.Indent;
@@ -153,6 +155,19 @@ public final class StructureMembers {
   public String toString() {
     return MoreObjects.toStringHelper(this).add("name", name).add("members", members)
         .add("structureSize", structureSize).toString();
+  }
+
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof StructureMembers)) {
+      return false;
+    }
+    StructureMembers other = (StructureMembers) o;
+    return getName().equals(other.getName()) && getStructureSize() == other.getStructureSize()
+        && getMembers().size() == other.getMembers().size()
+        && getMembers().stream().allMatch(m -> m.equals(other.findMember(m.getName())));
   }
 
   /** A member of a StructureData. */
@@ -335,6 +350,20 @@ public final class StructureMembers {
      */
     public boolean isScalar() {
       return size == 1;
+    }
+
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Member)) {
+        return false;
+      }
+      Member other = (Member) o;
+      return getFullName().equals(other.getName()) && getDescription().equals(other.getDescription())
+          && getUnitsString().equals(other.getUnitsString()) && getDataType() == other.getDataType()
+          && getSize() == other.getSize() && Arrays.equals(getShape(), other.getShape())
+          && Objects.equals(getStructureMembers(), other.getStructureMembers());
     }
 
     ////////////////////////////////////////////////

--- a/cdm/core/src/test/java/ucar/ma2/TestArray.java
+++ b/cdm/core/src/test/java/ucar/ma2/TestArray.java
@@ -1,121 +1,174 @@
 package ucar.ma2;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.StructureMembers.MemberBuilder;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class TestArray {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  @Parameterized.Parameters(name = "{0}")
-  public static List<Object[]> getTestParameters() {
-    final int[] shape = new int[] {1};
-    List<Object[]> testCases = new ArrayList<>();
+  @RunWith(Parameterized.class)
+  public static class TestArrayParameterized {
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> getTestParameters() {
+      final int[] shape = new int[] {1};
+      List<Object[]> testCases = new ArrayList<>();
 
-    testCases.add(new Object[] {DataType.BOOLEAN, shape, new boolean[] {false}, new boolean[] {false, false}});
-    testCases.add(new Object[] {DataType.BYTE, shape, new byte[] {1}, new byte[] {1, 1}});
-    testCases.add(new Object[] {DataType.CHAR, shape, new char[] {'a'}, new char[] {'a', 'a'}});
-    testCases.add(new Object[] {DataType.SHORT, shape, new short[] {1}, new short[] {1, 1}});
-    testCases.add(new Object[] {DataType.INT, shape, new int[] {1}, new int[] {1, 1}});
-    testCases.add(new Object[] {DataType.LONG, shape, new long[] {1}, new long[] {1, 1}});
-    testCases.add(new Object[] {DataType.FLOAT, shape, new float[] {1.1f}, new float[] {1.1f, 1.1f}});
-    testCases.add(new Object[] {DataType.DOUBLE, shape, new double[] {1.1}, new double[] {1.1, 1.1}});
-    testCases.add(new Object[] {DataType.SEQUENCE, shape, new Object[] {1}, new Object[] {1, 1}});
-    testCases.add(new Object[] {DataType.STRING, shape, new Object[] {1}, new Object[] {1, 1}});
-    testCases.add(new Object[] {DataType.STRUCTURE, shape, new Object[] {1}, new Object[] {1, 1}});
-    testCases.add(new Object[] {DataType.ENUM1, shape, new byte[] {1}, new byte[] {1, 1}});
-    testCases.add(new Object[] {DataType.ENUM2, shape, new short[] {1}, new short[] {1, 1}});
-    testCases.add(new Object[] {DataType.ENUM4, shape, new int[] {1}, new int[] {1, 1}});
-    testCases.add(new Object[] {DataType.OPAQUE, shape, new Object[] {1}, new Object[] {1, 1}});
-    // Cannot be created through the factory
-    // testCases.add(new Object[] {DataType.OBJECT, shape, new Object[]{1}, new Object[]{1, 1}});
-    testCases.add(new Object[] {DataType.UBYTE, shape, new byte[] {1}, new byte[] {1, 1}});
-    testCases.add(new Object[] {DataType.USHORT, shape, new short[] {1}, new short[] {1, 1}});
-    testCases.add(new Object[] {DataType.UINT, shape, new int[] {1}, new int[] {1, 1}});
-    testCases.add(new Object[] {DataType.ULONG, shape, new long[] {1}, new long[] {1, 1}});
+      testCases.add(new Object[] {DataType.BOOLEAN, shape, new boolean[] {false}, new boolean[] {false, false}});
+      testCases.add(new Object[] {DataType.BYTE, shape, new byte[] {1}, new byte[] {1, 1}});
+      testCases.add(new Object[] {DataType.CHAR, shape, new char[] {'a'}, new char[] {'a', 'a'}});
+      testCases.add(new Object[] {DataType.SHORT, shape, new short[] {1}, new short[] {1, 1}});
+      testCases.add(new Object[] {DataType.INT, shape, new int[] {1}, new int[] {1, 1}});
+      testCases.add(new Object[] {DataType.LONG, shape, new long[] {1}, new long[] {1, 1}});
+      testCases.add(new Object[] {DataType.FLOAT, shape, new float[] {1.1f}, new float[] {1.1f, 1.1f}});
+      testCases.add(new Object[] {DataType.DOUBLE, shape, new double[] {1.1}, new double[] {1.1, 1.1}});
+      testCases.add(new Object[] {DataType.SEQUENCE, shape, new Object[] {1}, new Object[] {1, 1}});
+      testCases.add(new Object[] {DataType.STRING, shape, new Object[] {1}, new Object[] {1, 1}});
+      testCases.add(new Object[] {DataType.STRUCTURE, shape, new Object[] {1}, new Object[] {1, 1}});
+      testCases.add(new Object[] {DataType.ENUM1, shape, new byte[] {1}, new byte[] {1, 1}});
+      testCases.add(new Object[] {DataType.ENUM2, shape, new short[] {1}, new short[] {1, 1}});
+      testCases.add(new Object[] {DataType.ENUM4, shape, new int[] {1}, new int[] {1, 1}});
+      testCases.add(new Object[] {DataType.OPAQUE, shape, new Object[] {1}, new Object[] {1, 1}});
+      // Cannot be created through the factory
+      // testCases.add(new Object[] {DataType.OBJECT, shape, new Object[]{1}, new Object[]{1, 1}});
+      testCases.add(new Object[] {DataType.UBYTE, shape, new byte[] {1}, new byte[] {1, 1}});
+      testCases.add(new Object[] {DataType.USHORT, shape, new short[] {1}, new short[] {1, 1}});
+      testCases.add(new Object[] {DataType.UINT, shape, new int[] {1}, new int[] {1, 1}});
+      testCases.add(new Object[] {DataType.ULONG, shape, new long[] {1}, new long[] {1, 1}});
 
-    return testCases;
+      return testCases;
+    }
+
+    private final DataType dataType;
+    private final int[] shape;
+    private final Object storage;
+    private final Object expectedCombinedArray;
+
+    public TestArrayParameterized(DataType dataType, int[] shape, Object storage, Object expectedCombinedArray) {
+      this.dataType = dataType;
+      this.shape = shape;
+      this.storage = storage;
+      this.expectedCombinedArray = expectedCombinedArray;
+    }
+
+    @Test
+    public void shouldCreateArray() {
+      final Array array = Array.factory(dataType, shape);
+      assertThat(array.getShape()).isEqualTo(shape);
+    }
+
+    @Test
+    public void shouldCreateArrayWithStorage() {
+      final Array array = Array.factory(dataType, shape, storage);
+      assertThat(array.getShape()).isEqualTo(shape);
+    }
+
+    @Test
+    public void shouldCreateArrayWithIndexAndStorage() {
+      final Array array = Array.factory(dataType, Index.factory(shape), storage);
+      assertThat(array.getShape()).isEqualTo(shape);
+    }
+
+    @Test
+    public void shouldCombineTwoArrays() {
+      // tested separately below
+      assumeTrue(dataType != DataType.STRUCTURE);
+
+      final int[] combinedShape = new int[] {2};
+
+      final Array array = Array.factory(dataType, shape, storage);
+      final List<Array> arrays = new ArrayList<>();
+      arrays.add(array);
+      arrays.add(array);
+
+      final Array combinedArray = Array.factoryCopy(dataType, combinedShape, arrays);
+
+      assertThat(combinedArray.getShape()).isEqualTo(combinedShape);
+      assertThat(combinedArray.getStorage()).isEqualTo(expectedCombinedArray);
+    }
+
+    @Test
+    public void shouldCombineTwoArrayStructures() {
+      // skip structures within structures
+      assumeTrue(dataType != DataType.STRUCTURE);
+
+      final Array array = Array.factory(dataType, shape, storage);
+      final ArrayStructure arrayStructure = createArrayStructure("name", dataType, shape, array);
+
+      final int[] combinedShape = new int[] {2};
+      final List<Array> arrays = new ArrayList<>();
+      arrays.add(arrayStructure);
+      arrays.add(arrayStructure);
+
+      final ArrayStructure combinedArray =
+          (ArrayStructure) Array.factoryCopy(DataType.STRUCTURE, combinedShape, arrays);
+
+      assertThat(combinedArray.getShape()).isEqualTo(combinedShape);
+      assertThat(combinedArray.getArray(0, arrayStructure.findMember("name"))).isEqualTo(array);
+      assertThat(combinedArray.getArray(1, arrayStructure.findMember("name"))).isEqualTo(array);
+    }
   }
 
-  private final DataType dataType;
-  private final int[] shape;
-  private final Object storage;
-  private final Object expectedCombinedArray;
+  public static class TestArrayNonParameterized {
 
-  public TestArray(DataType dataType, int[] shape, Object storage, Object expectedCombinedArray) {
-    this.dataType = dataType;
-    this.shape = shape;
-    this.storage = storage;
-    this.expectedCombinedArray = expectedCombinedArray;
+    @Test
+    public void shouldCombineTwoArrayStructuresWithDifferentValues() {
+      final DataType dataType = DataType.INT;
+      final int[] shape = new int[] {1};
+      final Array array = Array.factory(dataType, shape);
+      array.setInt(0, 5);
+      final Array array2 = Array.factory(dataType, shape);
+      array.setInt(0, 42);
+
+      final ArrayStructure arrayStructure = createArrayStructure("name", dataType, shape, array);
+      final ArrayStructure arrayStructure2 = createArrayStructure("name", dataType, shape, array2);
+
+      final int[] combinedShape = new int[] {2};
+      final List<Array> arrays = new ArrayList<>();
+      arrays.add(arrayStructure);
+      arrays.add(arrayStructure2);
+
+      final ArrayStructure combinedArray =
+          (ArrayStructure) Array.factoryCopy(DataType.STRUCTURE, combinedShape, arrays);
+
+      assertThat(combinedArray.getShape()).isEqualTo(combinedShape);
+      assertThat(combinedArray.getArray(0, arrayStructure.findMember("name"))).isEqualTo(array);
+      assertThat(combinedArray.getArray(1, arrayStructure.findMember("name"))).isEqualTo(array2);
+    }
+
+    @Test
+    public void shouldRefuseToCombineArrayStructuresWithDifferentMembers() {
+      final DataType dataType = DataType.INT;
+      final int[] shape = new int[] {1};
+      final Array array = Array.factory(dataType, shape);
+
+      final int[] combinedShape = new int[] {2};
+      final List<Array> arrays = new ArrayList<>();
+      arrays.add(createArrayStructure("name", DataType.INT, new int[] {1}, array));
+      arrays.add(createArrayStructure("name2", DataType.INT, new int[] {1}, array));
+
+      assertThrows(IllegalArgumentException.class, () -> Array.factoryCopy(DataType.STRUCTURE, combinedShape, arrays));
+    }
   }
 
-  @Test
-  public void shouldCreateArray() {
-    final Array array = Array.factory(dataType, shape);
-    assertThat(array.getShape()).isEqualTo(shape);
-  }
-
-  @Test
-  public void shouldCreateArrayWithStorage() {
-    final Array array = Array.factory(dataType, shape, storage);
-    assertThat(array.getShape()).isEqualTo(shape);
-  }
-
-  @Test
-  public void shouldCreateArrayWithIndexAndStorage() {
-    final Array array = Array.factory(dataType, Index.factory(shape), storage);
-    assertThat(array.getShape()).isEqualTo(shape);
-  }
-
-  @Test
-  public void shouldCombineTwoArrays() {
-    // tested separately below
-    assumeTrue(dataType != DataType.STRUCTURE);
-
-    final int[] combinedShape = new int[] {2};
-
-    final Array array = Array.factory(dataType, shape, storage);
-    final List<Array> arrays = new ArrayList<>();
-    arrays.add(array);
-    arrays.add(array);
-
-    final Array combinedArray = Array.factoryCopy(dataType, combinedShape, arrays);
-
-    assertThat(combinedArray.getShape()).isEqualTo(combinedShape);
-    assertThat(combinedArray.getStorage()).isEqualTo(expectedCombinedArray);
-  }
-
-  @Test
-  public void shouldCombineTwoArrayStructures() {
-    // skip structures within structures
-    assumeTrue(dataType != DataType.STRUCTURE);
-
-    final MemberBuilder memberBuilder = StructureMembers.builder().addMember("name", "desc", "units", dataType, shape);
+  private static ArrayStructure createArrayStructure(String memberName, DataType dataType, int[] shape, Array array) {
+    final MemberBuilder memberBuilder =
+        StructureMembers.builder().addMember(memberName, "desc", "units", dataType, shape);
     final StructureMembers members = StructureMembers.builder().addMember(memberBuilder).build();
     final StructureDataW structureData = new StructureDataW(members);
-    final Array array = Array.factory(dataType, shape, storage);
-    structureData.setMemberData("name", array);
-    final ArrayStructureW arrayStructure = new ArrayStructureW(structureData);
-
-    final int[] combinedShape = new int[] {2};
-    final List<Array> arrays = new ArrayList<>();
-    arrays.add(arrayStructure);
-    arrays.add(arrayStructure);
-
-    final ArrayStructure combinedArray = (ArrayStructure) Array.factoryCopy(DataType.STRUCTURE, combinedShape, arrays);
-
-    assertThat(combinedArray.getShape()).isEqualTo(combinedShape);
-    assertThat(combinedArray.getArray(0, members.getMember(0))).isEqualTo(array);
-    assertThat(combinedArray.getArray(1, members.getMember(0))).isEqualTo(array);
+    structureData.setMemberData(memberName, array);
+    return new ArrayStructureW(structureData);
   }
 }

--- a/cdm/core/src/test/java/ucar/ma2/TestArray.java
+++ b/cdm/core/src/test/java/ucar/ma2/TestArray.java
@@ -1,0 +1,121 @@
+package ucar.ma2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ucar.ma2.StructureMembers.MemberBuilder;
+
+@RunWith(Parameterized.class)
+public class TestArray {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> getTestParameters() {
+    final int[] shape = new int[] {1};
+    List<Object[]> testCases = new ArrayList<>();
+
+    testCases.add(new Object[] {DataType.BOOLEAN, shape, new boolean[] {false}, new boolean[] {false, false}});
+    testCases.add(new Object[] {DataType.BYTE, shape, new byte[] {1}, new byte[] {1, 1}});
+    testCases.add(new Object[] {DataType.CHAR, shape, new char[] {'a'}, new char[] {'a', 'a'}});
+    testCases.add(new Object[] {DataType.SHORT, shape, new short[] {1}, new short[] {1, 1}});
+    testCases.add(new Object[] {DataType.INT, shape, new int[] {1}, new int[] {1, 1}});
+    testCases.add(new Object[] {DataType.LONG, shape, new long[] {1}, new long[] {1, 1}});
+    testCases.add(new Object[] {DataType.FLOAT, shape, new float[] {1.1f}, new float[] {1.1f, 1.1f}});
+    testCases.add(new Object[] {DataType.DOUBLE, shape, new double[] {1.1}, new double[] {1.1, 1.1}});
+    testCases.add(new Object[] {DataType.SEQUENCE, shape, new Object[] {1}, new Object[] {1, 1}});
+    testCases.add(new Object[] {DataType.STRING, shape, new Object[] {1}, new Object[] {1, 1}});
+    testCases.add(new Object[] {DataType.STRUCTURE, shape, new Object[] {1}, new Object[] {1, 1}});
+    testCases.add(new Object[] {DataType.ENUM1, shape, new byte[] {1}, new byte[] {1, 1}});
+    testCases.add(new Object[] {DataType.ENUM2, shape, new short[] {1}, new short[] {1, 1}});
+    testCases.add(new Object[] {DataType.ENUM4, shape, new int[] {1}, new int[] {1, 1}});
+    testCases.add(new Object[] {DataType.OPAQUE, shape, new Object[] {1}, new Object[] {1, 1}});
+    // Cannot be created through the factory
+    // testCases.add(new Object[] {DataType.OBJECT, shape, new Object[]{1}, new Object[]{1, 1}});
+    testCases.add(new Object[] {DataType.UBYTE, shape, new byte[] {1}, new byte[] {1, 1}});
+    testCases.add(new Object[] {DataType.USHORT, shape, new short[] {1}, new short[] {1, 1}});
+    testCases.add(new Object[] {DataType.UINT, shape, new int[] {1}, new int[] {1, 1}});
+    testCases.add(new Object[] {DataType.ULONG, shape, new long[] {1}, new long[] {1, 1}});
+
+    return testCases;
+  }
+
+  private final DataType dataType;
+  private final int[] shape;
+  private final Object storage;
+  private final Object expectedCombinedArray;
+
+  public TestArray(DataType dataType, int[] shape, Object storage, Object expectedCombinedArray) {
+    this.dataType = dataType;
+    this.shape = shape;
+    this.storage = storage;
+    this.expectedCombinedArray = expectedCombinedArray;
+  }
+
+  @Test
+  public void shouldCreateArray() {
+    final Array array = Array.factory(dataType, shape);
+    assertThat(array.getShape()).isEqualTo(shape);
+  }
+
+  @Test
+  public void shouldCreateArrayWithStorage() {
+    final Array array = Array.factory(dataType, shape, storage);
+    assertThat(array.getShape()).isEqualTo(shape);
+  }
+
+  @Test
+  public void shouldCreateArrayWithIndexAndStorage() {
+    final Array array = Array.factory(dataType, Index.factory(shape), storage);
+    assertThat(array.getShape()).isEqualTo(shape);
+  }
+
+  @Test
+  public void shouldCombineTwoArrays() {
+    // tested separately below
+    assumeTrue(dataType != DataType.STRUCTURE);
+
+    final int[] combinedShape = new int[] {2};
+
+    final Array array = Array.factory(dataType, shape, storage);
+    final List<Array> arrays = new ArrayList<>();
+    arrays.add(array);
+    arrays.add(array);
+
+    final Array combinedArray = Array.factoryCopy(dataType, combinedShape, arrays);
+
+    assertThat(combinedArray.getShape()).isEqualTo(combinedShape);
+    assertThat(combinedArray.getStorage()).isEqualTo(expectedCombinedArray);
+  }
+
+  @Test
+  public void shouldCombineTwoArrayStructures() {
+    // skip structures within structures
+    assumeTrue(dataType != DataType.STRUCTURE);
+
+    final MemberBuilder memberBuilder = StructureMembers.builder().addMember("name", "desc", "units", dataType, shape);
+    final StructureMembers members = StructureMembers.builder().addMember(memberBuilder).build();
+    final StructureDataW structureData = new StructureDataW(members);
+    final Array array = Array.factory(dataType, shape, storage);
+    structureData.setMemberData("name", array);
+    final ArrayStructureW arrayStructure = new ArrayStructureW(structureData);
+
+    final int[] combinedShape = new int[] {2};
+    final List<Array> arrays = new ArrayList<>();
+    arrays.add(arrayStructure);
+    arrays.add(arrayStructure);
+
+    final ArrayStructure combinedArray = (ArrayStructure) Array.factoryCopy(DataType.STRUCTURE, combinedShape, arrays);
+
+    assertThat(combinedArray.getShape()).isEqualTo(combinedShape);
+    assertThat(combinedArray.getArray(0, members.getMember(0))).isEqualTo(array);
+    assertThat(combinedArray.getArray(1, members.getMember(0))).isEqualTo(array);
+  }
+}

--- a/cdm/core/src/test/java/ucar/ma2/TestStructureMembers.java
+++ b/cdm/core/src/test/java/ucar/ma2/TestStructureMembers.java
@@ -1,0 +1,110 @@
+package ucar.ma2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import ucar.ma2.StructureMembers.Member;
+import ucar.ma2.StructureMembers.MemberBuilder;
+
+@RunWith(Parameterized.class)
+public class TestStructureMembers {
+  @Parameterized.Parameters()
+  public static List<Object[]> getTestParameters() {
+    final int[] shape = new int[] {1};
+    List<Object[]> testCases = new ArrayList<>();
+
+    testCases.add(new Object[] {"name", "description", "units", DataType.BOOLEAN, shape, true});
+    testCases.add(new Object[] {"otherName", "description", "units", DataType.BOOLEAN, shape, false});
+    testCases.add(new Object[] {"name", "otherDescription", "units", DataType.BOOLEAN, shape, false});
+    testCases.add(new Object[] {"name", null, "units", DataType.BOOLEAN, shape, false});
+    testCases.add(new Object[] {"name", "description", "OtherUnits", DataType.BOOLEAN, shape, false});
+    testCases.add(new Object[] {"name", "description", null, DataType.BOOLEAN, shape, false});
+    testCases.add(new Object[] {"name", "description", "units", DataType.INT, shape, false});
+    testCases.add(new Object[] {"name", "description", "units", DataType.BOOLEAN, new int[] {2}, false});
+    testCases.add(new Object[] {"name", "description", "units", DataType.BOOLEAN, new int[] {-1}, false});
+    testCases.add(new Object[] {"name", "description", "units", DataType.BOOLEAN, new int[] {1, 1}, false});
+
+    return testCases;
+  }
+
+  private final String name;
+  private final String description;
+  private final String units;
+  private final DataType dataType;
+  private final int[] shape;
+  private final boolean isEqual;
+
+  public TestStructureMembers(String name, String description, String units, DataType dataType, int[] shape,
+      boolean isEqual) {
+    this.name = name;
+    this.description = description;
+    this.units = units;
+    this.dataType = dataType;
+    this.shape = shape;
+    this.isEqual = isEqual;
+  }
+
+  @Test
+  public void shouldCompareMembers() {
+    final Member member =
+        StructureMembers.builder().addMember("name", "description", "units", DataType.BOOLEAN, new int[] {1}).build();
+
+    final Member otherMember = StructureMembers.builder().addMember(name, description, units, dataType, shape).build();
+
+    assertThat(member.equals(otherMember)).isEqualTo(isEqual);
+  }
+
+  @Test
+  public void shouldCompareStructureMembers() {
+    final MemberBuilder memberBuilder =
+        StructureMembers.builder().addMember("name", "description", "units", DataType.BOOLEAN, new int[] {1});
+    final StructureMembers structureMembers = StructureMembers.builder().addMember(memberBuilder).build();
+
+    final MemberBuilder otherMember = StructureMembers.builder().addMember(name, description, units, dataType, shape);
+    final StructureMembers otherStructureMembers = StructureMembers.builder().addMember(otherMember).build();
+
+    assertThat(structureMembers.equals(otherStructureMembers)).isEqualTo(isEqual);
+  }
+
+  @Test
+  public void shouldCompareStructureMembersWithMultipleMembers() {
+    final MemberBuilder memberBuilder =
+        StructureMembers.builder().addMember("name1", "description1", "units1", DataType.INT, new int[] {2});
+    final MemberBuilder memberBuilder2 =
+        StructureMembers.builder().addMember("name", "description", "units", DataType.BOOLEAN, new int[] {1});
+    final StructureMembers structureMembers =
+        StructureMembers.builder().addMember(memberBuilder).addMember(memberBuilder2).build();
+
+    final MemberBuilder otherMemberBuilder =
+        StructureMembers.builder().addMember("name1", "description1", "units1", DataType.INT, new int[] {2});
+    final MemberBuilder otherMemberBuilder2 =
+        StructureMembers.builder().addMember(name, description, units, dataType, shape);
+    final StructureMembers otherStructureMembers =
+        StructureMembers.builder().addMember(otherMemberBuilder).addMember(otherMemberBuilder2).build();
+
+    assertThat(structureMembers.equals(otherStructureMembers)).isEqualTo(isEqual);
+  }
+
+  @Test
+  public void shouldCompareMembersThatAreStructures() {
+    final MemberBuilder innerMemberBuilder =
+        StructureMembers.builder().addMember("name", "description", "units", DataType.BOOLEAN, new int[] {1});
+    final StructureMembers innerStructureMembers = StructureMembers.builder().addMember(innerMemberBuilder).build();
+    final Member member =
+        StructureMembers.builder().addMember("name2", "description2", "units2", DataType.STRUCTURE, new int[] {1})
+            .setStructureMembers(innerStructureMembers).build();
+
+    final MemberBuilder otherInnerMember =
+        StructureMembers.builder().addMember(name, description, units, dataType, shape);
+    final StructureMembers otherInnerStructureMembers = StructureMembers.builder().addMember(otherInnerMember).build();
+    final Member otherMember =
+        StructureMembers.builder().addMember("name2", "description2", "units2", DataType.STRUCTURE, new int[] {1})
+            .setStructureMembers(otherInnerStructureMembers).build();
+
+    assertThat(member.equals(otherMember)).isEqualTo(isEqual);
+  }
+}

--- a/cdm/core/src/test/java/ucar/ma2/TestStructureMembers.java
+++ b/cdm/core/src/test/java/ucar/ma2/TestStructureMembers.java
@@ -56,6 +56,7 @@ public class TestStructureMembers {
     final Member otherMember = StructureMembers.builder().addMember(name, description, units, dataType, shape).build();
 
     assertThat(member.equals(otherMember)).isEqualTo(isEqual);
+    assertThat(otherMember.equals(member)).isEqualTo(isEqual);
   }
 
   @Test
@@ -68,6 +69,7 @@ public class TestStructureMembers {
     final StructureMembers otherStructureMembers = StructureMembers.builder().addMember(otherMember).build();
 
     assertThat(structureMembers.equals(otherStructureMembers)).isEqualTo(isEqual);
+    assertThat(otherStructureMembers.equals(structureMembers)).isEqualTo(isEqual);
   }
 
   @Test
@@ -87,6 +89,7 @@ public class TestStructureMembers {
         StructureMembers.builder().addMember(otherMemberBuilder).addMember(otherMemberBuilder2).build();
 
     assertThat(structureMembers.equals(otherStructureMembers)).isEqualTo(isEqual);
+    assertThat(otherStructureMembers.equals(structureMembers)).isEqualTo(isEqual);
   }
 
   @Test
@@ -106,5 +109,6 @@ public class TestStructureMembers {
             .setStructureMembers(otherInnerStructureMembers).build();
 
     assertThat(member.equals(otherMember)).isEqualTo(isEqual);
+    assertThat(otherMember.equals(member)).isEqualTo(isEqual);
   }
 }


### PR DESCRIPTION
## Description of Changes

Add `Array.factoryCopy` method that combines multiple Arrays. This functionality is needed for the gCDM, where the data may need to be chunked and then recombined. As I made some simple tests for this function, I thought it might be nice to make a separate PR for it.

Also added tests for some of the `Array.factory` methods (not for all of them though). Also added a TODO to the `DataType.Object` which seems like a hack that we could revisit.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
