### PR TITLE
Fix decimal separator

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -837,7 +837,7 @@ public class HorizCoordSys {
     StringBuilder sb = new StringBuilder("POLYGON((");
 
     for (LatLonPointNoNormalize point : points) {
-      sb.append(String.format("%.3f %.3f, ", point.getLongitude(), point.getLatitude()));
+      sb.append(String.format(Locale.ROOT, "%.3f %.3f, ", point.getLongitude(), point.getLatitude()));
     }
 
     sb.delete(sb.length() - 2, sb.length()); // Nuke trailing comma and space.

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestHorizCoordSys.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestHorizCoordSys.java
@@ -2,8 +2,13 @@ package ucar.nc2.ft2.coverage;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Locale;
+import org.junit.After;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +22,12 @@ import ucar.unidata.geoloc.ProjectionPoint;
 
 public class TestHorizCoordSys {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Locale DEFAULT_LOCALE = Locale.getDefault();
+
+  @After
+  public void resetLocale() {
+    Locale.setDefault(DEFAULT_LOCALE);
+  }
 
   @Test
   public void shouldRemoveNansWhenComputingLatLon() {
@@ -48,6 +59,25 @@ public class TestHorizCoordSys {
     for (LatLonPointNoNormalize latLonPoint : boundaryPoints) {
       assertThat(latLonPoint.getLatitude()).isNotNaN();
       assertThat(latLonPoint.getLongitude()).isNotNaN();
+    }
+  }
+
+  @Test
+  public void shouldUsePeriodsAsDecimalSeparatorsInWKT() throws IOException, URISyntaxException {
+    Locale.setDefault(new Locale("fr", "FR"));
+
+    final File testResource = new File(getClass().getResource("crossSeamLatLon1D.ncml").toURI());
+    final String expectedWKT = "POLYGON((" + "130.000 0.000, 170.000 0.000, 210.000 0.000, " + // Bottom edge
+        "230.000 0.000, 230.000 30.000, " + // Right edge
+        "230.000 50.000, 190.000 50.000, 150.000 50.000, " + // Top edge
+        "130.000 50.000, 130.000 20.000" + // Left edge
+        "))";
+
+    try (FeatureDatasetCoverage featureDatasetCoverage = CoverageDatasetFactory.open(testResource.getAbsolutePath())) {
+      assertThat(featureDatasetCoverage).isNotNull();
+      final CoverageCollection coverageCollection = featureDatasetCoverage.getCoverageCollections().get(0);
+      final String actualWKT = coverageCollection.getHorizCoordSys().getLatLonBoundaryAsWKT(2, 3);
+      assertThat(actualWKT).isEqualTo(expectedWKT);
     }
   }
 


### PR DESCRIPTION
## Description of Changes

Although WKT is allowed to have either a period or comma as a decimal separator, NCSS's open layer map cannot parse a comma as a decimal separator. This PR would force a period as a separator for the WKT output to fix the NCSS map for locales with a comma decimal separator.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
