### PR TITLE
Improve error message coverages

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCollection.java
@@ -129,6 +129,10 @@ public class CoverageCollection implements Closeable, CoordSysContainer {
 
     // we want them to share the same object for efficiency, esp 2D
     for (CoverageCoordSys csys : coordSys) {
+      if (!csys.makeHorizCoordSys().equals(hcs)) {
+        throw new IllegalArgumentException(
+            "Cannot open as a coverage collection because there are multiple horizontal coordinate systems");
+      }
       csys.setHorizCoordSys(hcs);
       csys.setImmutable();
     }

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis.java
@@ -4,6 +4,7 @@
  */
 package ucar.nc2.ft2.coverage;
 
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.*;
@@ -238,6 +239,20 @@ public abstract class CoverageCoordAxis implements Comparable<CoverageCoordAxis>
     Indent indent = new Indent(2);
     toString(f, indent);
     return f.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CoverageCoordAxis that = (CoverageCoordAxis) o;
+    return getNcoords() == that.getNcoords() && isSubset() == that.isSubset()
+        && Objects.equals(getName(), that.getName()) && getDataType() == that.getDataType()
+        && getAxisType() == that.getAxisType() && getDependenceType() == that.getDependenceType();
   }
 
   public int[] getShape() {

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis.java
@@ -4,7 +4,9 @@
  */
 package ucar.nc2.ft2.coverage;
 
+import com.google.common.base.Preconditions;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.*;
@@ -67,24 +69,27 @@ public abstract class CoverageCoordAxis implements Comparable<CoverageCoordAxis>
   protected final double startValue;
   protected final double endValue;
   protected final double resolution;
+  @Nullable
   protected final CoordAxisReader reader;
   protected final boolean isSubset;
 
+  @Nullable
   protected final TimeHelper timeHelper; // AxisType = Time, RunTime only
   protected final String units;
 
   // may be lazy eval
+  @Nullable
   protected double[] values; // null if isRegular, or use CoordAxisReader for lazy eval
 
   protected CoverageCoordAxis(CoverageCoordAxisBuilder builder) {
-    this.name = builder.name;
-    this.units = builder.units;
+    this.name = Preconditions.checkNotNull(builder.name);
+    this.units = Preconditions.checkNotNull(builder.units);
     this.description = builder.description;
-    this.dataType = builder.dataType;
-    this.axisType = builder.axisType;
-    this.attributes = builder.attributes;
-    this.dependenceType = builder.dependenceType;
-    this.spacing = builder.spacing;
+    this.dataType = Preconditions.checkNotNull(builder.dataType);
+    this.axisType = Preconditions.checkNotNull(builder.axisType);
+    this.attributes = Preconditions.checkNotNull(builder.attributes);
+    this.dependenceType = Preconditions.checkNotNull(builder.dependenceType);
+    this.spacing = Preconditions.checkNotNull(builder.spacing);
     this.values = builder.values;
     this.reader = builder.reader; // used only if values == null
     this.dependsOn = builder.dependsOn == null ? Collections.emptyList() : builder.dependsOn;

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -107,6 +107,21 @@ public class HorizCoordSys {
     }
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HorizCoordSys that = (HorizCoordSys) o;
+    return isProjection() == that.isProjection() && isLatLon1D == that.isLatLon1D && isLatLon2D() == that.isLatLon2D()
+        && Objects.equals(xAxis, that.xAxis) && Objects.equals(yAxis, that.yAxis)
+        && Objects.equals(latAxis, that.latAxis) && Objects.equals(lonAxis, that.lonAxis)
+        && Objects.equals(getLatAxis2D(), that.getLatAxis2D()) && Objects.equals(getLonAxis2D(), that.getLonAxis2D());
+  }
+
   public String getName() {
     if (isProjection)
       return xAxis.getName() + " " + yAxis.getName() + " " + transform.getName();

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageAdapter.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/adapter/DtCoverageAdapter.java
@@ -140,6 +140,7 @@ public class DtCoverageAdapter implements CoverageReader, CoordAxisReader {
   private static CoverageCoordAxis makeCoordAxisFromDimension(Dimension dim) {
     CoverageCoordAxisBuilder builder = new CoverageCoordAxisBuilder();
     builder.name = dim.getFullName();
+    builder.units = "";
     builder.dataType = DataType.INT;
     builder.axisType = AxisType.Dimension;
     builder.dependenceType = CoverageCoordAxis.DependenceType.dimension;

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoverageCollection.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoverageCollection.java
@@ -1,0 +1,104 @@
+package ucar.nc2.ft2.coverage;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import ucar.ma2.DataType;
+import ucar.nc2.AttributeContainerMutable;
+import ucar.nc2.constants.AxisType;
+import ucar.nc2.constants.FeatureType;
+import ucar.nc2.ft2.coverage.CoverageCoordAxis.Spacing;
+
+public class TestCoverageCollection {
+  private final AttributeContainerMutable attributes = new AttributeContainerMutable("myAttributes");
+
+  @Test
+  public void shouldCreateCoverageCollection() {
+    List<CoverageCoordSys> coordSystems =
+        Arrays.asList(new CoverageCoordSys("myCoordinateSystem1", Arrays.asList("lat", "lon"), null, FeatureType.GRID),
+            new CoverageCoordSys("myCoordinateSystem2", Arrays.asList("time", "lon", "lat"), null, FeatureType.GRID));
+
+    List<CoverageCoordAxis> coordAxes =
+        Arrays.asList(makeAxis("lat", AxisType.Lat), makeAxis("lon", AxisType.Lon), makeAxis("time", AxisType.Time));
+
+    Coverage coverage1 =
+        new Coverage("name1", DataType.INT, attributes, "myCoordinateSystem1", "units", "description", null, null);
+    Coverage coverage2 =
+        new Coverage("name2", DataType.INT, attributes, "myCoordinateSystem2", "units", "description", null, null);
+    List<Coverage> coverages = Arrays.asList(coverage1, coverage2);
+
+    CoverageCollection coverageCollection = new CoverageCollection("name", FeatureType.GRID, null, null, null, null,
+        coordSystems, null, coordAxes, coverages, null);
+    assertThat(coverageCollection).isNotNull();
+  }
+
+  @Test
+  public void shouldRefuseZeroHorizontalCoordinateSystems() {
+    List<CoverageCoordSys> coordSys = Collections.singletonList(
+        new CoverageCoordSys("myCoordinateSystem1", Collections.singletonList("time"), null, FeatureType.GRID));
+
+    List<CoverageCoordAxis> coordAxes = Collections.singletonList(makeAxis("time", AxisType.Time));
+
+    Coverage coverage1 =
+        new Coverage("name1", DataType.INT, attributes, "myCoordinateSystem1", "units", "description", null, null);
+    List<Coverage> coverages = Collections.singletonList(coverage1);
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new CoverageCollection("name",
+        FeatureType.GRID, null, null, null, null, coordSys, null, coordAxes, coverages, null));
+    assertThat(e).hasMessageThat().contains("must have horiz coordinates (x,y,projection or lat,lon)");
+  }
+
+  @Test
+  public void shouldRefuseMultipleHorizontalCoordinateSystems() {
+    List<CoverageCoordSys> differentLongitudeCoordSystems = Arrays.asList(
+        new CoverageCoordSys("myCoordinateSystem1", Arrays.asList("lat1", "lon1"), null, FeatureType.GRID),
+        new CoverageCoordSys("myCoordinateSystem2", Arrays.asList("lat1", "lon2"), null, FeatureType.GRID));
+
+    List<CoverageCoordAxis> coordAxes = Arrays.asList(makeAxis("lat1", AxisType.Lat), makeAxis("lon1", AxisType.Lon),
+        makeAxis("lat2", AxisType.Lat), makeAxis("lon2", AxisType.Lon));
+
+    Coverage coverage1 =
+        new Coverage("name1", DataType.INT, attributes, "myCoordinateSystem1", "units", "description", null, null);
+    Coverage coverage2 =
+        new Coverage("name2", DataType.INT, attributes, "myCoordinateSystem2", "units", "description", null, null);
+    List<Coverage> coverages = Arrays.asList(coverage1, coverage2);
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new CoverageCollection("name",
+        FeatureType.GRID, null, null, null, null, differentLongitudeCoordSystems, null, coordAxes, coverages, null));
+    assertThat(e).hasMessageThat()
+        .contains("Cannot open as a coverage collection because there are multiple horizontal coordinate systems");
+  }
+
+  @Test
+  public void shouldRefuseMultipleDisjointHorizontalCoordinateSystems() {
+    List<CoverageCoordSys> disjointCoordSystems = Arrays.asList(
+        new CoverageCoordSys("myCoordinateSystem1", Arrays.asList("lat1", "lon1"), null, FeatureType.GRID),
+        new CoverageCoordSys("myCoordinateSystem2", Arrays.asList("lat2", "lon2"), null, FeatureType.GRID));
+
+    List<CoverageCoordAxis> coordAxes = Arrays.asList(makeAxis("lat1", AxisType.Lat), makeAxis("lon1", AxisType.Lon),
+        makeAxis("lat2", AxisType.Lat), makeAxis("lon2", AxisType.Lon));
+
+    Coverage coverage1 =
+        new Coverage("name1", DataType.INT, attributes, "myCoordinateSystem1", "units", "description", null, null);
+    Coverage coverage2 =
+        new Coverage("name2", DataType.INT, attributes, "myCoordinateSystem2", "units", "description", null, null);
+    List<Coverage> coverages = Arrays.asList(coverage1, coverage2);
+
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new CoverageCollection("name",
+        FeatureType.GRID, null, null, null, null, disjointCoordSystems, null, coordAxes, coverages, null));
+    assertThat(e).hasMessageThat()
+        .contains("Cannot open as a coverage collection because there are multiple horizontal coordinate systems");
+  }
+
+  private static CoverageCoordAxis makeAxis(String name, AxisType type) {
+    final double[] values = new double[] {0.0, 10.0, 20.0, 30.0, 40.0};
+    final CoverageCoordAxisBuilder coverageCoordAxisBuilder = new CoverageCoordAxisBuilder(name, "unit", "description",
+        DataType.DOUBLE, type, null, CoverageCoordAxis.DependenceType.independent, null, Spacing.regularPoint,
+        values.length, values[0], values[values.length - 1], values[1] - values[0], values, null);
+    return new CoverageCoordAxis1D(coverageCoordAxisBuilder);
+  }
+}


### PR DESCRIPTION
## Description of Changes

A few different things:
- Improve preconditions for `CoverageCoordAxis` so that it can't be constructed with certain fields `null`.
- Add empty string `units` to `makeCoordAxisFromDimension` to avoid nullptr exception
- In order to improve the error message for the situation where a dataset has multiple horizontal coordinate systems in NCSS, add a check when a `CoverageCollection` is created. The `CoverageCollection` only has one horizontal coordinate system that the coordinate systems can share, so it seems good check that they can indeed share this horizontal coordinate system when constructing. In order to add this, add some `equals` operators to at least compare the names of the coordinate axes. 
- Add a few tests for this

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
