### PR TITLE
Fix longitude subsetting when all longitudes are requested

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -330,14 +330,15 @@ public class HorizCoordSys {
   }
 
   // here's where to deal with crossing seam
-  private Optional<CoverageCoordAxis> subsetLon(LatLonRect llbb, int stride) {
-    double wantMin = LatLonPoints.lonNormalFrom(llbb.getLonMin(), lonAxis.getStartValue());
-    double wantMax = LatLonPoints.lonNormalFrom(llbb.getLonMax(), lonAxis.getStartValue());
+  private Optional<CoverageCoordAxis> subsetLon(LatLonRect latLonBoundingBox, int stride) {
+    double wantMin = LatLonPoints.lonNormalFrom(latLonBoundingBox.getLonMin(), lonAxis.getStartValue());
+    double wantMax = LatLonPoints.lonNormalFrom(latLonBoundingBox.getLonMax(), lonAxis.getStartValue());
     double start = lonAxis.getStartValue();
     double end = lonAxis.getEndValue();
 
     // use MAMath.MinMax as a container for two values, min and max
-    List<MAMath.MinMax> lonIntvs = subsetLonIntervals(wantMin, wantMax, start, end, llbb.containsAllLongitude());
+    List<MAMath.MinMax> lonIntvs =
+        subsetLonIntervals(wantMin, wantMax, start, end, latLonBoundingBox.containsAllLongitude());
 
     if (lonIntvs.isEmpty())
       return Optional.empty(

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -337,7 +337,7 @@ public class HorizCoordSys {
     double end = lonAxis.getEndValue();
 
     // use MAMath.MinMax as a container for two values, min and max
-    List<MAMath.MinMax> lonIntvs = subsetLonIntervals(wantMin, wantMax, start, end);
+    List<MAMath.MinMax> lonIntvs = subsetLonIntervals(wantMin, wantMax, start, end, llbb.containsAllLongitude());
 
     if (lonIntvs.isEmpty())
       return Optional.empty(
@@ -361,6 +361,8 @@ public class HorizCoordSys {
    * wantMin may be less than or greater than wantMax.
    * 
    * cases:
+   * 0. contains all longitude, return all longitude
+   * (could be normalized such that wantMin == wantMax so handle separately)
    * A. wantMin < wantMax
    * 1 wantMin, wantMax > end : empty
    * 2 wantMin < end : [wantMin, min(wantMax,end)]
@@ -369,7 +371,11 @@ public class HorizCoordSys {
    * 1 wantMin, wantMax > end : all [start, end]
    * 2 wantMin, wantMax < end : 2 pieces: [wantMin, end] + [start, max]
    */
-  private List<MAMath.MinMax> subsetLonIntervals(double wantMin, double wantMax, double start, double end) {
+  private List<MAMath.MinMax> subsetLonIntervals(double wantMin, double wantMax, double start, double end,
+      boolean containsAllLongitude) {
+    if (containsAllLongitude) {
+      return Lists.newArrayList(new MAMath.MinMax(start, end));
+    }
     if (wantMin <= wantMax) {
       if (wantMin > end) { // none A.1
         return ImmutableList.of();

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/LatLonRect.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/LatLonRect.java
@@ -229,6 +229,15 @@ public class LatLonRect {
   }
 
   /**
+   * return does this rectangle contain all longitudes
+   *
+   * @return true if all longitudes are contained (width is >= 360) else false
+   */
+  public boolean containsAllLongitude() {
+    return allLongitude;
+  }
+
+  /**
    * return width of bounding box, always between 0 and 360 degrees.
    *
    * @return width of bounding box in degrees longitude


### PR DESCRIPTION
## Description of Changes

Fixes https://github.com/Unidata/tds/issues/315. When all longitudes are requested but not all latitudes (e.g. lon from [-180, 180]), and the longitude axis data is say {0... 360}, then the desired longitudes were getting normalized to be in the range [0, 360]. This causes the requested longitudes to be [180, 180] which results in only returning one point instead of all longitudes.

This PR uses the `allLongitude` boolean in the requested lat/lon box to fix this situation and adds a unit test for this.

Also added tests for NCSS in TDS PR: https://github.com/Unidata/tds/pull/354

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
