### PR TITLE
Fix MFileS3::exists to work for "directories"

### DIFF
--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -315,7 +315,7 @@ public class MFileS3 implements MFile {
     try {
       final ListObjectsV2Response listObjects =
           client.listObjectsV2(ListObjectsV2Request.builder().bucket(cdmS3Uri.getBucket()).prefix(key).build());
-      return !listObjects.contents().isEmpty();
+      return listObjects.sdkHttpResponse().isSuccessful() && !listObjects.contents().isEmpty();
     } catch (NoSuchBucketException e) {
       return false;
     }
@@ -323,8 +323,8 @@ public class MFileS3 implements MFile {
 
   private boolean bucketExists() {
     try {
-      getHeadBucketResponse();
-      return true;
+      final HeadBucketResponse response = getHeadBucketResponse();
+      return response != null && response.sdkHttpResponse().isSuccessful();
     } catch (NoSuchBucketException e) {
       return false;
     }
@@ -332,8 +332,8 @@ public class MFileS3 implements MFile {
 
   private boolean objectExists() {
     try {
-      headObjectResponse.get();
-      return true;
+      final HeadObjectResponse response = headObjectResponse.get();
+      return response != null && response.sdkHttpResponse().isSuccessful();
     } catch (NoSuchKeyException e) {
       return false;
     }

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -229,7 +229,7 @@ public class TestMFileS3 {
 
   @Test
   public void shouldNotWriteNonExistingObjectToStream() throws IOException {
-    final MFile mFile = new MFileS3(AWS_G16_S3_URI_DIR + "?NotARealKey");
+    final MFile mFile = new MFileS3(AWS_G16_S3_URI_DIR + "/NotARealKey");
 
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     assertThrows(NoSuchKeyException.class, () -> mFile.writeToStream(outputStream));
@@ -243,7 +243,7 @@ public class TestMFileS3 {
 
   @Test
   public void shouldReturnFalseForNonExistingFile() throws IOException {
-    final MFile mFile = new MFileS3(AWS_G16_S3_URI_DIR + "?NotARealKey");
+    final MFile mFile = new MFileS3(AWS_G16_S3_URI_DIR + "/NotARealKey");
     assertThat(mFile.exists()).isEqualTo(false);
   }
 

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -248,6 +248,60 @@ public class TestMFileS3 {
   }
 
   @Test
+  public void shouldCheckExistsForExistingDirectory() throws IOException {
+    final MFile withFragmentWithSlash = new MFileS3(AWS_G16_S3_URI_DIR + "/" + DELIMITER_FRAGMENT);
+    assertThat(withFragmentWithSlash.exists()).isEqualTo(true);
+
+    final MFile withoutFragmentWithSlash = new MFileS3(AWS_G16_S3_URI_DIR + "/");
+    assertThat(withoutFragmentWithSlash.exists()).isEqualTo(false);
+
+    final MFile withFragmentWithoutSlash = new MFileS3(AWS_G16_S3_URI_DIR + DELIMITER_FRAGMENT);
+    assertThat(withFragmentWithoutSlash.exists()).isEqualTo(false);
+
+    final MFile withoutFragmentWithoutSlash = new MFileS3(AWS_G16_S3_URI_DIR);
+    assertThat(withoutFragmentWithoutSlash.exists()).isEqualTo(false);
+  }
+
+  @Test
+  public void shouldReturnFalseForNonExistingDirectory() throws IOException {
+    final MFile withFragmentWithSlash = new MFileS3(AWS_G16_S3_URI_DIR + "/notADirectory/" + DELIMITER_FRAGMENT);
+    assertThat(withFragmentWithSlash.exists()).isEqualTo(false);
+
+    final MFile withoutFragmentWithSlash = new MFileS3(AWS_G16_S3_URI_DIR + "/notADirectory/");
+    assertThat(withoutFragmentWithSlash.exists()).isEqualTo(false);
+
+    final MFile withFragmentWithoutSlash = new MFileS3(AWS_G16_S3_URI_DIR + "/notADirectory" + DELIMITER_FRAGMENT);
+    assertThat(withFragmentWithoutSlash.exists()).isEqualTo(false);
+
+    final MFile withoutFragmentWithoutSlash = new MFileS3(AWS_G16_S3_URI_DIR + "/notADirectory");
+    assertThat(withoutFragmentWithoutSlash.exists()).isEqualTo(false);
+  }
+
+  @Test
+  public void shouldReturnFalseForKeyPrefixMatch() throws IOException {
+    final MFile mFile = new MFileS3(AWS_G16_S3_OBJECT_1.substring(0, AWS_G16_S3_OBJECT_1.length() - 5));
+    assertThat(mFile.exists()).isEqualTo(false);
+  }
+
+  @Test
+  public void shouldReturnTrueForBucket() throws IOException {
+    final MFile bucketWithDelimiter = new MFileS3(S3TestsCommon.TOP_LEVEL_AWS_BUCKET + DELIMITER_FRAGMENT);
+    assertThat(bucketWithDelimiter.exists()).isEqualTo(true);
+
+    final MFile bucketWithoutDelimiter = new MFileS3(S3TestsCommon.TOP_LEVEL_AWS_BUCKET);
+    assertThat(bucketWithoutDelimiter.exists()).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldReturnFalseForNonExistentBucket() throws IOException {
+    final MFile bucketWithDelimiter = new MFileS3("cdms3:notABucket" + DELIMITER_FRAGMENT);
+    assertThat(bucketWithDelimiter.exists()).isEqualTo(false);
+
+    final MFile bucketWithoutDelimiter = new MFileS3("cdms3:notABucket");
+    assertThat(bucketWithoutDelimiter.exists()).isEqualTo(false);
+  }
+
+  @Test
   public void shouldGetInputStream() throws IOException {
     final MFile mFile = new MFileS3(AWS_G16_S3_OBJECT_1);
     try (final InputStream inputStream = mFile.getInputStream()) {


### PR DESCRIPTION
## Description of Changes

Part of the fixes needed for S3 datasetScans.

The current `MFileS3::exists` only works for Objects, and uses a `headObject` request. This PR would extend this to work for buckets (need to do a `headBucket`) and "directories" ( by doing a `listObjects` and checking it has objects).

Note that "Directories" are defined in our code as URIs that have a delimiter fragment and also end with that delimiter unless it's a bucket (e.g. `cdms3:myBucket#delimiter=/` or `cdms3:myBucket?myKey/#delimiter=/`). 

I wonder if `cdms3:myBucket` should also be considered a directory?

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
