### PR TITLE
Apply filters to S3Controller getSubdirs

### DIFF
--- a/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
+++ b/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
@@ -121,7 +121,7 @@ public class ControllerS3 implements MController {
         logger.error("Error creating MFile for {} bucket {}", commonPrefix, initialUri.getBucket(), e);
       }
     }
-    return mFiles.iterator();
+    return new FilteredIterator(mc, mFiles.iterator(), true);
   }
 
   @Override

--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/S3TestsCommon.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/S3TestsCommon.java
@@ -15,4 +15,5 @@ public class S3TestsCommon {
   public static final String TOP_LEVEL_GCS_BUCKET = "cdms3://storage.googleapis.com/gcp-public-data-goes-16";
   public static final String TOP_LEVEL_OSDC_BUCKET =
       "cdms3://griffin-objstore.opensciencedatacloud.org/noaa-goes16-hurricane-archive-2017";
+  public static final String THREDDS_TEST_BUCKET = "cdms3:thredds-test-data";
 }


### PR DESCRIPTION
## Description of Changes

`S3Controller` should apply filters to `getSubDirs` as it already does to `getInventoryTop` and `getInventoryAll`. This in line with behavior present in `ControllerOS`. Also add tests that these three methods do indeed filter results.

