### PR TITLE
Change MFiles.create to be Nonnull

### DIFF
--- a/cdm/core/src/main/java/thredds/inventory/MFileProvider.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFileProvider.java
@@ -6,7 +6,7 @@
 package thredds.inventory;
 
 import java.io.IOException;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 /**
  * A Service Provider of {@link thredds.inventory.MFile}.
@@ -22,12 +22,11 @@ public interface MFileProvider {
   }
 
   /**
-   * Create an {@link thredds.inventory.MFile} from a given location if it exists and is readable, otherwise return
-   * null.
+   * Create an {@link thredds.inventory.MFile} from a given location, the file may or may not exist
    *
    * @param location location of a file or .
    * @return {@link thredds.inventory.MFile}
    */
-  @Nullable
+  @Nonnull
   MFile create(String location) throws IOException;
 }

--- a/cdm/core/src/main/java/thredds/inventory/MFiles.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFiles.java
@@ -7,7 +7,7 @@ package thredds.inventory;
 
 import java.io.IOException;
 import java.util.ServiceLoader;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.filesystem.MFileOS;
@@ -22,14 +22,13 @@ public class MFiles {
   private static final Logger logger = LoggerFactory.getLogger(NcmlReader.class);
 
   /**
-   * Create an {@link thredds.inventory.MFile} from a given location if it exists and is readable, otherwise return
-   * null.
+   * Create an {@link thredds.inventory.MFile} from a given location, the file may or may not exist
    *
    * @param location location of file (local or remote) to be used to back the MFile object
    * @return {@link thredds.inventory.MFile}
    */
-  @Nullable
-  public static MFile create(String location) {
+  @Nonnull
+  public static MFile create(@Nonnull String location) {
     MFileProvider mFileProvider = null;
 
     // look for dynamically loaded MFileProviders
@@ -40,12 +39,13 @@ public class MFiles {
       }
     }
 
-    MFile mfile = null;
     try {
-      mfile = mFileProvider != null ? mFileProvider.create(location) : MFileOS.getExistingFile(location);
+      if (mFileProvider != null) {
+        return mFileProvider.create(location);
+      }
     } catch (IOException ioe) {
       logger.error("Error creating MFile at {}.", location, ioe);
     }
-    return mfile;
+    return new MFileOS(location);
   }
 }

--- a/cdm/core/src/main/java/thredds/inventory/MFiles.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFiles.java
@@ -8,6 +8,7 @@ package thredds.inventory;
 import java.io.IOException;
 import java.util.ServiceLoader;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.filesystem.MFileOS;
@@ -47,5 +48,22 @@ public class MFiles {
       logger.error("Error creating MFile at {}.", location, ioe);
     }
     return new MFileOS(location);
+  }
+
+  /**
+   * Create an {@link thredds.inventory.MFile} from a given location if it exists, otherwise return
+   * null.
+   *
+   * @param location location of file (local or remote) to be used to back the MFile object
+   * @return {@link thredds.inventory.MFile}
+   */
+  @Nullable
+  public static MFile createIfExists(String location) {
+    if (location == null) {
+      return null;
+    }
+
+    final MFile mFile = create(location);
+    return mFile.exists() ? mFile : null;
   }
 }

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
@@ -72,7 +72,7 @@ class AggDataset implements Comparable<AggDataset> {
   protected AggDataset(String cacheLocation, String location, @Nullable String id,
       @Nullable EnumSet<Enhance> wantEnhance, @Nullable ucar.nc2.util.cache.FileFactory reader,
       @Nullable Object spiObject, @Nullable Element ncmlElem) {
-    this.mfile = location == null ? null : MFiles.create(location);
+    this.mfile = MFiles.createIfExists(location);
     this.cacheLocation = cacheLocation;
     this.id = id;
     this.enhance = (wantEnhance == null) ? NetcdfDataset.getEnhanceNone() : wantEnhance;

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
@@ -30,6 +30,7 @@ class AggDataset implements Comparable<AggDataset> {
   private static final boolean debugOpenFile = false;
   private static final boolean debugRead = false;
 
+  @Nullable
   private final MFile mfile;
   private final Set<Enhance> enhance; // used by Fmrc to read enhanced datasets
   @Nullable
@@ -71,7 +72,7 @@ class AggDataset implements Comparable<AggDataset> {
   protected AggDataset(String cacheLocation, String location, @Nullable String id,
       @Nullable EnumSet<Enhance> wantEnhance, @Nullable ucar.nc2.util.cache.FileFactory reader,
       @Nullable Object spiObject, @Nullable Element ncmlElem) {
-    this.mfile = MFiles.create(location); // may be null
+    this.mfile = location == null ? null : MFiles.create(location);
     this.cacheLocation = cacheLocation;
     this.id = id;
     this.enhance = (wantEnhance == null) ? NetcdfDataset.getEnhanceNone() : wantEnhance;

--- a/cdm/core/src/main/java/ucar/nc2/iosp/AbstractIOServiceProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/AbstractIOServiceProvider.java
@@ -165,7 +165,7 @@ public abstract class AbstractIOServiceProvider implements IOServiceProvider {
   public long getLastModified() {
     if (location != null) {
       MFile file = MFiles.create(location);
-      return file != null ? file.getLastModified() : 0;
+      return file.getLastModified();
     } else {
       return 0;
     }

--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.util.Objects;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -376,7 +377,7 @@ public class MFileS3 implements MFile {
       return protocol;
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public MFile create(String location) throws IOException {
       try {

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -7,11 +7,11 @@ package thredds.inventory.zarr;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import javax.annotation.Nonnull;
 import thredds.filesystem.MFileOS;
 import thredds.inventory.MFile;
 import thredds.inventory.MFileProvider;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -200,7 +200,7 @@ public class MFileZip implements MFile {
       return location != null && location.contains(ext);
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public MFile create(String location) throws IOException {
       return new MFileZip(location);


### PR DESCRIPTION
## Description of Changes

Currently, `MFiles.create` claims that it both creates an `MFile` using the `MFileProviders` or by using `MFileOS` and also checks if the file exists. However, the existence check only applies in the case of the `MFileOS` and not for instance `MFileS3` or `MFileZip`. Note that we now have a separate method for checking existence (`MFile::exists`).

This PR would remove checking for existence in the `create` function. I think this change makes the code nicer since the `create` wasn't really checking existence for all types of `MFiles`. It also avoids null checks when using `create`. It makes testing simpler, for instance, I want to make tests that use `MFile.create` to test something that doesn't necessarily require files to exist.

I do not believe this counts as a breaking change, though it does change the documented behavior of this function. I added a second variant `createIfExisting` that returns null if `exists` is false (old behavior for `create` when its a `MFileOS`). Can change the names if you prefer!


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
