### PR TITLE
Add MFile method to create child MFile

### DIFF
--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
@@ -139,4 +139,9 @@ public class MFileOS implements MFile {
   public File getFile() {
     return file;
   }
+
+  @Override
+  public MFileOS getChild(String newFilename) {
+    return new MFileOS(new File(file, newFilename));
+  }
 }

--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS7.java
@@ -141,6 +141,11 @@ public class MFileOS7 implements MFile {
     }
   }
 
+  @Override
+  public MFileOS7 getChild(String newFilename) {
+    throw new UnsupportedOperationException("MFileOS7::getChild not implemented. Filename: " + getName());
+  }
+
   public Path getNioPath() {
     return path;
   }

--- a/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
+++ b/cdm/core/src/main/java/thredds/inventory/CollectionManagerCatalog.java
@@ -168,6 +168,11 @@ public class CollectionManagerCatalog extends CollectionManagerAbstract implemen
     public void writeToStream(OutputStream outputStream, long offset, long maxBytes) {
       throw new UnsupportedOperationException("Writing MFileRemote not implemented. Filename: " + getName());
     }
+
+    @Override
+    public MFileRemote getChild(String newFilename) {
+      throw new UnsupportedOperationException("MFileRemote::getChild not implemented. Filename: " + getName());
+    }
   }
 
   ///////////////////////////////

--- a/cdm/core/src/main/java/thredds/inventory/MFile.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFile.java
@@ -9,6 +9,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import javax.annotation.Nullable;
 
 /**
  * An abstraction for java.io.File / java.nio.file.Path
@@ -95,4 +96,13 @@ public interface MFile extends Comparable<MFile> {
    * @param maxBytes the maximum number of bytes to copy
    */
   void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException;
+
+  /**
+   * Get child MFile of this MFile
+   *
+   * @param newFileName the relative file path of the new MFile
+   * @return the new MFile or null if the file can't be resolved
+   */
+  @Nullable
+  MFile getChild(String newFileName);
 }

--- a/cdm/core/src/test/java/thredds/filesystem/TestMFileOS.java
+++ b/cdm/core/src/test/java/thredds/filesystem/TestMFileOS.java
@@ -90,6 +90,15 @@ public class TestMFileOS {
         assertThat(inputStream.read()).isNotEqualTo(-1);
       }
     }
+
+    @Test
+    public void shouldGetChildMFile() {
+      final MFileOS mFile = new MFileOS(tempFolder.getRoot() + "/testFile");
+      final MFileOS newMFile = mFile.getChild("newFile");
+      assertThat(newMFile.getName()).isEqualTo("newFile");
+      assertThat(newMFile.getParent().getPath()).isEqualTo(mFile.getPath());
+      assertThat(newMFile.getPath()).isEqualTo(tempFolder.getRoot() + "/testFile/newFile");
+    }
   }
 
   private static File createTemporaryFile(int size) throws IOException {

--- a/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
+++ b/cdm/s3/src/main/java/thredds/inventory/s3/MFileS3.java
@@ -368,6 +368,20 @@ public class MFileS3 implements MFile {
     }
   }
 
+  @Nullable
+  @Override
+  public MFileS3 getChild(String newFilename) {
+    final String existingKey = cdmS3Uri.getKey().orElse("");
+    final boolean addDelimiter = delimiter != null && !existingKey.endsWith(delimiter) && !existingKey.isEmpty();
+    final String newKey = addDelimiter ? existingKey + delimiter + newFilename : existingKey + newFilename;
+
+    try {
+      return new MFileS3(cdmS3Uri.resolveNewKey(newKey));
+    } catch (URISyntaxException e) {
+      return null;
+    }
+  }
+
   public static class Provider implements MFileProvider {
 
     private static String protocol = CdmS3Uri.SCHEME_CDM_S3;

--- a/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
+++ b/cdm/s3/src/test/java/thredds/inventory/s3/TestMFileS3.java
@@ -302,6 +302,42 @@ public class TestMFileS3 {
   }
 
   @Test
+  public void shouldGetChildMFileFromBucket() throws IOException {
+    final MFileS3 withDelimiter = new MFileS3("cdms3:bucket" + DELIMITER_FRAGMENT);
+    final MFileS3 newMFileWithDelimiter = withDelimiter.getChild("newKey");
+    assertThat(newMFileWithDelimiter).isNotNull();
+    assertThat(newMFileWithDelimiter.getPath()).isEqualTo("cdms3:bucket?newKey" + DELIMITER_FRAGMENT);
+
+    final MFileS3 withoutDelimiter = new MFileS3("cdms3:bucket");
+    final MFileS3 newMFileWithoutDelimiter = withoutDelimiter.getChild("newKey");
+    assertThat(newMFileWithoutDelimiter).isNotNull();
+    assertThat(newMFileWithoutDelimiter.getPath()).isEqualTo("cdms3:bucket?newKey");
+  }
+
+  @Test
+  public void shouldGetChildMFileFromBucketAndKey() throws IOException {
+    final MFileS3 withDelimiterWithSlash = new MFileS3("cdms3:bucket?key/" + DELIMITER_FRAGMENT);
+    final MFileS3 newMFileWithDelimiterWithSlash = withDelimiterWithSlash.getChild("newKey");
+    assertThat(newMFileWithDelimiterWithSlash).isNotNull();
+    assertThat(newMFileWithDelimiterWithSlash.getPath()).isEqualTo("cdms3:bucket?key/newKey" + DELIMITER_FRAGMENT);
+
+    final MFileS3 withoutDelimiterWithSlash = new MFileS3("cdms3:bucket?key/");
+    final MFileS3 newMFileWithoutDelimiterWithSlash = withoutDelimiterWithSlash.getChild("newKey");
+    assertThat(newMFileWithoutDelimiterWithSlash).isNotNull();
+    assertThat(newMFileWithoutDelimiterWithSlash.getPath()).isEqualTo("cdms3:bucket?key/newKey");
+
+    final MFileS3 withDelimiterWithoutSlash = new MFileS3("cdms3:bucket?key" + DELIMITER_FRAGMENT);
+    final MFileS3 newMFileWithDelimiterWithoutSlash = withDelimiterWithoutSlash.getChild("newKey");
+    assertThat(newMFileWithDelimiterWithoutSlash).isNotNull();
+    assertThat(newMFileWithDelimiterWithoutSlash.getPath()).isEqualTo("cdms3:bucket?key/newKey" + DELIMITER_FRAGMENT);
+
+    final MFileS3 withoutDelimiterWithoutSlash = new MFileS3("cdms3:bucket?key");
+    final MFileS3 newMFileWithoutDelimiterWithoutSlash = withoutDelimiterWithoutSlash.getChild("newKey");
+    assertThat(newMFileWithoutDelimiterWithoutSlash).isNotNull();
+    assertThat(newMFileWithoutDelimiterWithoutSlash.getPath()).isEqualTo("cdms3:bucket?keynewKey");
+  }
+
+  @Test
   public void shouldGetInputStream() throws IOException {
     final MFile mFile = new MFileS3(AWS_G16_S3_OBJECT_1);
     try (final InputStream inputStream = mFile.getInputStream()) {

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -174,6 +174,11 @@ public class MFileZip implements MFile {
         "Writing MFileZip with a byte range to stream not implemented. Filename: " + getName());
   }
 
+  @Override
+  public MFileZip getChild(String newFilename) {
+    throw new UnsupportedOperationException("MFileZip::getChild not implemented. Filename: " + getName());
+  }
+
   public Path getRootPath() {
     return rootPath;
   }

--- a/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GcMFile.java
@@ -136,4 +136,9 @@ public class GcMFile implements thredds.inventory.MFile {
       IO.copyRafB(randomAccessFile, offset, maxBytes, outputStream);
     }
   }
+
+  @Override
+  public GcMFile getChild(String newFilename) {
+    throw new UnsupportedOperationException("GcMFile::getChild not implemented. Filename: " + getName());
+  }
 }


### PR DESCRIPTION
## Description of Changes

The method added in the PR is needed for S3 DatasetScans and also if we want featureCollection indices in S3. The idea is that if we have a directory and want to get the file path of a file in that directory, we should let `MFile` handle that to avoid repeatedly parsing path strings (For S3 the separator could be "/" or "?" if its a bucket, and it also may have a fragment in the uri like `cdms3:mybucket/dir#delimiter=/` so appending `/filename.nc` or whatever doesn't work.)
