### PR TITLE
Handle compressed s3 files with a fragment

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -400,7 +400,7 @@ public class NetcdfFiles {
    * @return RandomAccessFile for the object at location
    */
   public static ucar.unidata.io.RandomAccessFile getRaf(String location, int buffer_size) throws IOException {
-    String uriString = location.trim();
+    String uriString = removeFragment(location.trim());
     if (buffer_size <= 0)
       buffer_size = default_buffersize;
 
@@ -471,6 +471,10 @@ public class NetcdfFiles {
     }
 
     return raf;
+  }
+
+  private static String removeFragment(String uriString) {
+    return uriString.split("#")[0];
   }
 
   private static boolean looksCompressed(String filename) {

--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
@@ -19,13 +19,20 @@ import ucar.unidata.util.test.category.NeedsExternalResource;
 
 @Category(NeedsExternalResource.class)
 public class TestS3ExternalCompressionRead {
+  private static final String compressedObject = "cdms3:noaa-nexrad-level2?1991/07/20/KTLX/KTLX19910720_160529.gz";
+  private static final String fragment = "#delimiter=/";
 
   @Test
   public void testCompressedObjectRead() throws IOException {
-    String bucket = "noaa-nexrad-level2";
-    String key = "1991/07/20/KTLX/KTLX19910720_160529.gz";
-    String s3uri = "cdms3:" + bucket + "?" + key;
+    testCompressedObjectRead(compressedObject);
+  }
 
+  @Test
+  public void testCompressedObjectReadWithDelimiterFragment() throws IOException {
+    testCompressedObjectRead(compressedObject + fragment);
+  }
+
+  private static void testCompressedObjectRead(String s3uri) throws IOException {
     System.setProperty(S3TestsCommon.AWS_REGION_PROP_NAME, S3TestsCommon.AWS_G16_REGION);
     try (NetcdfFile ncfile = NetcdfFiles.open(s3uri)) {
 


### PR DESCRIPTION
## Description of Changes

Fix a bug that s3 files with a fragment (for instance `cdms3:myBucket?myKey.gz#delimiter=/`) were not being recognized as compressed files since the uri doesn't end in `.gz`.