### PR TITLE
Improve performance by using buffer

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
@@ -13,6 +13,7 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
+import ucar.nc2.util.IO;
 
 /**
  * Filter implementation of zlib compression.
@@ -71,10 +72,7 @@ public class Deflate extends Filter {
     InflaterInputStream iis = new InflaterInputStream(in, new Inflater(), dataIn.length);
 
     ByteArrayOutputStream os = new ByteArrayOutputStream();
-    int read;
-    while ((read = iis.read()) != -1) {
-      os.write(read);
-    }
+    IO.copyB(iis, os, IO.default_socket_buffersize);
     // close everything and return
     in.close();
     iis.close();


### PR DESCRIPTION
## Description of Changes

Improve performance by using buffer to copy a byte stream.

I noticed this performance issue when looking at an eSupport scenario where the NCSS dataset.html page was slow to load. For an aggregation with three hdf5 data files this took ~2 seconds to load for me, whereas after this fix it took ~200 ms.
