### PR TITLE
Convert all occurrences of  static [public|protected] to [public|protected] static

### DIFF
--- a/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CodeTableGen.java
+++ b/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CodeTableGen.java
@@ -95,7 +95,7 @@ public class CodeTableGen {
 
   // try to pretty print the WORD xml
 
-  static public void prettyPrint() throws IOException {
+  public static void prettyPrint() throws IOException {
     org.jdom2.Document doc;
     try {
       SAXBuilder builder = new SAXBuilder();
@@ -121,7 +121,7 @@ public class CodeTableGen {
 
   ///////////////////////////////////////////////////////////////////////
 
-  static public void transform(Element elem, Element telem) {
+  public static void transform(Element elem, Element telem) {
     String name = elem.getName();
 
     if (name.equals("sub-section") || name.equals("tc")) {
@@ -166,7 +166,7 @@ public class CodeTableGen {
   // tranform the WORD xml into something more pareseable
   // unfortunately, we then have to hand-edit the result
   // next time, probably beter to start with the NCEP HTML pages
-  static public void passOne() throws IOException {
+  public static void passOne() throws IOException {
     org.jdom2.Document orgDoc;
     try {
       SAXBuilder builder = new SAXBuilder();
@@ -248,7 +248,7 @@ public class CodeTableGen {
 
 
   // pass 2 - transform the hand-edited XML to its final form
-  static public void passTwo() throws IOException {
+  public static void passTwo() throws IOException {
     org.jdom2.Document tdoc;
     try {
       SAXBuilder builder = new SAXBuilder();
@@ -334,7 +334,7 @@ public class CodeTableGen {
   }
 
   // pass 3 - look for problems
-  static public void passThree() throws IOException {
+  public static void passThree() throws IOException {
     org.jdom2.Document tdoc;
     try {
       SAXBuilder builder = new SAXBuilder();
@@ -367,7 +367,7 @@ public class CodeTableGen {
   static Formatter f = new Formatter(System.out);
 
 
-  static public void main(String args[]) throws IOException {
+  public static void main(String args[]) throws IOException {
     // passTwo();
     passThree();
   }

--- a/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CompareCodeTables.java
+++ b/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CompareCodeTables.java
@@ -215,7 +215,7 @@ public class CompareCodeTables {
   }
 
 
-  static public void main(String args[]) throws IOException {
+  public static void main(String args[]) throws IOException {
     Map<Integer, Feature> wmoMap = new TreeMap<Integer, Feature>();
     CompareCodeTables ct = new CompareCodeTables();
     ct.readWmoCsv("C:/docs/BC_CodeFlagTable.csv", wmoMap);

--- a/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CompareTableB.java
+++ b/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CompareTableB.java
@@ -134,7 +134,7 @@ public class CompareTableB {
     compare2(robbMap, bmTable);
   }
 
-  static public void mainBrit(String args[]) throws IOException {
+  public static void mainBrit(String args[]) throws IOException {
     CompareTableB ct = new CompareTableB();
     ct.compareBrit();
   }
@@ -202,7 +202,7 @@ public class CompareTableB {
     System.out.printf("%s lines=%d elems=%d avg name len=%d%n", filename, count, n, avg / n);
   }
 
-  static public void main(String args[]) throws IOException {
+  public static void main(String args[]) throws IOException {
     CompareTableB ct = new CompareTableB();
     Map<Integer, Feature> wmoMap = new TreeMap<Integer, Feature>();
     ct.readWmoCsv("C:/docs/BC_TableB.csv", wmoMap);
@@ -551,7 +551,7 @@ public class CompareTableB {
     return sb.toString();
   }
 
-  static public void main2(String args[]) throws IOException {
+  public static void main2(String args[]) throws IOException {
     CompareTableB ct = new CompareTableB();
     ct.compareAll();
   }

--- a/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CompareTableD.java
+++ b/bufr/src/test/java/ucar/nc2/iosp/bufr/tables/CompareTableD.java
@@ -290,7 +290,7 @@ public class CompareTableD {
     return f + "-" + x + "-" + y;
   }
 
-  static public void main(String args[]) throws IOException {
+  public static void main(String args[]) throws IOException {
     CompareTableD ct = new CompareTableD();
     ct.readWmoCsv("C:/docs/B_TableD.csv", wmoMap);
     ct.readTable();

--- a/cdm-test/src/test/java/SevenZip/CRC.java
+++ b/cdm-test/src/test/java/SevenZip/CRC.java
@@ -3,7 +3,7 @@
 package SevenZip;
 
 public class CRC {
-  static public int[] Table = new int[256];
+  public static int[] Table = new int[256];
 
   static {
     for (int i = 0; i < 256; i++) {

--- a/cdm-test/src/test/java/SevenZip/Compression/RangeCoder/Encoder.java
+++ b/cdm-test/src/test/java/SevenZip/Compression/RangeCoder/Encoder.java
@@ -114,15 +114,15 @@ public class Encoder {
     }
   }
 
-  static public int GetPrice(int Prob, int symbol) {
+  public static int GetPrice(int Prob, int symbol) {
     return ProbPrices[(((Prob - symbol) ^ ((-symbol))) & (kBitModelTotal - 1)) >>> kNumMoveReducingBits];
   }
 
-  static public int GetPrice0(int Prob) {
+  public static int GetPrice0(int Prob) {
     return ProbPrices[Prob >>> kNumMoveReducingBits];
   }
 
-  static public int GetPrice1(int Prob) {
+  public static int GetPrice1(int Prob) {
     return ProbPrices[(kBitModelTotal - Prob) >>> kNumMoveReducingBits];
   }
 }

--- a/cdm-test/src/test/java/SevenZip/LzmaAlone.java
+++ b/cdm-test/src/test/java/SevenZip/LzmaAlone.java
@@ -1,7 +1,7 @@
 package SevenZip;
 
 public class LzmaAlone {
-  static public class CommandLine {
+  public static class CommandLine {
     public static final int kEncode = 0;
     public static final int kDecode = 1;
     public static final int kBenchmak = 2;

--- a/cdm-test/src/test/java/SevenZip/LzmaBench.java
+++ b/cdm-test/src/test/java/SevenZip/LzmaBench.java
@@ -269,7 +269,7 @@ public class LzmaBench {
     PrintRating(rating);
   }
 
-  static public int LzmaBenchmark(int numIterations, int dictionarySize) throws Exception {
+  public static int LzmaBenchmark(int numIterations, int dictionarySize) throws Exception {
     if (numIterations <= 0)
       return 0;
     if (dictionarySize < (1 << 18)) {

--- a/cdm-test/src/test/java/ucar/nc2/TestCheckFileType.java
+++ b/cdm-test/src/test/java/ucar/nc2/TestCheckFileType.java
@@ -33,7 +33,7 @@ public class TestCheckFileType extends UnitTestCommon {
   static final String PREFIX = "thredds/public/testdata/";
 
   @Parameterized.Parameters(name = "{1}")
-  static public List<Object[]> getTestParameters() {
+  public static List<Object[]> getTestParameters() {
     List<Object[]> result = new ArrayList<>();
     result.add(new Object[] {NCheader.NC_FORMAT_NETCDF3, "testData.nc"});
     result.add(new Object[] {NCheader.NC_FORMAT_64BIT_OFFSET, "nc_test_cdf2.nc"});

--- a/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadandCount.java
+++ b/cdm-test/src/test/java/ucar/nc2/dt/grid/TestReadandCount.java
@@ -123,7 +123,7 @@ public class TestReadandCount {
     doOne(dir, name, ngrids, ncoordSys, ncoordAxes, nVertCooordAxes);
   }
 
-  static public void doOne(String dir, String name, int ngrids, int ncoordSys, int ncoordAxes, int nVertCooordAxes)
+  public static void doOne(String dir, String name, int ngrids, int ncoordSys, int ncoordAxes, int nVertCooordAxes)
       throws Exception {
     System.out.printf("test read GridDataset= %s%s%n", dir, name);
     ucar.nc2.dt.grid.GridDataset gridDs = GridDataset.open(dir + name);

--- a/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestRdaCoordsMatchGbx.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/coverage/TestRdaCoordsMatchGbx.java
@@ -35,13 +35,13 @@ public class TestRdaCoordsMatchGbx {
   private static final boolean showFileCounters = true;
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     Grib.setDebugFlags(new DebugFlagsImpl("Grib/debugGbxIndexOnly"));
     countersAll = GribCoordsMatchGbx.getCounters();
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     System.out.printf("countersAll = %s%n", countersAll);
   }

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestCFPointDatasets.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestCFPointDatasets.java
@@ -35,7 +35,7 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class TestCFPointDatasets {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  static public String CFpointObs_topdir = TestDir.cdmLocalFromTestDataDir + "point/";
+  public static String CFpointObs_topdir = TestDir.cdmLocalFromTestDataDir + "point/";
 
   public static List<Object[]> getPointDatasets() {
     List<Object[]> result = new ArrayList<>();

--- a/cdm-test/src/test/java/ucar/nc2/ft/point/TestPreCFpointDatasets.java
+++ b/cdm-test/src/test/java/ucar/nc2/ft/point/TestPreCFpointDatasets.java
@@ -31,7 +31,7 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class TestPreCFpointDatasets {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  static public String CFpointObs_pre16 = TestDir.cdmLocalFromTestDataDir + "pointPre1.6/";
+  public static String CFpointObs_pre16 = TestDir.cdmLocalFromTestDataDir + "pointPre1.6/";
 
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbx.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbx.java
@@ -30,7 +30,7 @@ public class TestCoordinatesMatchGbx {
   private static final boolean showFileCounters = false;
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     Grib.setDebugFlags(new DebugFlagsImpl("Grib/debugGbxIndexOnly"));
     countersAll = GribCoordsMatchGbx.getCounters();
 
@@ -39,7 +39,7 @@ public class TestCoordinatesMatchGbx {
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     logger.debug("countersAll = {}", countersAll);
     Variable.permitCaching = true;

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbxP.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestCoordinatesMatchGbxP.java
@@ -34,13 +34,13 @@ public class TestCoordinatesMatchGbxP {
   private static final boolean showFileCounters = true;
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     Grib.setDebugFlags(new DebugFlagsImpl("Grib/debugGbxIndexOnly"));
     countersAll = GribCoordsMatchGbx.getCounters();
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     System.out.printf("countersAll = %s%n", countersAll);
   }

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
@@ -36,7 +36,7 @@ public class TestGribCollectionCoordinates {
   private static CollectionUpdateType updateMode = CollectionUpdateType.always;
 
   @BeforeClass
-  static public void before() throws IOException {
+  public static void before() throws IOException {
     GribIosp.debugIndexOnlyCount = 0;
     GribCollectionImmutable.countGC = 0;
     PartitionCollectionImmutable.countPC = 0;
@@ -48,7 +48,7 @@ public class TestGribCollectionCoordinates {
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     /*
      * Formatter out = new Formatter(System.out);

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionMissing.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionMissing.java
@@ -69,7 +69,7 @@ public class TestGribCollectionMissing {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     GribIosp.debugIndexOnlyCount = 0;
     GribCollectionImmutable.countGC = 0;
     PartitionCollectionImmutable.countPC = 0;
@@ -81,7 +81,7 @@ public class TestGribCollectionMissing {
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     Formatter out = new Formatter(System.out);
 
@@ -322,7 +322,7 @@ public class TestGribCollectionMissing {
     count.nread++;
   }
 
-  static public class Count {
+  public static class Count {
     int nread;
     int nmiss;
     int nerrs;

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionsBig.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionsBig.java
@@ -66,7 +66,7 @@ public class TestGribCollectionsBig {
   // String topdir = "B:/rdavm"; // use for local windows to get around samba bug
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     GribIosp.debugIndexOnlyCount = 0;
     GribCollectionImmutable.countGC = 0;
     PartitionCollectionImmutable.countPC = 0;
@@ -78,7 +78,7 @@ public class TestGribCollectionsBig {
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     Formatter out = new Formatter(System.out);
 

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionsDense.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionsDense.java
@@ -65,7 +65,7 @@ public class TestGribCollectionsDense {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     GribIosp.debugIndexOnlyCount = 0;
     GribCollectionImmutable.countGC = 0;
     PartitionCollectionImmutable.countPC = 0;
@@ -77,7 +77,7 @@ public class TestGribCollectionsDense {
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     Formatter out = new Formatter(System.out);
 

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreation.java
@@ -44,7 +44,7 @@ public class TestGribIndexCreation {
   private static CollectionUpdateType updateMode = CollectionUpdateType.always;
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     GribIosp.debugIndexOnlyCount = 0;
     GribCollectionImmutable.countGC = 0;
     PartitionCollectionImmutable.countPC = 0;
@@ -61,7 +61,7 @@ public class TestGribIndexCreation {
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     Formatter out = new Formatter(System.out);
 

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreationOther.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribIndexCreationOther.java
@@ -34,7 +34,7 @@ public class TestGribIndexCreationOther {
   private static final boolean show = false;
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     GribIosp.debugIndexOnlyCount = 0;
     GribCollectionImmutable.countGC = 0;
     PartitionCollectionImmutable.countPC = 0;
@@ -46,7 +46,7 @@ public class TestGribIndexCreationOther {
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
     Formatter out = new Formatter(System.out);
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/bufr/ScannerPqact.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/bufr/ScannerPqact.java
@@ -290,7 +290,7 @@ public class ScannerPqact extends Scanner {
   static Formatter out = new Formatter(System.out);
 
   // LOOK turn this into a test
-  static public void main(String args[]) throws IOException {
+  public static void main(String args[]) throws IOException {
 
     // read pattern matching
     readPqactTable("D:/bufr/pqact.txt");

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4eos.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4eos.java
@@ -32,7 +32,7 @@ import java.lang.invoke.MethodHandles;
 public class TestH4eos {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String testDir = TestDir.cdmUnitTestDir + "formats/hdf4/eos/";
+  public static String testDir = TestDir.cdmUnitTestDir + "formats/hdf4/eos/";
 
   // test the coordSysBuilder - check if grid exists
   @Test

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4misc.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4misc.java
@@ -29,7 +29,7 @@ import java.lang.invoke.MethodHandles;
 @Category(NeedsCdmUnitTest.class)
 public class TestH4misc {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  static public String testDir = TestDir.cdmUnitTestDir + "formats/hdf4/";
+  public static String testDir = TestDir.cdmUnitTestDir + "formats/hdf4/";
 
   @Test
   public void testUnsigned() throws IOException, InvalidRangeException {

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4readAll.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4readAll.java
@@ -33,7 +33,7 @@ public class TestH4readAll {
   static private String testDir = TestDir.cdmUnitTestDir + "formats/hdf4/";
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     H4header.setDebugFlags(new DebugFlagsImpl("")); // make sure debug flags are off
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4readAndCount.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf4/TestH4readAndCount.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class TestH4readAndCount {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String testDir = TestDir.cdmUnitTestDir + "formats/hdf4/";
+  public static String testDir = TestDir.cdmUnitTestDir + "formats/hdf4/";
 
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5OddTypes.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5OddTypes.java
@@ -30,10 +30,10 @@ import java.nio.ByteBuffer;
  */
 public class TestH5OddTypes {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  static public String testDir = TestH5.testDir;
+  public static String testDir = TestH5.testDir;
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     H5header.setDebugFlags(new DebugFlagsImpl("")); // make sure debug flags are off
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5ReadAndCount.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5ReadAndCount.java
@@ -27,7 +27,7 @@ import java.util.List;
 @Category(NeedsCdmUnitTest.class)
 public class TestH5ReadAndCount {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  static public String testDir = TestH5.testDir;
+  public static String testDir = TestH5.testDir;
 
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5npoess.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5npoess.java
@@ -29,7 +29,7 @@ public class TestH5npoess {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     H5header.setDebugFlags(new DebugFlagsImpl("")); // make sure debug flags are off
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5readAll.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5readAll.java
@@ -30,7 +30,7 @@ public class TestH5readAll {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     H5header.setDebugFlags(new DebugFlagsImpl("")); // make sure debug flags are off
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4problems.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestN4problems.java
@@ -34,7 +34,7 @@ public class TestN4problems {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     H5header.setDebugFlags(new DebugFlagsImpl("")); // make sure debug flags are off
   }
 

--- a/cdm-test/src/test/java/ucar/nc2/util/net/Json.java
+++ b/cdm-test/src/test/java/ucar/nc2/util/net/Json.java
@@ -31,14 +31,14 @@ abstract public class Json {
 
   //////////////////////////////////////////////////
 
-  static public Object parse(String text) throws IOException {
+  public static Object parse(String text) throws IOException {
     Parser parser = new Parser();
     return parser.parse(text);
   }
 
   //////////////////////////////////////////////////
 
-  static protected class Parser {
+  protected static class Parser {
 
     public Parser() {}
 
@@ -160,17 +160,17 @@ abstract public class Json {
     }
   }
 
-  static public String toString(Object o) {
+  public static String toString(Object o) {
     return toString(o, "");
   }
 
-  static public String toString(Object o, String demark) {
+  public static String toString(Object o, String demark) {
     StringBuilder buf = new StringBuilder();
     toStringR(o, buf, demark, 0);
     return buf.toString();
   }
 
-  static protected void toStringR(Object o, StringBuilder buf, String demark, int indent) {
+  protected static void toStringR(Object o, StringBuilder buf, String demark, int indent) {
     boolean first = true;
     if (o instanceof List) {
       List<Object> list = (List<Object>) o;
@@ -230,7 +230,7 @@ abstract public class Json {
 
   static String blanks = "                                                  ";
 
-  static protected String indent(int n) {
+  protected static String indent(int n) {
     while (n > blanks.length()) {
       blanks = blanks + blanks;
     }

--- a/cdm-test/src/timing/java/timing/IO/TimeCompression.java
+++ b/cdm-test/src/timing/java/timing/IO/TimeCompression.java
@@ -55,13 +55,13 @@ import java.util.Random;
 public class TimeCompression {
   static boolean debug = false;
 
-  static public void main(String[] args) throws IOException {
+  public static void main(String[] args) throws IOException {
     testCompressRandom();
     testCompressFile("D:/data/NAM_CONUS_80km_20070501_1200.nc");
     testCompressFile("D:/data/NAM_CONUS_80km_20070501_1200.nc");
   }
 
-  static public void testCompressFile(String filename) throws IOException {
+  public static void testCompressFile(String filename) throws IOException {
     compressFile(filename, "C:/temp/tempFile.compress1", true);
     compressFile(filename, "C:/temp/tempFile.gzip", false);
 
@@ -70,7 +70,7 @@ public class TimeCompression {
   }
 
   // test Deflater on real files
-  static public void compressFile(String filenameIn, String filenameOut, boolean inflate) throws IOException {
+  public static void compressFile(String filenameIn, String filenameOut, boolean inflate) throws IOException {
     long lenIn = new File(filenameIn).length();
     if (debug)
       System.out.println("read " + filenameIn + " len = " + lenIn);
@@ -100,7 +100,7 @@ public class TimeCompression {
     System.out.println(" " + name + " took = " + took + " sec; rate = " + rate + "Mb/sec; compress = " + ratio);
   }
 
-  static public void uncompressFile(String filenameIn, String filenameOut, boolean inflate) throws IOException {
+  public static void uncompressFile(String filenameIn, String filenameOut, boolean inflate) throws IOException {
     long lenIn = new File(filenameIn).length();
     if (debug)
       System.out.println("read compressed file= " + filenameIn + " len = " + lenIn);
@@ -132,7 +132,7 @@ public class TimeCompression {
 
   /////////////////////////////////////////////////////////////
   // random floats
-  static public void testCompressRandom() throws IOException {
+  public static void testCompressRandom() throws IOException {
     deflateRandom("C:/temp/tempFile.compress1", false);
     deflateRandom("C:/temp/tempFile.compress2", true);
 
@@ -147,7 +147,7 @@ public class TimeCompression {
   }
 
   // test DeflaterOutputStream - write 1M random floats
-  static public void deflateRandom(String filenameOut, boolean buffer) throws IOException {
+  public static void deflateRandom(String filenameOut, boolean buffer) throws IOException {
     FileOutputStream fout = new FileOutputStream(filenameOut);
     OutputStream out = new DeflaterOutputStream(fout);
     if (buffer)
@@ -169,7 +169,7 @@ public class TimeCompression {
   }
 
   // test GZIPOutputStream - write 1M random floats
-  static public void gzipRandom(String filenameOut, boolean buffer) throws IOException {
+  public static void gzipRandom(String filenameOut, boolean buffer) throws IOException {
     FileOutputStream fout = new FileOutputStream(filenameOut);
     OutputStream out = new GZIPOutputStream(fout);
     if (buffer)
@@ -191,7 +191,7 @@ public class TimeCompression {
   }
 
   // test InflaterInputStream
-  static public void inflateRandom(String filename, boolean buffer) throws IOException {
+  public static void inflateRandom(String filename, boolean buffer) throws IOException {
     FileInputStream fin = new FileInputStream(filename);
     InputStream in = new InflaterInputStream(fin);
     if (buffer)
@@ -213,7 +213,7 @@ public class TimeCompression {
   }
 
   // test InflaterInputStream
-  static public void unzipRandom(String filename, boolean buffer) throws IOException {
+  public static void unzipRandom(String filename, boolean buffer) throws IOException {
     FileInputStream fin = new FileInputStream(filename);
     InputStream in = new GZIPInputStream(fin);
     if (buffer)
@@ -235,7 +235,7 @@ public class TimeCompression {
   }
 
   // test DeflaterOutputStream
-  static public void main2(String[] args) throws IOException {
+  public static void main2(String[] args) throws IOException {
     String filenameIn = "C:/temp/tempFile2";
     String filenameOut = "C:/temp/tempFile2.compress2";
 

--- a/cdm-test/src/timing/java/timing/IO/TimeDigest.java
+++ b/cdm-test/src/timing/java/timing/IO/TimeDigest.java
@@ -10,7 +10,7 @@ import java.security.Provider;
 import java.util.Set;
 
 public class TimeDigest {
-  static public void main(String args[]) {
+  public static void main(String args[]) {
     testDigest();
   }
 

--- a/cdm-test/src/timing/java/timing/Stat.java
+++ b/cdm-test/src/timing/java/timing/Stat.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 public class Stat {
   static private HashMap<String, Stat> map = new HashMap<String, Stat>();
 
-  static public Stat factory(String name) {
+  public static Stat factory(String name) {
     Stat s = map.get(name);
     if (s == null) {
       s = new Stat(name, false);

--- a/cdm-test/src/timing/java/ucar/nc2/ReadRaw.java
+++ b/cdm-test/src/timing/java/ucar/nc2/ReadRaw.java
@@ -160,7 +160,7 @@ public class ReadRaw {
 
   }
 
-  static public void main(String args[]) throws IOException {
+  public static void main(String args[]) throws IOException {
     new ReadRaw();
   }
 }

--- a/cdm-test/src/timing/java/ucar/nc2/TimeRecords2.java
+++ b/cdm-test/src/timing/java/ucar/nc2/TimeRecords2.java
@@ -43,7 +43,7 @@ public class TimeRecords2 {
     System.out.println(" readOneVariable took=" + took + " secs (" + total + ")");
   }
 
-  static public void main(String[] args) throws IOException {
+  public static void main(String[] args) throws IOException {
     doOne("C:/data/metars/Surface_METAR_20070326_0000.col.nc", "parent_index");
     doOne("C:/data/metars/Surface_METAR_20070326_0000.nc", "parent_index");
   }

--- a/cdm-test/src/timing/java/ucar/nc2/util/xml/TestMetarEncoding.java
+++ b/cdm-test/src/timing/java/ucar/nc2/util/xml/TestMetarEncoding.java
@@ -137,7 +137,7 @@ public class TestMetarEncoding extends java.util.TimerTask {
     runC();
   }
 
-  static public void main(String[] args) {
+  public static void main(String[] args) {
     Calendar c = Calendar.getInstance(); // contains current startup time
     // c.add(Calendar.SECOND, 30); // starting in 30 seconds
     Timer timer = new Timer();

--- a/cdm/core/src/main/java/ucar/nc2/Attribute.java
+++ b/cdm/core/src/main/java/ucar/nc2/Attribute.java
@@ -38,7 +38,7 @@ public class Attribute extends CDMNode {
 
   /** @deprecated move to jni.Nc4Iosp */
   @Deprecated
-  static public final String[] SPECIALS =
+  public static final String[] SPECIALS =
       {CDM.NCPROPERTIES, CDM.ISNETCDF4, CDM.SUPERBLOCKVERSION, CDM.DAP4_LITTLE_ENDIAN, CDM.EDU_UCAR_PREFIX};
 
   /**

--- a/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
@@ -66,7 +66,7 @@ public class CDM {
   public static final String ISNETCDF4 = "_IsNetcdf4";
   public static final String SUPERBLOCKVERSION = "_SuperblockVersion";
 
-  static public final String[] SPECIALS = {NCPROPERTIES, ISNETCDF4, SUPERBLOCKVERSION};
+  public static final String[] SPECIALS = {NCPROPERTIES, ISNETCDF4, SUPERBLOCKVERSION};
 
   public static final String DAP4_LITTLE_ENDIAN = "_DAP4_Little_Endian";
   public static final String EDU_UCAR_PREFIX = "_edu.ucar";

--- a/cdm/core/src/main/java/ucar/nc2/util/DiskCache2.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/DiskCache2.java
@@ -68,7 +68,7 @@ public class DiskCache2 {
    * Default DiskCache2 strategy: use $user_home/.unidata/cache/, no scouring, alwaysUseCache = false
    * Mimics default DiskCache static class
    */
-  static public DiskCache2 getDefault() {
+  public static DiskCache2 getDefault() {
     String root = System.getProperty("nj22.cache");
 
     if (root == null) {
@@ -90,7 +90,7 @@ public class DiskCache2 {
   }
 
   // NOOP
-  static public DiskCache2 getNoop() {
+  public static DiskCache2 getNoop() {
     DiskCache2 noop = new DiskCache2();
     noop.neverUseCache = true;
     return noop;

--- a/cdm/core/src/test/java/thredds/filesystem/TestMFileOS7.java
+++ b/cdm/core/src/test/java/thredds/filesystem/TestMFileOS7.java
@@ -28,7 +28,7 @@ public class TestMFileOS7 {
   public static class TestMFileOS7Parameterized {
 
     @Parameterized.Parameters(name = "{0}")
-    static public List<Integer> getTestParameters() {
+    public static List<Integer> getTestParameters() {
       return Arrays.asList(0, 1, 60000, 100000);
     }
 

--- a/cdm/core/src/test/java/timing/TimingCopy.java
+++ b/cdm/core/src/test/java/timing/TimingCopy.java
@@ -45,7 +45,7 @@ public class TimingCopy {
 
   static boolean debug = true;
 
-  static public void main(String args[]) throws IOException {
+  public static void main(String args[]) throws IOException {
     // 3/16/2015
     // copyURL2null("http://thredds-dev.unidata.ucar.edu/thredds/fileServer/grib/NCEP/GFS/CONUS_80km/GFS_CONUS_80km_20141116_0000.grib1/files/GFS_CONUS_80km_20141116_0000.grib1",
     // 20000);
@@ -195,7 +195,7 @@ public class TimingCopy {
 
   // }
 
-  static public void copyFile(String filenameIn, String filenameOut, boolean buffer) throws IOException {
+  public static void copyFile(String filenameIn, String filenameOut, boolean buffer) throws IOException {
     long lenIn = new File(filenameIn).length();
     if (debug)
       System.out.println("read " + filenameIn + " len = " + lenIn);
@@ -225,7 +225,7 @@ public class TimingCopy {
     System.out.println(" copy (" + name + ") took = " + took + " sec; rate = " + rate + "Mb/sec");
   }
 
-  static public void copyFile2null(String filenameIn, int buffer) throws IOException {
+  public static void copyFile2null(String filenameIn, int buffer) throws IOException {
     long lenIn = new File(filenameIn).length();
     if (debug)
       System.out.println("read " + filenameIn + " len = " + lenIn);
@@ -242,7 +242,7 @@ public class TimingCopy {
     System.out.println(" copy (" + filenameIn + ") took = " + took + " sec; rate = " + rate + "Mb/sec");
   }
 
-  static public void copyFileNIO(String filenameIn, String filenameOut, long kbchunks) throws IOException {
+  public static void copyFileNIO(String filenameIn, String filenameOut, long kbchunks) throws IOException {
 
     FileInputStream in = new FileInputStream(filenameIn);
     FileChannel inChannel = in.getChannel();
@@ -276,13 +276,13 @@ public class TimingCopy {
     System.out.println(" copyFileNIO(" + kbchunks + " kb chunk) took = " + took + " sec; rate = " + rate + "Mb/sec");
   }
 
-  static public void testNIO(String filenameIn, String filenameOut, long kbchunks) throws IOException {
+  public static void testNIO(String filenameIn, String filenameOut, long kbchunks) throws IOException {
 
     ByteBuffer bb = ByteBuffer.allocate(8 * 1000);
     FloatBuffer fb = bb.asFloatBuffer();
   }
 
-  static public void readFile(String filenameIn, int bufferSize) throws IOException {
+  public static void readFile(String filenameIn, int bufferSize) throws IOException {
     long lenIn = new File(filenameIn).length();
     if (debug)
       System.out.println("read " + filenameIn + " len = " + lenIn);
@@ -307,7 +307,7 @@ public class TimingCopy {
   }
 
 
-  static public void copyURL(String url, String filenameOut, int bufferSize) throws IOException {
+  public static void copyURL(String url, String filenameOut, int bufferSize) throws IOException {
 
     File outFile = new File(filenameOut);
 
@@ -322,7 +322,7 @@ public class TimingCopy {
         + Format.d(rate, 3) + "Mb/sec ok=" + ok);
   }
 
-  static public void copyURL2null(String url, int bufferSize) throws IOException {
+  public static void copyURL2null(String url, int bufferSize) throws IOException {
 
     long start = System.currentTimeMillis();
     long count = IO.copyUrlB(url, null, bufferSize);
@@ -335,7 +335,7 @@ public class TimingCopy {
   }
 
 
-  static public void readURL(String urlString, int bufferSize) throws IOException {
+  public static void readURL(String urlString, int bufferSize) throws IOException {
 
     System.out.println("start=" + new Date());
     long start = System.currentTimeMillis();

--- a/cdm/core/src/test/java/ucar/nc2/iosp/hdf5/TestEnumTypedef.java
+++ b/cdm/core/src/test/java/ucar/nc2/iosp/hdf5/TestEnumTypedef.java
@@ -70,7 +70,7 @@ public class TestEnumTypedef extends UnitTestCommon {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCase> defineTestCases() {
+  public static List<TestCase> defineTestCases() {
     List<TestCase> testcases = new ArrayList<>();
     TestCase tc;
     String file;

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlRead.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestNcmlRead.java
@@ -254,7 +254,7 @@ public class TestNcmlRead extends TestCase {
     return Math.abs((d1 - d2) / d1) < 1.0e-5;
   }
 
-  static public class TestRead2 extends TestNcmlRead {
+  public static class TestRead2 extends TestNcmlRead {
 
     // equivalent dataset using "readMetadata"
     public TestRead2(String name) {
@@ -264,7 +264,7 @@ public class TestNcmlRead extends TestCase {
     }
   }
 
-  static public class TestReadHttps extends TestNcmlRead {
+  public static class TestReadHttps extends TestNcmlRead {
 
     // Test handling of incorrect https variant of NcML namespace URI.
     // See note in Catalog.java.

--- a/cdm/core/src/test/java/ucar/nc2/util/cache/TestNetcdfFileCache.java
+++ b/cdm/core/src/test/java/ucar/nc2/util/cache/TestNetcdfFileCache.java
@@ -31,11 +31,11 @@ public class TestNetcdfFileCache {
   private static FileFactory factory = new MyFileFactory();
 
   @BeforeClass
-  static public void setUp() {
+  public static void setUp() {
     cache = new FileCache(5, 100, 60 * 60);
   }
 
-  static public class MyFileFactory implements FileFactory {
+  public static class MyFileFactory implements FileFactory {
     public FileCacheable open(DatasetUrl location, int buffer_size, CancelTask cancelTask, Object iospMessage)
         throws IOException {
       return NetcdfDatasets.openFile(location, buffer_size, cancelTask, iospMessage);

--- a/cdm/core/src/test/java/ucar/unidata/geoloc/TestLongitudeNormalization.java
+++ b/cdm/core/src/test/java/ucar/unidata/geoloc/TestLongitudeNormalization.java
@@ -71,7 +71,7 @@ public class TestLongitudeNormalization {
    * @param start starting point
    * @return longitude into the range [center +/- 180] deg
    */
-  static public double lonNormalFrom(double lon, double start) {
+  public static double lonNormalFrom(double lon, double start) {
     while (lon < start)
       lon += 360;
     while (lon > start + 360)

--- a/cdm/core/src/test/java/ucar/unidata/geoloc/TestLongitudeWrap.java
+++ b/cdm/core/src/test/java/ucar/unidata/geoloc/TestLongitudeWrap.java
@@ -55,7 +55,7 @@ public class TestLongitudeWrap {
    * @param lon2 end
    * @return
    */
-  static public double lonDiff(double lon1, double lon2) {
+  public static double lonDiff(double lon1, double lon2) {
     return Math.IEEEremainder(lon1 - lon2, 720.0);
   }
 }

--- a/cdm/gcdm/src/test/java/ucar/gcdm/TestGcdmReadSection.java
+++ b/cdm/gcdm/src/test/java/ucar/gcdm/TestGcdmReadSection.java
@@ -25,13 +25,13 @@ public class TestGcdmReadSection {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
-  static public void before() {
+  public static void before() {
     // make sure to fetch data through gcdm every time
     Variable.permitCaching = false;
   }
 
   @AfterClass
-  static public void after() {
+  public static void after() {
     Variable.permitCaching = true;
   }
 

--- a/cdm/image/src/test/java/ucar/nc2/iosp/TestMiscIosp.java
+++ b/cdm/image/src/test/java/ucar/nc2/iosp/TestMiscIosp.java
@@ -28,14 +28,14 @@ public class TestMiscIosp {
   private static int leaks;
 
   @BeforeClass
-  static public void startup() {
+  public static void startup() {
     RandomAccessFile.setDebugLeaks(true);
     RandomAccessFile.enableDefaultGlobalFileCache();
     leaks = RandomAccessFile.getOpenFiles().size();
   }
 
   @AfterClass
-  static public void checkLeaks() {
+  public static void checkLeaks() {
     FileCache.shutdown();
     RandomAccessFile.setGlobalFileCache(null);
     assert leaks == TestDir.checkLeaks();

--- a/cdm/misc/src/test/java/ucar/nc2/geotiff/TestGeoTiffWriter2.java
+++ b/cdm/misc/src/test/java/ucar/nc2/geotiff/TestGeoTiffWriter2.java
@@ -35,7 +35,7 @@ public class TestGeoTiffWriter2 {
 
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
-  static public String topdir = TestDir.cdmUnitTestDir;
+  public static String topdir = TestDir.cdmUnitTestDir;
 
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> getTestParameters() {

--- a/cdm/misc/src/test/java/ucar/nc2/geotiff/TestGeotiffRead.java
+++ b/cdm/misc/src/test/java/ucar/nc2/geotiff/TestGeotiffRead.java
@@ -28,7 +28,7 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class TestGeotiffRead {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  static public File topdir = new File(TestDir.cdmUnitTestDir + "/formats/geotiff/");
+  public static File topdir = new File(TestDir.cdmUnitTestDir + "/formats/geotiff/");
 
   // Even if this class is being excluded due to the NeedsCdmUnitTest annotation, JUnit still calls this method.
   // So, it mustn't throw an exception. Instead, when cdmUnitTest/ isn't available, it'll return an empty list.

--- a/cdm/misc/src/test/java/ucar/nc2/iosp/grads/TestGrads.java
+++ b/cdm/misc/src/test/java/ucar/nc2/iosp/grads/TestGrads.java
@@ -32,14 +32,14 @@ public class TestGrads {
   private static int leaks;
 
   @BeforeClass
-  static public void startup() {
+  public static void startup() {
     RandomAccessFile.setDebugLeaks(true);
     RandomAccessFile.enableDefaultGlobalFileCache();
     leaks = RandomAccessFile.getOpenFiles().size();
   }
 
   @AfterClass
-  static public void checkLeaks() {
+  public static void checkLeaks() {
     FileCache.shutdown();
     RandomAccessFile.setGlobalFileCache(null);
     assert leaks == TestDir.checkLeaks();

--- a/cdm/misc/src/test/java/ucar/nc2/iosp/noaa/TestGhcnm.java
+++ b/cdm/misc/src/test/java/ucar/nc2/iosp/noaa/TestGhcnm.java
@@ -58,7 +58,7 @@ public class TestGhcnm {
   }
 
   // LOOK make into test
-  static public void main2(String args[]) throws IOException {
+  public static void main2(String args[]) throws IOException {
     Set<Integer> stns = new HashSet<>(10 * 1000);
     stnDuplicates("C:/data/ghcnm/ghcnm.v3.0.0-beta1.20101207.qae.inv", stns, false);
     stnDuplicates("C:/data/ghcnm/ghcnm.v3.0.0-beta1.20101207.qca.inv", stns, true);

--- a/cdm/radial/src/test/java/ucar/nc2/iosp/TestMiscIosp.java
+++ b/cdm/radial/src/test/java/ucar/nc2/iosp/TestMiscIosp.java
@@ -33,14 +33,14 @@ public class TestMiscIosp {
   private static int leaks;
 
   @BeforeClass
-  static public void startup() {
+  public static void startup() {
     RandomAccessFile.setDebugLeaks(true);
     RandomAccessFile.enableDefaultGlobalFileCache();
     leaks = RandomAccessFile.getOpenFiles().size();
   }
 
   @AfterClass
-  static public void checkLeaks() {
+  public static void checkLeaks() {
     FileCache.shutdown();
     RandomAccessFile.setGlobalFileCache(null);
     assert leaks == TestDir.checkLeaks();

--- a/cdm/radial/src/test/java/ucar/nc2/iosp/nexrad2/TestNexrad2.java
+++ b/cdm/radial/src/test/java/ucar/nc2/iosp/nexrad2/TestNexrad2.java
@@ -95,7 +95,7 @@ public class TestNexrad2 {
 
   }
 
-  static public boolean testCoordSystem(NetcdfFile nexrad2) throws IOException {
+  public static boolean testCoordSystem(NetcdfFile nexrad2) throws IOException {
     Dimension scanR = nexrad2.findDimension("scanR");
     assert null != scanR;
     Dimension scanV = nexrad2.findDimension("scanV");

--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3NetcdfFileCache.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3NetcdfFileCache.java
@@ -34,16 +34,16 @@ public class TestS3NetcdfFileCache {
   private static final String S3_URI = "cdms3:" + BUCKET + "?" + FILENAME;
 
   @BeforeClass
-  static public void setUp() {
+  public static void setUp() {
     cache = new FileCache(5, 100, 60 * 60);
   }
 
   @AfterClass
-  static public void tearDown() {
+  public static void tearDown() {
     cache.clearCache(true);
   }
 
-  static public class MyFileFactory implements FileFactory {
+  public static class MyFileFactory implements FileFactory {
     public FileCacheable open(DatasetUrl location, int buffer_size, CancelTask cancelTask, Object iospMessage)
         throws IOException {
       return NetcdfDatasets.openFile(location, buffer_size, cancelTask, iospMessage);

--- a/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
+++ b/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
@@ -30,7 +30,7 @@ public class TestMFileZip {
   public static class TestMFileZipParameterized {
 
     @Parameterized.Parameters(name = "{0}, {1}")
-    static public List<Integer[]> getTestParameters() {
+    public static List<Integer[]> getTestParameters() {
       List<Integer[]> result = new ArrayList<>();
       result.add(new Integer[] {0, 0});
       result.add(new Integer[] {0, 1});

--- a/dap4/src/main/java/dap4/core/dmr/DMRPrinter.java
+++ b/dap4/src/main/java/dap4/core/dmr/DMRPrinter.java
@@ -47,7 +47,7 @@ public class DMRPrinter {
 
   public static final boolean ALLOWFIELDMAPS = false;
 
-  static public final String XMLDOCUMENTHEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>";
+  public static final String XMLDOCUMENTHEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>";
 
   //////////////////////////////////////////////////
   // Types
@@ -58,7 +58,7 @@ public class DMRPrinter {
 
   //////////////////////////////////////////////////
   // Static Methods
-  static public void print(DapDataset dmr, PrintStream stream) {
+  public static void print(DapDataset dmr, PrintStream stream) {
     try {
       PrintWriter pw = new PrintWriter(stream);
       new DMRPrinter(dmr, pw).print();
@@ -67,7 +67,7 @@ public class DMRPrinter {
     } ;
   }
 
-  static public String printAsString(DapDataset dmr) {
+  public static String printAsString(DapDataset dmr) {
     String s = null;
     try {
       StringWriter sw = new StringWriter();

--- a/dap4/src/main/java/dap4/core/dmr/DapEnumeration.java
+++ b/dap4/src/main/java/dap4/core/dmr/DapEnumeration.java
@@ -21,7 +21,7 @@ public class DapEnumeration extends DapType {
   // Static Methods
 
   // See if two enumeration objects appear to be identical
-  static public boolean same(DapEnumeration enum1, DapEnumeration enum2) {
+  public static boolean same(DapEnumeration enum1, DapEnumeration enum2) {
     if (!enum1.getShortName().equals(enum2.getShortName()))
       return false;
     if (enum1.getBaseType() != enum2.getBaseType())

--- a/dap4/src/main/java/dap4/core/interfaces/ArrayScheme.java
+++ b/dap4/src/main/java/dap4/core/interfaces/ArrayScheme.java
@@ -19,7 +19,7 @@ public enum ArrayScheme {
   //////////////////////////////////////////////////
   // Static methods
 
-  static public ArrayScheme schemeFor(DapVariable field) {
+  public static ArrayScheme schemeFor(DapVariable field) {
     DapType ftype = field.getBaseType();
     ArrayScheme scheme = null;
     boolean isscalar = field.getRank() == 0;

--- a/dap4/src/main/java/dap4/core/util/ChecksumMode.java
+++ b/dap4/src/main/java/dap4/core/util/ChecksumMode.java
@@ -14,12 +14,12 @@ public enum ChecksumMode {
   FALSE, // => dap4.checksum=false
   TRUE; // => dap4.checksum=true
 
-  static public final ChecksumMode dfalt = TRUE; // Must be TRUE|FALSE
+  public static final ChecksumMode dfalt = TRUE; // Must be TRUE|FALSE
 
   static final String[] trues = new String[] {"true", "on", "yes", "1"};
   static final String[] falses = new String[] {"false", "off", "no", "0"};
 
-  static public String toString(ChecksumMode mode) {
+  public static String toString(ChecksumMode mode) {
     if (mode == null)
       mode = ChecksumMode.dfalt;
     switch (mode) {
@@ -33,7 +33,7 @@ public enum ChecksumMode {
     return ChecksumMode.toString(dfalt);
   }
 
-  static public ChecksumMode modeFor(String s) {
+  public static ChecksumMode modeFor(String s) {
     if (s == null || s.length() == 0)
       return null;
     for (String f : falses) {
@@ -53,7 +53,7 @@ public enum ChecksumMode {
    * @param mode
    * @return TRUE|FALSE
    */
-  static public ChecksumMode asTrueFalse(ChecksumMode mode) {
+  public static ChecksumMode asTrueFalse(ChecksumMode mode) {
     if (mode == null || mode == NONE)
       mode = dfalt;
     return mode;

--- a/dap4/src/main/java/dap4/core/util/DapDump.java
+++ b/dap4/src/main/java/dap4/core/util/DapDump.java
@@ -23,7 +23,7 @@ public abstract class DapDump {
   //////////////////////////////////////////////////
   // Provide a simple dump of binary data
 
-  static public void dumpbytesbuf(ByteBuffer buf0, boolean skipdmr) {
+  public static void dumpbytesbuf(ByteBuffer buf0, boolean skipdmr) {
     int savepos = buf0.position();
     int limit0 = buf0.limit();
     int skipcount = 0;
@@ -56,7 +56,7 @@ public abstract class DapDump {
    *
    * @param buf0 byte buffer to dump
    */
-  static public void dumpbytesbuf(ByteBuffer buf0) {
+  public static void dumpbytesbuf(ByteBuffer buf0) {
     int stop = buf0.limit();
     int size = stop + 8;
     int savepos = buf0.position();
@@ -109,22 +109,22 @@ public abstract class DapDump {
     }
   }
 
-  static public void dumpbytesstream(OutputStream stream, ByteOrder order, String tag) {
+  public static void dumpbytesstream(OutputStream stream, ByteOrder order, String tag) {
     if (stream instanceof ByteArrayOutputStream) {
       byte[] content = ((ByteArrayOutputStream) stream).toByteArray();
       dumpbytesraw(content, order, tag);
     }
   }
 
-  static public void dumpbytesrawbuf(ByteBuffer buf, ByteOrder order, String tag) {
+  public static void dumpbytesrawbuf(ByteBuffer buf, ByteOrder order, String tag) {
     dumpbytesraw(buf.array(), 0, buf.limit(), order, tag);
   }
 
-  static public void dumpbytesraw(byte[] content, ByteOrder order, String tag) {
+  public static void dumpbytesraw(byte[] content, ByteOrder order, String tag) {
     dumpbytesraw(content, 0, content.length, order, tag);
   }
 
-  static public void dumpbytesraw(byte[] content, int start, int len, ByteOrder order, String tag) {
+  public static void dumpbytesraw(byte[] content, int start, int len, ByteOrder order, String tag) {
     System.err.println("++++++++++ " + tag + " ++++++++++ ");
     ByteBuffer tmp = ByteBuffer.wrap(content).order(order);
     tmp.position(start);

--- a/dap4/src/main/java/dap4/core/util/DapUtil.java
+++ b/dap4/src/main/java/dap4/core/util/DapUtil.java
@@ -28,24 +28,24 @@ public abstract class DapUtil // Should only contain static methods
   //////////////////////////////////////////////////
   // Constants
 
-  static public final BigInteger BIG_UMASK64 = new BigInteger("FFFFFFFFFFFFFFFF", 16);
-  static public final Charset UTF8 = Charset.forName("UTF-8");
+  public static final BigInteger BIG_UMASK64 = new BigInteger("FFFFFFFFFFFFFFFF", 16);
+  public static final Charset UTF8 = Charset.forName("UTF-8");
 
   // Define the Serialization Constants common to servlet and client
 
-  static public final ByteOrder NETWORK_ORDER = ByteOrder.BIG_ENDIAN;
-  static public final ByteOrder NATIVE_ORDER = ByteOrder.nativeOrder();
+  public static final ByteOrder NETWORK_ORDER = ByteOrder.BIG_ENDIAN;
+  public static final ByteOrder NATIVE_ORDER = ByteOrder.nativeOrder();
 
-  static public final String LF = "\n";
-  static public final String CRLF = "\r\n";
-  static public final int CRLFSIZE = 2;
+  public static final String LF = "\n";
+  public static final String CRLF = "\r\n";
+  public static final int CRLFSIZE = 2;
 
-  static public Pattern DAP4EXT_RE = Pattern.compile("^.*(.dmr|.dap|.dsr|.xml|.html)$");
+  public static Pattern DAP4EXT_RE = Pattern.compile("^.*(.dmr|.dap|.dsr|.xml|.html)$");
 
   //////////////////////////////////////////////////
   // return last name part of an fqn; result will be escaped.
 
-  static public String fqnSuffix(String fqn) {
+  public static String fqnSuffix(String fqn) {
     int structindex = fqn.lastIndexOf('.');
     int groupindex = fqn.lastIndexOf('/');
     if (structindex >= 0)
@@ -55,7 +55,7 @@ public abstract class DapUtil // Should only contain static methods
   }
 
   // return prefix name part of an fqn; result will be escaped.
-  static public String fqnPrefix(String fqn) {
+  public static String fqnPrefix(String fqn) {
     int structindex = fqn.lastIndexOf('.');
     int groupindex = fqn.lastIndexOf('/');
     if (structindex >= 0)
@@ -73,7 +73,7 @@ public abstract class DapUtil // Should only contain static methods
    * @return a List of strings (all with escaping still intact)
    *         representing s split at unescaped instances of sep.
    */
-  static public List<String> backslashSplit(String s, char sep) {
+  public static List<String> backslashSplit(String s, char sep) {
     List<String> path = new ArrayList<String>();
     int len = s.length();
     StringBuilder piece = new StringBuilder();
@@ -93,7 +93,7 @@ public abstract class DapUtil // Should only contain static methods
     return path;
   }
 
-  static public Integer stringToInteger(String s) {
+  public static Integer stringToInteger(String s) {
     try {
       return Integer.parseInt(s);
     } catch (NumberFormatException e) {
@@ -101,7 +101,7 @@ public abstract class DapUtil // Should only contain static methods
     }
   }
 
-  static public boolean hasSequence(DapNode node) {
+  public static boolean hasSequence(DapNode node) {
     switch (node.getSort()) {
       case SEQUENCE:
         return true;
@@ -138,7 +138,7 @@ public abstract class DapUtil // Should only contain static methods
    *        false if we are looking for a file
    * @return absolute path of the file or null
    */
-  static public String locateFile(String filename, String abspath, boolean wantdir) {
+  public static String locateFile(String filename, String abspath, boolean wantdir) {
     Deque<String> q = new ArrayDeque<String>();
     // clean up the path and filename
     filename = filename.trim().replace('\\', '/');
@@ -185,7 +185,7 @@ public abstract class DapUtil // Should only contain static methods
    *        false if we are looking for a file
    * @return absolute path of the file|dir wrt to abspath
    */
-  static public String locateRelative(String relpath, String abspath, boolean wantdir) {
+  public static String locateRelative(String relpath, String abspath, boolean wantdir) {
     // clean up the path and filename
     relpath = relpath.trim().replace('\\', '/');
     if (relpath.charAt(0) == '/')
@@ -215,7 +215,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param path convert this path
    * @return canonicalized version
    */
-  static public String canonicalpath(String path) {
+  public static String canonicalpath(String path) {
     if (path == null)
       return null;
     path = path.trim();
@@ -233,7 +233,7 @@ public abstract class DapUtil // Should only contain static methods
     return path;
   }
 
-  static public String relativize(String path) {
+  public static String relativize(String path) {
     if (path == null)
       return path;
     path = path.replace('\\', '/');
@@ -246,13 +246,13 @@ public abstract class DapUtil // Should only contain static methods
     return path;
   }
 
-  static public String absolutize(String path) {
+  public static String absolutize(String path) {
     if (path != null && !path.startsWith("/") && !hasDriveLetter(path))
       path = "/" + path;
     return path;
   }
 
-  static public boolean checkFixedSize(DapVariable var) {
+  public static boolean checkFixedSize(DapVariable var) {
     DapType dt = var.getBaseType();
     switch (dt.getTypeSort()) {
       case Structure:
@@ -276,7 +276,7 @@ public abstract class DapUtil // Should only contain static methods
    *        as defined by the buffer limit.
    * @return The byte array contents of the buffer
    */
-  static public byte[] extract(ByteBuffer buf) {
+  public static byte[] extract(ByteBuffer buf) {
     int len = buf.limit();
     byte[] bytes = new byte[len];
     buf.rewind();
@@ -284,7 +284,7 @@ public abstract class DapUtil // Should only contain static methods
     return bytes;
   }
 
-  static public byte[] readbinaryfile(InputStream stream) throws IOException {
+  public static byte[] readbinaryfile(InputStream stream) throws IOException {
     // Extract the stream into a bytebuffer
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     byte[] tmp = new byte[1 << 16];
@@ -312,7 +312,7 @@ public abstract class DapUtil // Should only contain static methods
    * @return amount actually read
    * @throws IOException
    */
-  static public int readbinaryfilepartial(InputStream stream, byte[] buffer, int count) throws IOException {
+  public static int readbinaryfilepartial(InputStream stream, byte[] buffer, int count) throws IOException {
     try {
       // Extract the stream into a bytebuffer
       int offset = 0;
@@ -330,7 +330,7 @@ public abstract class DapUtil // Should only contain static methods
     }
   }
 
-  static public String readtextfile(InputStream stream) throws IOException {
+  public static String readtextfile(InputStream stream) throws IOException {
     StringBuilder buf = new StringBuilder();
     InputStreamReader rdr = new InputStreamReader(stream, UTF8);
     for (;;) {
@@ -347,7 +347,7 @@ public abstract class DapUtil // Should only contain static methods
    * top-level variable to and including the given variable
    * such that all but the last element is a structure.
    */
-  static public List<DapVariable> getStructurePath(DapVariable var) {
+  public static List<DapVariable> getStructurePath(DapVariable var) {
     List<DapNode> path = var.getPath();
     List<DapVariable> structpath = new ArrayList<DapVariable>();
     for (int i = 0; i < path.size(); i++) {
@@ -372,7 +372,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param path
    * @return path or ""
    */
-  static public String denullify(String path) {
+  public static String denullify(String path) {
     return (path == null ? "" : path);
   }
 
@@ -382,7 +382,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param obj
    * @return obj or ""
    */
-  static public Object stringable(Object obj) {
+  public static Object stringable(Object obj) {
     return (obj == null ? "" : obj);
   }
 
@@ -392,11 +392,11 @@ public abstract class DapUtil // Should only contain static methods
    * @param path
    * @return path or null
    */
-  static public String nullify(String path) {
+  public static String nullify(String path) {
     return (path != null && path.length() == 0 ? null : path);
   }
 
-  static public long[] getDimSizes(List<DapDimension> dims) {
+  public static long[] getDimSizes(List<DapDimension> dims) {
     long[] sizes = new long[dims.size()];
     for (int i = 0; i < dims.size(); i++) {
       sizes[i] = dims.get(i).getSize();
@@ -404,7 +404,7 @@ public abstract class DapUtil // Should only contain static methods
     return sizes;
   }
 
-  static public long dimProduct(List<DapDimension> dimset) // dimension crossproduct
+  public static long dimProduct(List<DapDimension> dimset) // dimension crossproduct
   {
     long count = 1;
     for (DapDimension dim : dimset) {
@@ -446,7 +446,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param dimset the list of DapDimension
    * @return true if slices is whole wrt dimset; false otherwise
    */
-  static public boolean isWhole(List<Slice> slices, List<DapDimension> dimset) {
+  public static boolean isWhole(List<Slice> slices, List<DapDimension> dimset) {
     if (slices.size() != dimset.size())
       return false;
     for (int i = 0; i < slices.size(); i++) {
@@ -458,7 +458,7 @@ public abstract class DapUtil // Should only contain static methods
     return true;
   }
 
-  static public long sliceProduct(List<Slice> slices) // another crossproduct
+  public static long sliceProduct(List<Slice> slices) // another crossproduct
   {
     long count = 1;
     if (slices != null)
@@ -468,7 +468,7 @@ public abstract class DapUtil // Should only contain static methods
     return count;
   }
 
-  static public boolean hasStrideOne(List<Slice> slices) {
+  public static boolean hasStrideOne(List<Slice> slices) {
     for (Slice slice : slices) {
       if (slice.getStride() != 1)
         return false;
@@ -487,7 +487,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param upto end point for join (exclusive)
    * @return the join
    */
-  static public String join(String[] array, String sep, int from, int upto) {
+  public static String join(String[] array, String sep, int from, int upto) {
     if (sep == null)
       sep = "";
     if (from < 0 || upto > array.length)
@@ -510,7 +510,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param path
    * @return Relativized path
    */
-  static public String xrelpath(String path) {
+  public static String xrelpath(String path) {
     return DapUtil.canonicalpath(path);
   }
 
@@ -521,7 +521,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param path
    * @return true, if path has drive letter
    */
-  static public boolean hasDriveLetter(String path) {
+  public static boolean hasDriveLetter(String path) {
     return XURI.hasDriveLetter(path);
   }
 
@@ -532,7 +532,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param path
    * @return repaired path
    */
-  static public String repairPath(String path) {
+  public static String repairPath(String path) {
     return XURI.hideDriveLetter(path);
   }
 
@@ -543,7 +543,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param breakpoint return the index past last protocol
    * @return list of leading protocols without the trailing :
    */
-  static public List<String> getProtocols(String url, int[] breakpoint) {
+  public static List<String> getProtocols(String url, int[] breakpoint) {
     // break off any leading protocols;
     // there may be more than one.
     // Watch out for Windows paths starting with a drive letter.
@@ -573,7 +573,7 @@ public abstract class DapUtil // Should only contain static methods
     return allprotocols;
   }
 
-  static public String merge(String[] pieces, String sep) {
+  public static String merge(String[] pieces, String sep) {
     if (pieces == null)
       return "";
     StringBuilder buf = new StringBuilder();
@@ -606,12 +606,12 @@ public abstract class DapUtil // Should only contain static methods
   /**
    * Re-throw run-time exceptions
    */
-  static public void checkruntime(Exception e) {
+  public static void checkruntime(Exception e) {
     if (e instanceof RuntimeException)
       throw (RuntimeException) e;
   }
 
-  static public String canonjoin(String prefix, String suffix) {
+  public static String canonjoin(String prefix, String suffix) {
     StringBuilder result = new StringBuilder();
     if (prefix == null)
       prefix = "";
@@ -632,7 +632,7 @@ public abstract class DapUtil // Should only contain static methods
     return result.toString();
   }
 
-  static public boolean hasWindowsDrive(final String path) {
+  public static boolean hasWindowsDrive(final String path) {
     if (path != null && path.length() >= 2 && path.charAt(1) == ':') {
       final char c = path.charAt(0);
       return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
@@ -640,17 +640,17 @@ public abstract class DapUtil // Should only contain static methods
     return false;
   }
 
-  static public boolean isAbsolutePath(final String path) {
+  public static boolean isAbsolutePath(final String path) {
     return path != null && (hasWindowsDrive(path) || path.charAt(0) == '/' || path.charAt(0) == '\\');
   }
 
-  static public String canonFileURL(String url) {
+  public static String canonFileURL(String url) {
     if (url == null || url.startsWith("file:"))
       return url;
     return "file:" + absolutize(url);
   }
 
-  static public String stripDap4Extensions(String path) {
+  public static String stripDap4Extensions(String path) {
     for (;;) {
       Matcher m = DAP4EXT_RE.matcher(path);
       if (!m.matches())
@@ -676,7 +676,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param slices
    * @return true, if contiguous
    */
-  static public boolean isContiguous(List<Slice> slices) {
+  public static boolean isContiguous(List<Slice> slices) {
     for (Slice sl : slices) {
       if (sl.getStride() != 1)
         return false;
@@ -690,7 +690,7 @@ public abstract class DapUtil // Should only contain static methods
    * @param slices
    * @return true, if single position
    */
-  static public boolean isSinglePoint(List<Slice> slices) {
+  public static boolean isSinglePoint(List<Slice> slices) {
     for (Slice sl : slices) {
       if (sl.getCount() != 1)
         return false;
@@ -699,7 +699,7 @@ public abstract class DapUtil // Should only contain static methods
   }
 
 
-  static public List<Slice> dimsetToSlices(List<DapDimension> dimset) throws dap4.core.util.DapException {
+  public static List<Slice> dimsetToSlices(List<DapDimension> dimset) throws dap4.core.util.DapException {
     if (dimset == null || dimset.size() == 0)
       return Slice.SCALARSLICES;
     List<Slice> slices = new ArrayList<Slice>(dimset.size());
@@ -711,21 +711,21 @@ public abstract class DapUtil // Should only contain static methods
     return slices;
   }
 
-  static public boolean isScalarSlices(List<Slice> slices) {
+  public static boolean isScalarSlices(List<Slice> slices) {
     if (slices == null || slices.size() != 1)
       return false;
     Slice s = slices.get(0);
     return (s.getFirst() == 0 && s.getStop() == 1);
   }
 
-  static public long[] longvector(int[] iv) {
+  public static long[] longvector(int[] iv) {
     long[] lv = new long[iv.length];
     for (int i = 0; i < iv.length; i++)
       lv[i] = (long) iv[i];
     return lv;
   }
 
-  static public int[] intvector(long[] lv) {
+  public static int[] intvector(long[] lv) {
     int[] iv = new int[lv.length];
     for (int i = 0; i < lv.length; i++)
       iv[i] = (int) lv[i];

--- a/dap4/src/main/java/dap4/core/util/Slice.java
+++ b/dap4/src/main/java/dap4/core/util/Slice.java
@@ -35,19 +35,19 @@ public class Slice {
   // its "last" value is the UNDEFINED value).
   // This will primarily be used in the constraint expression parser
 
-  static public final int UNDEFINED = -1;
+  public static final int UNDEFINED = -1;
 
   // Define maximum legal dimension based on the spec
 
-  static public final int MAXLENGTH = 0x3FFFFFFF;
+  public static final int MAXLENGTH = 0x3FFFFFFF;
 
-  static public enum Sort {
+  public static enum Sort {
     Single, Multi;
   }
 
   // Define a set of slices indicating the canonical scalar set
-  static public List<Slice> SCALARSLICES;
-  static public Slice SCALARSLICE;
+  public static List<Slice> SCALARSLICES;
+  public static Slice SCALARSLICE;
 
   static {
     try {
@@ -336,7 +336,7 @@ public class Slice {
    * @return new, composed Range
    * @throws DapException
    */
-  static public Slice compose(Slice target, Slice src) throws DapException {
+  public static Slice compose(Slice target, Slice src) throws DapException {
     int sr_stride = target.getStride() * src.getStride();
     int sr_first = MAP(target, src.getFirst());
     int lastx = MAP(target, src.getLast());

--- a/dap4/src/main/java/dap4/core/util/XURI.java
+++ b/dap4/src/main/java/dap4/core/util/XURI.java
@@ -30,8 +30,8 @@ public class XURI {
   static final char PAIRSEP = '=';
 
   // static final String DRIVELETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-  static protected final Pattern drivelettertest = Pattern.compile("^([/]?)[a-zA-Z][:]");
-  static protected final Pattern filedrivelettertest = Pattern.compile("^(file://)([a-zA-Z][:].*)");
+  protected static final Pattern drivelettertest = Pattern.compile("^([/]?)[a-zA-Z][:]");
+  protected static final Pattern filedrivelettertest = Pattern.compile("^(file://)([a-zA-Z][:].*)");
 
   // Define assembly flags
 
@@ -487,7 +487,7 @@ public class XURI {
    *
    * @param s part of the url
    */
-  static public String canonical(String s) {
+  public static String canonical(String s) {
     if (s != null) {
       s = s.trim();
       if (s.length() == 0)
@@ -503,7 +503,7 @@ public class XURI {
    * @param path
    * @return true, if path has drive letter
    */
-  static public boolean hasDriveLetter(String path) {
+  public static boolean hasDriveLetter(String path) {
     Matcher m = drivelettertest.matcher(path);
     return m.lookingAt();
   }
@@ -514,7 +514,7 @@ public class XURI {
    *
    * @return repaired path
    */
-  static public String hideDriveLetter(String path) {
+  public static String hideDriveLetter(String path) {
     Matcher m = drivelettertest.matcher(path);
     if (m.lookingAt()) {
       if (m.group(1).equals(""))
@@ -529,7 +529,7 @@ public class XURI {
    * @parem xu url string
    * @return vector of schemes
    */
-  static public String[] allSchemes(String xu) {
+  public static String[] allSchemes(String xu) {
     int endschemes = xu.indexOf("//");
     if (endschemes < 0)
       return new String[0];
@@ -544,7 +544,7 @@ public class XURI {
    * @param path
    * @return repaired path
    */
-  static public String truePath(String path) {
+  public static String truePath(String path) {
     // Check for a windows drive and repair
     Matcher m = drivelettertest.matcher(path);
     if (m.lookingAt() && m.group(1) != null)

--- a/dap4/src/main/java/dap4/dap4lib/D4Index.java
+++ b/dap4/src/main/java/dap4/dap4lib/D4Index.java
@@ -24,7 +24,7 @@ public class D4Index extends ucar.ma2.Index {
    * compute the set of dimension indices that correspond
    * to the offset.
    */
-  static public Index offsetToIndex(int offset, int[] shape) {
+  public static Index offsetToIndex(int offset, int[] shape) {
     // offset = d3*(d2*(d1*(x1))+x2)+x3
     int[] indices = new int[shape.length];
     for (int i = shape.length - 1; i >= 0; i--) {
@@ -41,7 +41,7 @@ public class D4Index extends ucar.ma2.Index {
    * @return list of corresponding slices
    */
 
-  static public List<Slice> indexToSlices(ucar.ma2.Index indices) throws DapException {
+  public static List<Slice> indexToSlices(ucar.ma2.Index indices) throws DapException {
     // short circuit the scalar case
     int rank = indices.getRank();
     if (rank == 0)
@@ -64,7 +64,7 @@ public class D4Index extends ucar.ma2.Index {
    * @return Index corresponding to slices
    * @throws DapException
    */
-  static public D4Index slicesToIndex(List<Slice> slices) throws DapException {
+  public static D4Index slicesToIndex(List<Slice> slices) throws DapException {
     int[] positions = new int[slices.size()];
     int[] dimsizes = new int[slices.size()];
     for (int i = 0; i < positions.length; i++) {

--- a/dap4/src/main/java/dap4/dap4lib/DapProtocol.java
+++ b/dap4/src/main/java/dap4/dap4lib/DapProtocol.java
@@ -31,9 +31,9 @@ public abstract class DapProtocol implements DapCodes {
   //////////////////////////////////////////////////
   // Static variables
 
-  static protected final Set<String> DAP4EXTENSIONS;
-  static protected final Set<String> DAP4QUERYMARKERS;
-  static protected final Set<String> DAP4SCHEMES;
+  protected static final Set<String> DAP4EXTENSIONS;
+  protected static final Set<String> DAP4QUERYMARKERS;
+  protected static final Set<String> DAP4SCHEMES;
 
   static {
     DAP4EXTENSIONS = new HashSet<String>();
@@ -56,7 +56,7 @@ public abstract class DapProtocol implements DapCodes {
   // Map RequestMode X ResponseFormat => ContentType
   public static Map<String, ContentType> contenttypes;
 
-  static public String contentKey(RequestMode mode, ResponseFormat format) {
+  public static String contentKey(RequestMode mode, ResponseFormat format) {
     return mode.id() + "." + format.id();
   }
 
@@ -120,7 +120,7 @@ public abstract class DapProtocol implements DapCodes {
    * @param xuri parsed uri
    * @return true if this uri appears to be processible by DAP4
    */
-  static public boolean isDap4URI(XURI xuri) {
+  public static boolean isDap4URI(XURI xuri) {
     boolean found = false;
     // This is definitive
     if ("dap4".equalsIgnoreCase(xuri.getScheme()))
@@ -152,7 +152,7 @@ public abstract class DapProtocol implements DapCodes {
     return false;
   }
 
-  static public boolean isDap4URI(String uri) {
+  public static boolean isDap4URI(String uri) {
     try {
       XURI xuri = new XURI(uri);
       return isDap4URI(xuri);

--- a/dap4/src/main/java/dap4/dap4lib/DeChunkedInputStream.java
+++ b/dap4/src/main/java/dap4/dap4lib/DeChunkedInputStream.java
@@ -40,7 +40,7 @@ public class DeChunkedInputStream extends InputStream {
   //////////////////////////////////////////////////
   // Types
 
-  static protected class Chunk { // Could we use ByteBuffer?
+  protected static class Chunk { // Could we use ByteBuffer?
     public byte[] chunk;
     public int size; // note that chunk.length > size is possible
     public int avail;
@@ -56,7 +56,7 @@ public class DeChunkedInputStream extends InputStream {
     }
   }
 
-  static public enum State {
+  public static enum State {
     INITIAL, MORE, END, ERROR;
   }
 

--- a/dap4/src/main/java/dap4/dap4lib/HttpDSP.java
+++ b/dap4/src/main/java/dap4/dap4lib/HttpDSP.java
@@ -39,7 +39,7 @@ public class HttpDSP extends D4DSP {
   //////////////////////////////////////////////////
   // Static methods
 
-  static public void setHttpDebug() {
+  public static void setHttpDebug() {
     HTTPIntercepts.setGlobalDebugInterceptors(true);
   }
 

--- a/dap4/src/main/java/dap4/dap4lib/cdm/CDMTypeFcns.java
+++ b/dap4/src/main/java/dap4/dap4lib/cdm/CDMTypeFcns.java
@@ -43,7 +43,7 @@ public abstract class CDMTypeFcns {
   // Static Methods
 
   /* Needed to implement Array.getElement() */
-  static public Class cdmElementClass(DataType dt) {
+  public static Class cdmElementClass(DataType dt) {
     switch (dt) {
       case BOOLEAN:
         return Boolean.class;
@@ -82,7 +82,7 @@ public abstract class CDMTypeFcns {
     return null;
   }
 
-  static public Object createVector(DataType type, long count) {
+  public static Object createVector(DataType type, long count) {
     int icount = (int) count;
     Object vector = null;
     switch (type) {
@@ -129,17 +129,17 @@ public abstract class CDMTypeFcns {
     return vector;
   }
 
-  static public boolean signify(DapType type) {
+  public static boolean signify(DapType type) {
     return daptype2cdmtype(type).isUnsigned();
   }
 
-  static public Object createVector(DapType type, long count) {
+  public static Object createVector(DapType type, long count) {
     if (type.getAtomicType() == TypeSort.Enum)
       return createVector(((DapEnumeration) type).getBaseType(), count);
     return CoreTypeFcns.createVector(type.getTypeSort(), count);
   }
 
-  static public DataType enumTypeFor(DapType type) {
+  public static DataType enumTypeFor(DapType type) {
     switch (type.getTypeSort()) {
       case Char:
       case Int8:
@@ -164,7 +164,7 @@ public abstract class CDMTypeFcns {
     return null;
   }
 
-  static public DapType cdmtype2daptype(DataType datatype) {
+  public static DapType cdmtype2daptype(DataType datatype) {
     switch (datatype) {
       case CHAR:
         return DapType.CHAR;
@@ -210,7 +210,7 @@ public abstract class CDMTypeFcns {
     return null;
   }
 
-  static public DataType daptype2cdmtype(DapType type) {
+  public static DataType daptype2cdmtype(DapType type) {
     assert (type != null);
     switch (type.getTypeSort()) {
       case Char:
@@ -280,7 +280,7 @@ public abstract class CDMTypeFcns {
    * @param atomtype The type of interest
    * @return the size, in databuffer
    */
-  static public int daptypeSize(TypeSort atomtype) {
+  public static int daptypeSize(TypeSort atomtype) {
     switch (atomtype) {
       case Char: // remember serial size is 1, not 2.
       case UInt8:
@@ -303,7 +303,7 @@ public abstract class CDMTypeFcns {
     return 0;
   }
 
-  static public long extract(TypeSort sort, Object value) {
+  public static long extract(TypeSort sort, Object value) {
     long lvalue = 0;
     switch (sort) {
       case Int8:
@@ -344,7 +344,7 @@ public abstract class CDMTypeFcns {
     return lvalue;
   }
 
-  static public Object convert(TypeSort dstsort, TypeSort srcsort, Object src) {
+  public static Object convert(TypeSort dstsort, TypeSort srcsort, Object src) {
     Object result = null;
     long lval;
     boolean ok = true;
@@ -1127,7 +1127,7 @@ public abstract class CDMTypeFcns {
   }
 
 
-  static public void vectorcopy(DapType datatype, Object src, Object dst, long srcoffset, long dstoffset)
+  public static void vectorcopy(DapType datatype, Object src, Object dst, long srcoffset, long dstoffset)
       throws DapException {
     switch (datatype.getTypeSort()) {
       case UInt8:
@@ -1185,7 +1185,7 @@ public abstract class CDMTypeFcns {
    * @param o
    * @return parsed attribute
    */
-  static public Object attributeParse(DataType cdmtype, EnumTypedef en, Object o) {
+  public static Object attributeParse(DataType cdmtype, EnumTypedef en, Object o) {
     String so = o.toString();
     if (en != null) {
       switch (cdmtype) {
@@ -1293,7 +1293,7 @@ public abstract class CDMTypeFcns {
     return o;
   }
 
-  static public boolean isPrimitiveVector(DataType type, Object o) {
+  public static boolean isPrimitiveVector(DataType type, Object o) {
     Class c = o.getClass();
     if (!c.isArray())
       return false;
@@ -1332,7 +1332,7 @@ public abstract class CDMTypeFcns {
     return false;
   }
 
-  static public Array arrayify(DataType datatype, Object o) {
+  public static Array arrayify(DataType datatype, Object o) {
     // 1. o is a constant
     if (!o.getClass().isArray()) {
       Object ovec = createVector(datatype, 1);
@@ -1343,13 +1343,13 @@ public abstract class CDMTypeFcns {
     return Array.factory(datatype, shape, o);
   }
 
-  static public Array arrayify(DapType type, Object o) {
+  public static Array arrayify(DapType type, Object o) {
     if (type.getAtomicType() == TypeSort.Enum)
       return arrayify(((DapEnumeration) type).getBaseType(), o);
     return arrayify(CDMTypeFcns.daptype2cdmtype(type), o);
   }
 
-  static public List listify(Object vector) {
+  public static List listify(Object vector) {
     List list = new ArrayList();
     int icount = java.lang.reflect.Array.getLength(vector);
     for (int i = 0; i < icount; i++) {
@@ -1358,7 +1358,7 @@ public abstract class CDMTypeFcns {
     return list;
   }
 
-  static public Object bytesAsTypeVec(DapType daptype, byte[] bytes) {
+  public static Object bytesAsTypeVec(DapType daptype, byte[] bytes) {
     TypeSort tsort = daptype.getTypeSort();
     int count = (bytes.length / daptype.getSize());
     switch (tsort) {
@@ -1389,7 +1389,7 @@ public abstract class CDMTypeFcns {
     return null;
   }
 
-  static public void decodebytes(ByteOrder remoteorder, DapType daptype, byte[] bytes, Object vector) {
+  public static void decodebytes(ByteOrder remoteorder, DapType daptype, byte[] bytes, Object vector) {
     TypeSort tsort = daptype.getTypeSort();
     ByteBuffer bb = ByteBuffer.wrap(bytes).order(remoteorder);
     switch (tsort) {

--- a/dap4/src/main/java/dap4/dap4lib/cdm/CDMUtil.java
+++ b/dap4/src/main/java/dap4/dap4lib/cdm/CDMUtil.java
@@ -303,7 +303,7 @@ public abstract class CDMUtil {
    * @return list of corresponding slices
    */
 
-  static public List<Slice> indexToSlices(Index indices) throws DapException {
+  public static List<Slice> indexToSlices(Index indices) throws DapException {
     // short circuit the scalar case
     int rank = indices.getRank();
     if (rank == 0)
@@ -326,7 +326,7 @@ public abstract class CDMUtil {
    * @return Index corresponding to slices
    * @throws DapException
    */
-  static public Index slicesToIndex(List<Slice> slices) throws DapException {
+  public static Index slicesToIndex(List<Slice> slices) throws DapException {
     int[] positions = new int[slices.size()];
     int[] dimsizes = new int[slices.size()];
     for (int i = 0; i < positions.length; i++) {

--- a/dap4/src/main/java/dap4/dap4lib/cdm/nc2/DataToCDM.java
+++ b/dap4/src/main/java/dap4/dap4lib/cdm/nc2/DataToCDM.java
@@ -57,7 +57,7 @@ abstract public class DataToCDM {
   //////////////////////////////////////////////////
   // Correlate CDM Variables with ucar.ma2.Array objects
 
-  static public Map<Variable, Array> createDataMap(D4DSP dsp, NodeMap nodemap) throws DapException {
+  public static Map<Variable, Array> createDataMap(D4DSP dsp, NodeMap nodemap) throws DapException {
     Map<DapVariable, D4Array> datamap = dsp.getVariableDataMap();
     DapDataset dmr = dsp.getDMR();
     Map<Variable, Array> arraymap = new HashMap<>();

--- a/dap4/src/test/java/dap4/test/Dap4ManifestIF.java
+++ b/dap4/src/test/java/dap4/test/Dap4ManifestIF.java
@@ -14,7 +14,7 @@ package dap4.test;
 public interface Dap4ManifestIF {
 
   // List of all file names
-  static public final String[][] dap4_manifest = {{"test_one_var"}, {"test_atomic_array"}, {"test_atomic_types"},
+  public static final String[][] dap4_manifest = {{"test_one_var"}, {"test_atomic_array"}, {"test_atomic_types"},
       {"test_enum_1"}, {"test_enum_2"}, {"test_enum_3"}, {"test_enum_array"}, {"test_fill"}, {"test_fill_2"},
       {"test_groups1"}, {"test_misc1"}, {"test_one_vararray"}, {"test_opaque"}, {"test_opaque_array"}, {"test_struct1"},
       {"test_struct_array"}, {"test_struct_nested"}, {"test_struct_nested3"}, {"test_struct_type"}, {"test_test"},
@@ -22,7 +22,7 @@ public interface Dap4ManifestIF {
       {"test_vlen4"}, {"test_vlen5"}, {"test_vlen6"}, {"test_vlen7"}, {"test_vlen8"}, {"test_zerodim"}}; // dap4manifest
 
   // Define the Manifest of constrained tests
-  static public final String[][] constraint_manifest =
+  public static final String[][] constraint_manifest =
       {{"test_atomic_array", "1", "/vu8[1][0:2:2];/vd[1];/vs[1][0];/vo[0][1]"},
           {"test_atomic_array", "2", "/v16[0:1,3]"}, {"test_atomic_array", "3", "/v16[3,0:1]"},
           {"test_one_vararray", "4", "/t[1]"}, {"test_one_vararray", "5", "/t[0:1]"},

--- a/dap4/src/test/java/dap4/test/Dap4Server.java
+++ b/dap4/src/test/java/dap4/test/Dap4Server.java
@@ -97,7 +97,7 @@ public class Dap4Server {
     return ok;
   }
 
-  static public Dap4Server findServer() throws DapException {
+  public static Dap4Server findServer() throws DapException {
     // Find the server to use
     for (Dap4Server svc : registry) {
       if (svc.ping())

--- a/dap4/src/test/java/dap4/test/DapTestCommon.java
+++ b/dap4/src/test/java/dap4/test/DapTestCommon.java
@@ -30,18 +30,18 @@ abstract public class DapTestCommon extends UnitTestCommon {
 
   static final String DEFAULTTREEROOT = "dap4";
 
-  static public final String FILESERVER = "file://localhost:8080";
+  public static final String FILESERVER = "file://localhost:8080";
 
-  static public final String ORDERTAG = "ucar.littleendian";
-  static public final String TRANSLATETAG = "ucar.translate";
-  static public final String TESTTAG = "ucar.testing";
+  public static final String ORDERTAG = "ucar.littleendian";
+  public static final String TRANSLATETAG = "ucar.translate";
+  public static final String TESTTAG = "ucar.testing";
 
   static final String D4TESTDIRNAME = "";
 
   // Equivalent to the path to the webapp/d4ts for testing purposes
-  static protected final String DFALTRESOURCEPATH = "/src/test/data/resources";
+  protected static final String DFALTRESOURCEPATH = "/src/test/data/resources";
 
-  static protected final String[] LEGALEXTENSIONS = {".dap", ".dmr", ".nc", "dmp", ".ncdump", ".dds", ".das", ".dods"};
+  protected static final String[] LEGALEXTENSIONS = {".dap", ".dmr", ".nc", "dmp", ".ncdump", ".dds", ".das", ".dods"};
 
   //////////////////////////////////////////////////
 
@@ -105,7 +105,7 @@ abstract public class DapTestCommon extends UnitTestCommon {
     }
   }
 
-  static public class TestCaseCommon {
+  public static class TestCaseCommon {
     public String name;
 
     public TestCaseCommon() {
@@ -120,11 +120,11 @@ abstract public class DapTestCommon extends UnitTestCommon {
   //////////////////////////////////////////////////
   // Static variables
 
-  static protected String dap4root = null;
-  static protected String dap4testroot = null;
-  static protected String dap4resourcedir = null;
+  protected static String dap4root = null;
+  protected static String dap4testroot = null;
+  protected static String dap4resourcedir = null;
 
-  static protected TestProperties props = null;
+  protected static TestProperties props = null;
 
   static {
     dap4root = locateDAP4Root(threddsroot);
@@ -138,11 +138,11 @@ abstract public class DapTestCommon extends UnitTestCommon {
   //////////////////////////////////////////////////
   // Static methods
 
-  static protected String getD4TestsRoot() {
+  protected static String getD4TestsRoot() {
     return dap4testroot;
   }
 
-  static protected String getResourceRoot() {
+  protected static String getResourceRoot() {
     return dap4resourcedir;
   }
 
@@ -266,7 +266,7 @@ abstract public class DapTestCommon extends UnitTestCommon {
    * @param exclusions The array of excluded names
    * @return manifest with excluded names removed
    */
-  static public String[][] excludeNames(String[][] manifest, String[] exclusions) {
+  public static String[][] excludeNames(String[][] manifest, String[] exclusions) {
     List<String[]> xlist = new ArrayList<>(manifest.length);
     for (int i = 0; i < manifest.length; i++) {
       String name = manifest[i][0]; // Assume tuple element 0 is always the name
@@ -283,7 +283,7 @@ abstract public class DapTestCommon extends UnitTestCommon {
 
   // Filter a document with respect to a set of regular expressions
   // Used to remove e.g. unwanted attributes
-  static public boolean regexpFilter(StringBuilder document, String regexp, boolean repeat) {
+  public static boolean regexpFilter(StringBuilder document, String regexp, boolean repeat) {
     boolean changed = false;
     String doc = document.toString();
     Pattern p = Pattern.compile(regexp, Pattern.DOTALL);
@@ -298,7 +298,7 @@ abstract public class DapTestCommon extends UnitTestCommon {
     return changed;
   }
 
-  static public boolean regexpFilters(StringBuilder sbdoc, String[] regexps, boolean repeat) {
+  public static boolean regexpFilters(StringBuilder sbdoc, String[] regexps, boolean repeat) {
     boolean changed = false;
     for (String re : regexps) {
       if (regexpFilter(sbdoc, re, repeat))
@@ -311,7 +311,7 @@ abstract public class DapTestCommon extends UnitTestCommon {
 
   // Filter a document with respect to a set of regular expressions
   // on a per-line basis
-  static public boolean regexpFilterLine(StringBuilder document, String regexp, boolean repeat) {
+  public static boolean regexpFilterLine(StringBuilder document, String regexp, boolean repeat) {
     boolean changed = false;
     Pattern p = Pattern.compile(regexp, Pattern.DOTALL);
     String[] lines = document.toString().split("\r?\n");

--- a/dap4/src/test/java/dap4/test/Dump.java
+++ b/dap4/src/test/java/dap4/test/Dump.java
@@ -21,7 +21,7 @@ public class Dump {
   //////////////////////////////////////////////////
   // Constants
 
-  static public boolean DUMPCSUM = false;
+  public static boolean DUMPCSUM = false;
 
   static final String LBRACE = "{";
   static final String RBRACE = "}";
@@ -32,7 +32,7 @@ public class Dump {
   // Type decls
 
   // Place to insert the command list
-  static public interface Commands {
+  public static interface Commands {
     public void run(Dump printer) throws IOException;
   }
 

--- a/dap4/src/test/java/dap4/test/TestConstraints.java
+++ b/dap4/src/test/java/dap4/test/TestConstraints.java
@@ -40,22 +40,22 @@ public class TestConstraints extends DapTestCommon implements Dap4ManifestIF {
   // Constants
 
   // Define the server to use
-  static protected final String SERVERNAME = "d4ts";
-  static protected final String SERVER = "remotetest.unidata.ucar.edu";
-  static protected final int SERVERPORT = -1;
-  static protected final String SERVERPATH = "d4ts/testfiles";
+  protected static final String SERVERNAME = "d4ts";
+  protected static final String SERVER = "remotetest.unidata.ucar.edu";
+  protected static final int SERVERPORT = -1;
+  protected static final String SERVERPATH = "d4ts/testfiles";
 
   // Define the input set location(s)
-  static protected final String INPUTEXT = ".nc"; // note that the .dap is deliberately left off
-  static protected final String INPUTQUERY = "?" + DapConstants.CHECKSUMTAG + "=false&";
-  static protected final String INPUTFRAG = "#dap4";
+  protected static final String INPUTEXT = ".nc"; // note that the .dap is deliberately left off
+  protected static final String INPUTQUERY = "?" + DapConstants.CHECKSUMTAG + "=false&";
+  protected static final String INPUTFRAG = "#dap4";
 
-  static protected final String BASELINEDIR = "/baselineconstraints";
-  static protected final String BASELINEEXT = ".nc.ncdump";
+  protected static final String BASELINEDIR = "/baselineconstraints";
+  protected static final String BASELINEEXT = ".nc.ncdump";
 
   // Following files cannot be tested because of flaws in sequence handling
   // by the CDM code in ucar.nc2.dataset.
-  static protected String[] EXCLUSIONS =
+  protected static String[] EXCLUSIONS =
       {"test_vlen2", "test_vlen3", "test_vlen4", "test_vlen5", "test_vlen6", "test_vlen7", "test_vlen8"};
 
   //////////////////////////////////////////////////
@@ -63,8 +63,8 @@ public class TestConstraints extends DapTestCommon implements Dap4ManifestIF {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String resourceroot;
-  static public Dap4Server server;
+  public static String resourceroot;
+  public static Dap4Server server;
 
   static {
     // This test uses remotetest
@@ -99,7 +99,7 @@ public class TestConstraints extends DapTestCommon implements Dap4ManifestIF {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCaseCommon> defineTestCases() {
+  public static List<TestCaseCommon> defineTestCases() {
     assert (server != null);
     List<TestCaseCommon> testcases = new ArrayList<>();
     String[][] manifest = excludeNames(constraint_manifest, EXCLUSIONS);

--- a/dap4/src/test/java/dap4/test/TestDap4Url.java
+++ b/dap4/src/test/java/dap4/test/TestDap4Url.java
@@ -44,7 +44,7 @@ public class TestDap4Url extends DapTestCommon implements Dap4ManifestIF {
   // Constants
 
   // Legal url formats
-  static protected String[] urls = {"https://remotetest.unidata.ucar.edu/d4ts/testfiles/test_one_var.nc#dap4",
+  protected static String[] urls = {"https://remotetest.unidata.ucar.edu/d4ts/testfiles/test_one_var.nc#dap4",
       "dap4://remotetest.unidata.ucar.edu/d4ts/testfiles/test_one_var.nc",
       "https://remotetest.unidata.ucar.edu/d4ts/testfiles/test_one_var.nc",
       // "https://remotetest.unidata.ucar.edu/thredds/dap4/testAll/H.1.1.nc",
@@ -55,7 +55,7 @@ public class TestDap4Url extends DapTestCommon implements Dap4ManifestIF {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String resourceroot;
+  public static String resourceroot;
 
   static {
     resourceroot = getResourceRoot();
@@ -82,7 +82,7 @@ public class TestDap4Url extends DapTestCommon implements Dap4ManifestIF {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCaseCommon> defineTestCases() {
+  public static List<TestCaseCommon> defineTestCases() {
     List<TestCaseCommon> testcases = new ArrayList<>();
     for (String u : urls) {
       TestCase tc = new TestCase(u);

--- a/dap4/src/test/java/dap4/test/TestHyrax.java
+++ b/dap4/src/test/java/dap4/test/TestHyrax.java
@@ -39,18 +39,18 @@ public class TestHyrax extends DapTestCommon implements Dap4ManifestIF {
   // Constants
 
   // Define the server to use
-  static protected final String SERVERNAME = "hyrax";
-  static protected final String SERVER = "test.opendap.org";
-  static protected final int SERVERPORT = -1;
-  static protected final String SERVERPATH = "opendap";
+  protected static final String SERVERNAME = "hyrax";
+  protected static final String SERVER = "test.opendap.org";
+  protected static final int SERVERPORT = -1;
+  protected static final String SERVERPATH = "opendap";
 
   // Define the input set location(s)
-  static protected final String INPUTEXT = "";
-  static protected final String INPUTQUERY = "?dap4.checksum=true";
-  static protected final String INPUTFRAG = "#dap4&hyrax";
+  protected static final String INPUTEXT = "";
+  protected static final String INPUTQUERY = "?dap4.checksum=true";
+  protected static final String INPUTFRAG = "#dap4&hyrax";
 
-  static protected final String BASELINEDIR = "/baselinehyrax";
-  static protected final String BASELINEEXT = ".ncdump";
+  protected static final String BASELINEDIR = "/baselinehyrax";
+  protected static final String BASELINEEXT = ".ncdump";
 
   static final String[][] hyrax_manifest = new String[][] {{"nc4_nc_classic_no_comp.nc", "nc4_test_files", null},
       {"nc4_nc_classic_comp.nc", "nc4_test_files", null}, {"nc4_unsigned_types.nc", "nc4_test_files", null},
@@ -66,8 +66,8 @@ public class TestHyrax extends DapTestCommon implements Dap4ManifestIF {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String resourceroot;
-  static public Dap4Server server;
+  public static String resourceroot;
+  public static Dap4Server server;
 
   static {
     server = new Dap4Server("hyrax", SERVER, SERVERPORT, SERVERPATH);
@@ -101,7 +101,7 @@ public class TestHyrax extends DapTestCommon implements Dap4ManifestIF {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCaseCommon> defineTestCases() {
+  public static List<TestCaseCommon> defineTestCases() {
     assert (server != null);
     List<TestCaseCommon> testcases = new ArrayList<>();
     String[][] manifest = excludeNames(hyrax_manifest, HYRAX_EXCLUSIONS);

--- a/dap4/src/test/java/dap4/test/TestParserCE.java
+++ b/dap4/src/test/java/dap4/test/TestParserCE.java
@@ -108,7 +108,7 @@ public class TestParserCE extends DapTestCommon implements Dap4ManifestIF {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCaseCommon> defineTestCases() {
+  public static List<TestCaseCommon> defineTestCases() {
     List<TestCaseCommon> testcases = new ArrayList<>();
     for (String[] triple : testinputs) {
       TestCase tc = new TestCase(triple[0], triple[1], triple[2]);

--- a/dap4/src/test/java/dap4/test/TestParserDMR.java
+++ b/dap4/src/test/java/dap4/test/TestParserDMR.java
@@ -45,20 +45,20 @@ public class TestParserDMR extends DapTestCommon implements Dap4ManifestIF {
   static final boolean PARSEDEBUG = false;
 
   // Define the input set location(s)
-  static protected final String INPUTDIR = "/rawtestfiles";
-  static protected final String INPUTEXT = ".nc.dmr";
+  protected static final String INPUTDIR = "/rawtestfiles";
+  protected static final String INPUTEXT = ".nc.dmr";
 
   // Define some common DMR filter regular expression
   static String RE_ENDIAN = "\n[ \t]*<Attribute[ \t]+name=[\"]_DAP4_Little_Endian[\"].*?</Attribute>[ \t]*";
   static String RE_NCPROPS = "\n[ \t]*<Attribute[ \t]+name=[\"]_NCProperties[\"].*?</Attribute>[ \t]*";
-  static protected final String RE_UNLIMITED = "[ \t]+_edu.ucar.isunlimited=\"1\"";
+  protected static final String RE_UNLIMITED = "[ \t]+_edu.ucar.isunlimited=\"1\"";
 
   //////////////////////////////////////////////////
   // Static Fields
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String resourceroot;
+  public static String resourceroot;
 
   static {
     resourceroot = getResourceRoot();
@@ -87,7 +87,7 @@ public class TestParserDMR extends DapTestCommon implements Dap4ManifestIF {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCaseCommon> defineTestCases() {
+  public static List<TestCaseCommon> defineTestCases() {
     List<TestCaseCommon> testcases = new ArrayList<>();
     for (String[] tuple : dap4_manifest) {
       String name = tuple[0];

--- a/dap4/src/test/java/dap4/test/TestRaw.java
+++ b/dap4/src/test/java/dap4/test/TestRaw.java
@@ -40,17 +40,17 @@ public class TestRaw extends DapTestCommon implements Dap4ManifestIF {
   // Constants
 
   // Define the input set location(s)
-  static protected final String INPUTDIR = "/rawtestfiles";
-  static protected final String INPUTEXT = ".nc.dap";
-  static protected final String INPUTQUERY = "?" + DapConstants.CHECKSUMTAG + "=false";
-  static protected final String INPUTFRAG = "";
-  static protected final String BASELINEDIR = "/baselineraw";
-  static protected final String BASELINEEXT = ".nc.ncdump";
+  protected static final String INPUTDIR = "/rawtestfiles";
+  protected static final String INPUTEXT = ".nc.dap";
+  protected static final String INPUTQUERY = "?" + DapConstants.CHECKSUMTAG + "=false";
+  protected static final String INPUTFRAG = "";
+  protected static final String BASELINEDIR = "/baselineraw";
+  protected static final String BASELINEEXT = ".nc.ncdump";
 
 
   // Following files cannot be tested because of flaws in sequence handling
   // by the CDM code in ucar.nc2.dataset.
-  static protected String[] EXCLUSIONS =
+  protected static String[] EXCLUSIONS =
       {"test_vlen2", "test_vlen3", "test_vlen4", "test_vlen5", "test_vlen6", "test_vlen7", "test_vlen8"};
 
   // Attribute suppression
@@ -64,7 +64,7 @@ public class TestRaw extends DapTestCommon implements Dap4ManifestIF {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String resourceroot;
+  public static String resourceroot;
 
   static {
     resourceroot = getResourceRoot();
@@ -94,7 +94,7 @@ public class TestRaw extends DapTestCommon implements Dap4ManifestIF {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCaseCommon> defineTestCases() {
+  public static List<TestCaseCommon> defineTestCases() {
     List<TestCaseCommon> testcases = new ArrayList<>();
     String[][] manifest = excludeNames(dap4_manifest, EXCLUSIONS);
     for (String[] tuple : manifest) {
@@ -188,7 +188,7 @@ public class TestRaw extends DapTestCommon implements Dap4ManifestIF {
   //////////////////////////////////////////////////
   // Support Methods
 
-  static protected String buildURL(String name) {
+  protected static String buildURL(String name) {
     StringBuilder url = new StringBuilder();
     url.append("file://");
     url.append(resourceroot);

--- a/dap4/src/test/java/dap4/test/TestRemote.java
+++ b/dap4/src/test/java/dap4/test/TestRemote.java
@@ -38,22 +38,22 @@ public class TestRemote extends DapTestCommon implements Dap4ManifestIF {
   // Constants
 
   // Define the server to use
-  static protected final String SERVERNAME = "d4ts";
-  static protected final String SERVER = "remotetest.unidata.ucar.edu";
-  static protected final int SERVERPORT = -1;
-  static protected final String SERVERPATH = "d4ts/testfiles";
+  protected static final String SERVERNAME = "d4ts";
+  protected static final String SERVER = "remotetest.unidata.ucar.edu";
+  protected static final int SERVERPORT = -1;
+  protected static final String SERVERPATH = "d4ts/testfiles";
 
   // Define the input set location(s)
-  static protected final String INPUTEXT = ".nc"; // note that the .dap is deliberately left off
-  static protected final String INPUTQUERY = "?" + DapConstants.CHECKSUMTAG + "=true";
-  static protected final String INPUTFRAG = "#dap4";
+  protected static final String INPUTEXT = ".nc"; // note that the .dap is deliberately left off
+  protected static final String INPUTQUERY = "?" + DapConstants.CHECKSUMTAG + "=true";
+  protected static final String INPUTFRAG = "#dap4";
 
-  static protected final String BASELINEDIR = "/baselineremote";
-  static protected final String BASELINEEXT = ".nc.ncdump";
+  protected static final String BASELINEDIR = "/baselineremote";
+  protected static final String BASELINEEXT = ".nc.ncdump";
 
   // Following files cannot be tested because of flaws in sequence handling
   // by the CDM code in ucar.nc2.dataset.
-  static protected String[] EXCLUSIONS =
+  protected static String[] EXCLUSIONS =
       {"test_vlen2", "test_vlen3", "test_vlen4", "test_vlen5", "test_vlen6", "test_vlen7", "test_vlen8"};
 
   //////////////////////////////////////////////////
@@ -61,8 +61,8 @@ public class TestRemote extends DapTestCommon implements Dap4ManifestIF {
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public String resourceroot;
-  static public Dap4Server server;
+  public static String resourceroot;
+  public static Dap4Server server;
 
   static {
     server = new Dap4Server("remotetest", SERVER, SERVERPORT, SERVERPATH);
@@ -94,7 +94,7 @@ public class TestRemote extends DapTestCommon implements Dap4ManifestIF {
   // Test Generator
 
   @Parameterized.Parameters(name = "{index}: {0}")
-  static public List<TestCaseCommon> defineTestCases() {
+  public static List<TestCaseCommon> defineTestCases() {
     assert (server != null);
     List<TestCaseCommon> testcases = new ArrayList<>();
     String[][] manifest = excludeNames(dap4_manifest, EXCLUSIONS);

--- a/grib/src/test/java/ucar/nc2/grib/collection/TestGcMFile.java
+++ b/grib/src/test/java/ucar/nc2/grib/collection/TestGcMFile.java
@@ -27,7 +27,7 @@ public class TestGcMFile {
   public static class TestGcMFileParameterized {
 
     @Parameterized.Parameters(name = "{0}")
-    static public List<Integer> getTestParameters() {
+    public static List<Integer> getTestParameters() {
       return Arrays.asList(0, 1, 60000, 100000);
     }
 

--- a/httpservices/src/main/java/ucar/httpservices/HTTPAuthUtil.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPAuthUtil.java
@@ -87,7 +87,7 @@ public abstract class HTTPAuthUtil {
   // as the scheme field of AuthScope. The HttpHost schem is
   // a protocol like http or https. The schem field of AuthScope
   // is the authorization scheme like Basic or NTLM or Digest.
-  static public HttpHost authscopeToHost(AuthScope scope) {
+  public static HttpHost authscopeToHost(AuthScope scope) {
     return new HttpHost(scope.getHost(), scope.getPort(), HttpHost.DEFAULT_SCHEME_NAME);
   }
 
@@ -95,7 +95,7 @@ public abstract class HTTPAuthUtil {
   // as the scheme field of AuthScope. The HttpHost schem is
   // a protocol like http or https. The schem field of AuthScope
   // is the authorization scheme like Basic or NTLM or Digest.
-  static public AuthScope hostToAuthScope(HttpHost host) {
+  public static AuthScope hostToAuthScope(HttpHost host) {
     return new AuthScope(host.getHostName(), host.getPort(), AuthScope.ANY_REALM, AuthScope.ANY_SCHEME);
   }
 

--- a/httpservices/src/main/java/ucar/httpservices/HTTPIntercepts.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPIntercepts.java
@@ -37,7 +37,7 @@ public class HTTPIntercepts {
   }
 
   // Default printer
-  static public Printer logprinter = new Printer() {
+  public static Printer logprinter = new Printer() {
     public void print(String s) {
       logger.debug(s);
     }
@@ -140,25 +140,25 @@ public class HTTPIntercepts {
   // Static Variables
 
   // Use this flag to indicate that all instances should set debug.
-  static protected boolean defaultinterception = false;
+  protected static boolean defaultinterception = false;
 
   // Global set debug interceptors
-  static public void setGlobalDebugInterceptors(boolean tf) {
-    defaultinterception = tf;
+  public static void setGlobalDebugInterceptors(boolean tf) {
+    defaultinterception = true;
   }
 
   // Use this flag to have debug interceptors print their info
   // in addition to whatever else it does
-  static protected Printer defaultprinter = null;
+  protected static Printer defaultprinter = null;
 
-  static public void setGlobalPrinter(Printer printer) {
+  public static void setGlobalPrinter(Printer printer) {
     defaultprinter = printer;
   }
 
   //////////////////////////////////////////////////
   // Specific Interceptors
 
-  static public class DebugInterceptResponse extends HTTPIntercepts.InterceptCommon implements HttpResponseInterceptor {
+  public static class DebugInterceptResponse extends HTTPIntercepts.InterceptCommon implements HttpResponseInterceptor {
     protected StatusLine statusline = null; // Status Line
 
     public int getStatusCode() {
@@ -180,7 +180,7 @@ public class HTTPIntercepts {
     }
   }
 
-  static public class DebugInterceptRequest extends InterceptCommon implements HttpRequestInterceptor {
+  public static class DebugInterceptRequest extends InterceptCommon implements HttpRequestInterceptor {
     protected RequestLine requestline = null; // request Line
 
     public String getMethod() {

--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -542,7 +542,7 @@ public class HTTPSession implements Closeable {
     }
   }
 
-  static protected synchronized String checkCompressors(String compressors) {
+  protected static synchronized String checkCompressors(String compressors) {
     // Syntactic check of compressors
     Set<String> cset = new HashSet<>();
     compressors = compressors.replace(',', ' ');

--- a/httpservices/src/test/java/ucar/httpservices/TestThreading.java
+++ b/httpservices/src/test/java/ucar/httpservices/TestThreading.java
@@ -53,17 +53,17 @@ public class TestThreading extends UnitTestCommon {
   ////////////////////////////////////////////////// .
   // Constants
 
-  static public final boolean DEBUG = false;
+  public static final boolean DEBUG = false;
 
-  static public final boolean AWAIT = true;
+  public static final boolean AWAIT = true;
 
 
-  static protected final int DFALTTHREADS = 100;
-  static protected final int DFALTMAXCONNS = (DFALTTHREADS / 2);
+  protected static final int DFALTTHREADS = 100;
+  protected static final int DFALTMAXCONNS = (DFALTTHREADS / 2);
 
-  static protected final String DFALTSERVER = "http://" + TestDir.dap2TestServer;
+  protected static final String DFALTSERVER = "http://" + TestDir.dap2TestServer;
 
-  static protected final String DFALTURLFMT = DFALTSERVER + "/dts/test.%02d";
+  protected static final String DFALTURLFMT = DFALTSERVER + "/dts/test.%02d";
 
   static {
     HTTPSession.TESTING = true;
@@ -200,7 +200,7 @@ public class TestThreading extends UnitTestCommon {
     }
   }
 
-  static public class Failure extends Exception {
+  public static class Failure extends Exception {
     Failure(String m, Exception e) {
       super(m, e);
     }

--- a/httpservices/src/test/java/ucar/nc2/util/net/TestHang.java
+++ b/httpservices/src/test/java/ucar/nc2/util/net/TestHang.java
@@ -42,9 +42,9 @@ public class TestHang {
 
   static private HTTPSession session;
 
-  static protected final String server = "http://" + TestDir.dap2TestServer;
+  protected static final String server = "http://" + TestDir.dap2TestServer;
 
-  static protected final String url = server + "/dts/test.%02d.dds";
+  protected static final String url = server + "/dts/test.%02d.dds";
 
   static boolean isxfail(int x) {
     for (Integer i : XFAIL) {

--- a/httpservices/src/test/java/ucar/nc2/util/net/TestURIParse.java
+++ b/httpservices/src/test/java/ucar/nc2/util/net/TestURIParse.java
@@ -53,7 +53,7 @@ import java.net.URISyntaxException;
 public class TestURIParse extends UnitTestCommon {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static public boolean DEBUG = false;
+  public static boolean DEBUG = false;
 
   static final String CARON = "http://" + TestDir.remoteTestServer
       + "/thredds/cdmremote/scanCdmUnitTests/formats/hdf5/grid_1_3d_xyz_aug.h5?req=data&var=HDFEOS_INFORMATION/StructMetadata\\.0";
@@ -120,7 +120,7 @@ public class TestURIParse extends UnitTestCommon {
     Assert.assertTrue("TestMisc.testURX", pass);
   }
 
-  static protected boolean uriCompare(URI uri1, URI uri2) {
+  protected static boolean uriCompare(URI uri1, URI uri2) {
     boolean ok = true;
     ok = ok && uriPartCompare(uri1.getScheme(), uri2.getScheme());
     ok = ok && uriPartCompare(uri1.getHost(), uri2.getHost());
@@ -131,7 +131,7 @@ public class TestURIParse extends UnitTestCommon {
     return ok;
   }
 
-  static protected boolean uriCompareRaw(URI uri1, URI uri2) {
+  protected static boolean uriCompareRaw(URI uri1, URI uri2) {
     boolean ok = true;
     ok = ok && uriPartCompare(uri1.getScheme(), uri2.getScheme());
     ok = ok && uriPartCompare(uri1.getHost(), uri2.getHost());
@@ -142,7 +142,7 @@ public class TestURIParse extends UnitTestCommon {
     return ok;
   }
 
-  static protected boolean uriPartCompare(String s1, String s2) {
+  protected static boolean uriPartCompare(String s1, String s2) {
     if (s1 == s2)
       return true;
     if (s1 == null || s2 == null)
@@ -150,7 +150,7 @@ public class TestURIParse extends UnitTestCommon {
     return (s1.equals(s2));
   }
 
-  static protected String dump(URI uri) {
+  protected static String dump(URI uri) {
     StringBuilder buf = new StringBuilder();
     buf.append(uri.getScheme()).append("://");
     buf.append(uri.getHost());
@@ -165,7 +165,7 @@ public class TestURIParse extends UnitTestCommon {
     return buf.toString();
   }
 
-  static protected String dumpraw(URI uri) {
+  protected static String dumpraw(URI uri) {
     StringBuilder buf = new StringBuilder();
     buf.append(uri.getScheme()).append("://");
     buf.append(uri.getHost());

--- a/opendap/src/test/java/opendap/test/TestDapParser.java
+++ b/opendap/src/test/java/opendap/test/TestDapParser.java
@@ -30,13 +30,13 @@ import java.net.URL;
 public class TestDapParser extends TestFiles {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  static protected boolean VISUAL = false;
+  protected static boolean VISUAL = false;
 
-  static protected final int ISUNKNOWN = 0;
-  static protected final int ISDAS = 1;
-  static protected final int ISDDS = 2;
-  static protected final int ISDDX = 3;
-  static protected final int ISERR = 4;
+  protected static final int ISUNKNOWN = 0;
+  protected static final int ISDAS = 1;
+  protected static final int ISDDS = 2;
+  protected static final int ISDDX = 3;
+  protected static final int ISERR = 4;
 
   protected boolean isddx = false;
 

--- a/opendap/src/test/java/opendap/test/TestDuplicates.java
+++ b/opendap/src/test/java/opendap/test/TestDuplicates.java
@@ -57,7 +57,7 @@ public class TestDuplicates extends UnitTestCommon {
   }
 
   // Collect results locally
-  static public class Result {
+  public static class Result {
     String title;
     String url;
     String cdl;

--- a/opendap/src/test/java/opendap/test/TestMisc.java
+++ b/opendap/src/test/java/opendap/test/TestMisc.java
@@ -50,7 +50,7 @@ public class TestMisc extends UnitTestCommon {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   // Collect testcases locally
-  static public class Testcase {
+  public static class Testcase {
     String title;
     String url;
     String cdl;

--- a/opendap/src/test/java/opendap/test/TestSources.java
+++ b/opendap/src/test/java/opendap/test/TestSources.java
@@ -16,7 +16,7 @@ public class TestSources extends TestFiles {
   // Remote test info
 
   /* Use this for experimenting with new URLS */
-  static public final String XURL1 = "http://" + TestDir.dap2TestServer + "/dts";
+  public static final String XURL1 = "http://" + TestDir.dap2TestServer + "/dts";
 
   // "http://testremote.unidata.ucar.edu/thredds/dodsC/fmrc/NCEP/NAM/CONUS_12km/files";
   static final String[] X1 = {"test.01;1;f64"};


### PR DESCRIPTION
## Description of Changes

In accord with this [comment](https://github.com/Unidata/netcdf-java/pull/1152#pullrequestreview-1320799197), this PR converts all occurrences of
````
"static public" to "public static"
and
"static protected" to "protected static"
````
There are a couple of spotLess changes as well.

Warning: It turn out there are a lot of occurrences of "static public", so this PR touches a lot of files.

The changes were made by two commands:
````
1. find . -name '*.java' -exec grep '^[\t ]*static[ ][ ]*public' '{}' \;
2. sed -i.bak2 -e 's|^\([\t ]*\)static[ ][ ]*protected|\1protected static|' <file>
````
Command 1 located all .java files containing "static public". Command 2 was applied to the files located by command 1; it converts "static public" to "public static". Similar commands were applied for "static protected".

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) until ready for review
- [X] Make sure GitHub tests pass
- [X] Make sure Jenkins tests pass
- [X] Mark PR as "Ready for Review"
