### PR TITLE
Fix nested structures in NcStream

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/stream/NcStreamDataCol.java
+++ b/cdm/core/src/main/java/ucar/nc2/stream/NcStreamDataCol.java
@@ -699,6 +699,9 @@ public class NcStreamDataCol {
     StructureMembers.MemberBuilder result = members.addMember(name, null, null, dataType, msection.getShape());
     Array data = decode(memberData, parentSection);
     result.setDataArray(data);
+    if (data instanceof ArrayStructure) {
+      result.setStructureMembers(((ArrayStructure) data).getStructureMembers());
+    }
   }
 
 }


### PR DESCRIPTION
## Description of Changes

If data had a structure within a structure, the inner structure's members wouldn't get set when read with the NcStreamReader (used by CdmRemote). This caused TDS integration test 

`thredds.server.cdmr.TestCdmRemoteCompareDataP.doOne[/share/testdata/cdmUnitTest/thredds-test-data/local/thredds-test-data/cdmUnitTest/formats/netcdf4/testNestedStructure.nc]`

to fail with a nullptr exception. With this fix all the CdmRemote tests pass. There aren't any netcdf-java unit tests hitting this code as far as I could tell, but I ran the netcdf-java tests on [Jenkins on this branch](https://jenkins-aws.unidata.ucar.edu/job/tara-netcdf-java/19/) just in case.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
