### PR TITLE
Projection angular coordinates

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/constants/CF.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/CF.java
@@ -163,6 +163,9 @@ public class CF {
   public static final String PROJECTION_X_COORDINATE = "projection_x_coordinate";
   public static final String PROJECTION_Y_COORDINATE = "projection_y_coordinate";
 
+  public static final String PROJECTION_X_ANG_COORDINATE = "projection_x_angular_coordinate";
+  public static final String PROJECTION_Y_ANG_COORDINATE = "projection_y_angular_coordinate";
+
   // cf_role
   public static final String PROFILE_ID = "profile_id";
   public static final String TIMESERIES_ID = "timeseries_id"; // alias STATION_ID

--- a/cdm/core/src/main/java/ucar/nc2/constants/CF.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/CF.java
@@ -118,6 +118,8 @@ public class CF {
   public static final String GRID_MAPPING_NAME = "grid_mapping_name";
   public static final String GRID_NORTH_POLE_LATITUDE = "grid_north_pole_latitude"; // rotated grid
   public static final String GRID_NORTH_POLE_LONGITUDE = "grid_north_pole_longitude"; // rotated grid
+  public static final String ROTATED_LATITUDE = "rotated_latitude";
+  public static final String ROTATED_LONGITUDE = "rotated_longitude";
   public static final String INVERSE_FLATTENING = "inverse_flattening";
   public static final String LATITUDE_OF_PROJECTION_ORIGIN = "latitude_of_projection_origin";
   public static final String LONGITUDE_OF_PROJECTION_ORIGIN = "longitude_of_projection_origin";

--- a/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
@@ -424,11 +424,13 @@ public class CF1Convention extends CSMConvention {
         return AxisType.Lon;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE)
+          || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
         return AxisType.GeoX;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE)
+          || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
         return AxisType.GeoY;
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
@@ -425,12 +425,12 @@ public class CF1Convention extends CSMConvention {
       }
 
       if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE)
-          || sname.equalsIgnoreCase(CF.GRID_LONGITUDE) || sname.equalsIgnoreCase("rotated_longitude")) {
+          || sname.equalsIgnoreCase(CF.GRID_LONGITUDE) || sname.equalsIgnoreCase(CF.ROTATED_LONGITUDE)) {
         return AxisType.GeoX;
       }
 
       if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE)
-          || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
+          || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase(CF.ROTATED_LATITUDE)) {
         return AxisType.GeoY;
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
@@ -424,8 +424,8 @@ public class CF1Convention extends CSMConvention {
         return AxisType.Lon;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE)
-          || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE)
+          || sname.equalsIgnoreCase(CF.GRID_LONGITUDE) || sname.equalsIgnoreCase("rotated_longitude")) {
         return AxisType.GeoX;
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/conv/CF1Convention.java
@@ -424,13 +424,11 @@ public class CF1Convention extends CSMConvention {
         return AxisType.Lon;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LONGITUDE)
-          || sname.equalsIgnoreCase("rotated_longitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
         return AxisType.GeoX;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LATITUDE)
-          || sname.equalsIgnoreCase("rotated_latitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
         return AxisType.GeoY;
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
@@ -482,8 +482,8 @@ public class CF1Convention extends CSMConvention {
         return AxisType.Lon;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE)
-          || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE)
+          || sname.equalsIgnoreCase(CF.GRID_LONGITUDE) || sname.equalsIgnoreCase("rotated_longitude")) {
         return AxisType.GeoX;
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
@@ -483,12 +483,12 @@ public class CF1Convention extends CSMConvention {
       }
 
       if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE)
-          || sname.equalsIgnoreCase(CF.GRID_LONGITUDE) || sname.equalsIgnoreCase("rotated_longitude")) {
+          || sname.equalsIgnoreCase(CF.GRID_LONGITUDE) || sname.equalsIgnoreCase(CF.ROTATED_LONGITUDE)) {
         return AxisType.GeoX;
       }
 
       if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE)
-          || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
+          || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase(CF.ROTATED_LATITUDE)) {
         return AxisType.GeoY;
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
@@ -482,13 +482,11 @@ public class CF1Convention extends CSMConvention {
         return AxisType.Lon;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LONGITUDE)
-          || sname.equalsIgnoreCase("rotated_longitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
         return AxisType.GeoX;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LATITUDE)
-          || sname.equalsIgnoreCase("rotated_latitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
         return AxisType.GeoY;
       }
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/conv/CF1Convention.java
@@ -482,11 +482,13 @@ public class CF1Convention extends CSMConvention {
         return AxisType.Lon;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_X_COORDINATE)
+          || sname.equalsIgnoreCase(CF.PROJECTION_X_ANG_COORDINATE) || sname.equalsIgnoreCase("rotated_longitude")) {
         return AxisType.GeoX;
       }
 
-      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE) || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
+      if (sname.equalsIgnoreCase(CF.PROJECTION_Y_COORDINATE) || sname.equalsIgnoreCase(CF.PROJECTION_Y_ANG_COORDINATE)
+          || sname.equalsIgnoreCase(CF.GRID_LATITUDE) || sname.equalsIgnoreCase("rotated_latitude")) {
         return AxisType.GeoY;
       }
 

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -52,6 +52,8 @@ dependencies {
   netcdfAll project(':cdm:cdm-image')
   netcdfAll project(':cdm:cdm-radial')
   netcdfAll project(':cdm:cdm-misc')
+  netcdfAll project(':cdm:cdm-s3')
+  netcdfAll project(':cdm:cdm-zarr')
   netcdfAll project(':bufr')
   netcdfAll project(':grib')
   netcdfAll project(':netcdf4')

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -52,8 +52,6 @@ dependencies {
   netcdfAll project(':cdm:cdm-image')
   netcdfAll project(':cdm:cdm-radial')
   netcdfAll project(':cdm:cdm-misc')
-  netcdfAll project(':cdm:cdm-s3')
-  netcdfAll project(':cdm:cdm-zarr')
   netcdfAll project(':bufr')
   netcdfAll project(':grib')
   netcdfAll project(':netcdf4')


### PR DESCRIPTION
## Description of Changes

Add "projection_x_angular_coordinate" and "projection_y_angular_coordinate" as acceptable axes standard names so that NJ conforms with CF-1.9 recommendation for geostationary gridded projection attributes.

Resolves https://github.com/Unidata/netcdf-java/issues/1200

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [X] Mark PR as "Ready for Review"
