### PR TITLE
Fix checksum handling in DAP4.

### DIFF
--- a/cdm/core/src/main/java/ucar/ma2/Index.java
+++ b/cdm/core/src/main/java/ucar/ma2/Index.java
@@ -570,10 +570,10 @@ public class Index implements Cloneable {
       throw new ArrayIndexOutOfBoundsException();
     if (rank == 0)
       return this;
-    int prefixrank = (hasvlen ? rank : rank - 1);
+    int prefixrank = (hasvlen ? rank - 1 : rank);
     System.arraycopy(index, 0, current, 0, prefixrank);
     if (hasvlen)
-      current[prefixrank] = -1;
+      current[rank] = -1; // ??
     return this;
   }
 

--- a/dap4/src/main/java/dap4/core/ce/CEConstraint.java
+++ b/dap4/src/main/java/dap4/core/ce/CEConstraint.java
@@ -334,7 +334,7 @@ public class CEConstraint {
     Segment seg = findSegment(var);
     if (seg != null)
       slices = seg.slices;
-    if (slices == null)
+    if (slices == null || slices.size() == 0)
       slices = Universal.universalSlices(var);
     return slices;
   }

--- a/dap4/src/main/java/dap4/core/ce/CEConstraint.java
+++ b/dap4/src/main/java/dap4/core/ce/CEConstraint.java
@@ -334,7 +334,7 @@ public class CEConstraint {
     Segment seg = findSegment(var);
     if (seg != null)
       slices = seg.slices;
-    if (slices == null || slices.isEmpty() == 0)
+    if (slices == null || slices.isEmpty())
       slices = Universal.universalSlices(var);
     return slices;
   }

--- a/dap4/src/main/java/dap4/core/ce/CEConstraint.java
+++ b/dap4/src/main/java/dap4/core/ce/CEConstraint.java
@@ -334,7 +334,7 @@ public class CEConstraint {
     Segment seg = findSegment(var);
     if (seg != null)
       slices = seg.slices;
-    if (slices == null || slices.size() == 0)
+    if (slices == null || slices.isEmpty() == 0)
       slices = Universal.universalSlices(var);
     return slices;
   }

--- a/dap4/src/main/java/dap4/core/dmr/DMRPrinter.java
+++ b/dap4/src/main/java/dap4/core/dmr/DMRPrinter.java
@@ -94,7 +94,6 @@ public class DMRPrinter {
   // Following extracted from context
   protected ByteOrder order = null;
   protected Map<DapVariable, Long> localchecksummap = null;
-  protected Map<DapVariable, Long> remotechecksummap = null;
 
   protected EnumSet<Controls> controls = EnumSet.noneOf(Controls.class);
 
@@ -120,8 +119,7 @@ public class DMRPrinter {
     this.format = (format == null ? ResponseFormat.XML : format);
     this.cxt = (cxt == null ? new DapContext() : cxt);
     this.order = (ByteOrder) this.cxt.get(DapConstants.DAP4ENDIANTAG);
-    this.localchecksummap = (Map<DapVariable, Long>) this.cxt.get("localchecksummap");
-    this.remotechecksummap = (Map<DapVariable, Long>) this.cxt.get("remotechecksummap");
+    this.localchecksummap = (Map<DapVariable, Long>) this.cxt.get("checksummap");
   }
 
   //////////////////////////////////////////////////

--- a/dap4/src/main/java/dap4/core/util/SliceConstraint.java
+++ b/dap4/src/main/java/dap4/core/util/SliceConstraint.java
@@ -63,7 +63,7 @@ public class SliceConstraint {
   }
 
   protected void add(List<Slice> slices) throws DapException {
-    if (slices == null || slices.size() == 0)
+    if (slices == null || slices.isEmpty())
       throw new DapException("Null slice set");
     if (this.slicesets.size() == this.rank)
       throw new DapException("Sliceset overflow");

--- a/dap4/src/main/java/dap4/dap4lib/cdm/CDMUtil.java
+++ b/dap4/src/main/java/dap4/dap4lib/cdm/CDMUtil.java
@@ -179,7 +179,7 @@ public abstract class CDMUtil {
   }
 
   public static boolean hasVLEN(List<Range> ranges) {
-    if (ranges == null || ranges.size() == 0)
+    if (ranges == null || ranges.isEmpty())
       return false;
     return ranges.get(ranges.size() - 1) == Range.VLEN;
   }
@@ -213,7 +213,7 @@ public abstract class CDMUtil {
    * @return effective shape
    */
   public static int[] computeEffectiveShape(List<DapDimension> dimset) {
-    if (dimset == null || dimset.size() == 0)
+    if (dimset == null || dimset.isEmpty())
       return new int[0];
     int effectiverank = dimset.size();
     int[] shape = new int[effectiverank];

--- a/dap4/src/test/data/resources/baselineremote/test_atomic_array.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_atomic_array.nc.ncdump
@@ -10,21 +10,29 @@ netcdf test_atomic_array {
     d5 = 5;
   variables:
     ubyte vu8(d2, d3);
+      vu8:_DAP4_Checksum_CRC32 = -735091578;
 
     short v16(d4);
+      v16:_DAP4_Checksum_CRC32 = -1835461610;
 
     uint vu32(d2, d3);
+      vu32:_DAP4_Checksum_CRC32 = 207024370;
 
     double vd(d2);
+      vd:_DAP4_Checksum_CRC32 = 2081016750;
 
     char vc(d2);
+      vc:_DAP4_Checksum_CRC32 = 1672337415;
 
     string vs(d2, d2);
+      vs:_DAP4_Checksum_CRC32 = 1731162308;
 
     opaque vo(d1, d2);
+      vo:_DAP4_Checksum_CRC32 = 660035085;
 
     enum cloud_class_t primary_cloud(d5);
       string primary_cloud:_FillValue = "Missing";
+      primary_cloud:_DAP4_Checksum_CRC32 = -1249222022;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_atomic_types.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_atomic_types.nc.ncdump
@@ -4,36 +4,51 @@ netcdf test_atomic_types {
 
   variables:
     byte v8;
+      v8:_DAP4_Checksum_CRC32 = 1069182125;
 
     ubyte vu8;
+      vu8:_DAP4_Checksum_CRC32 = -16777216;
 
     short v16;
+      v16:_DAP4_Checksum_CRC32 = -1402891809;
 
     ushort vu16;
+      vu16:_DAP4_Checksum_CRC32 = -65536;
 
     int v32;
+      v32:_DAP4_Checksum_CRC32 = 306674911;
 
     uint vu32;
+      vu32:_DAP4_Checksum_CRC32 = -1;
 
     long v64;
+      v64:_DAP4_Checksum_CRC32 = -855876548;
 
     ulong vu64;
+      vu64:_DAP4_Checksum_CRC32 = 558161692;
 
     float vf;
+      vf:_DAP4_Checksum_CRC32 = -1943399579;
 
     double vd;
+      vd:_DAP4_Checksum_CRC32 = -222639246;
 
     char vc;
+      vc:_DAP4_Checksum_CRC32 = -1528910307;
 
     string vs;
+      vs:_DAP4_Checksum_CRC32 = 915515092;
 
     opaque vo;
+      vo:_DAP4_Checksum_CRC32 = -766649635;
 
     enum cloud_class_t primary_cloud;
       string primary_cloud:_FillValue = "Missing";
+      primary_cloud:_DAP4_Checksum_CRC32 = 1007455905;
 
     enum cloud_class_t secondary_cloud;
       string secondary_cloud:_FillValue = "Missing";
+      secondary_cloud:_DAP4_Checksum_CRC32 = 314082080;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_enum_1.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_enum_1.nc.ncdump
@@ -5,6 +5,7 @@ netcdf test_enum_1 {
   variables:
     enum cloud_class_t primary_cloud;
       string primary_cloud:_FillValue = "Missing";
+      primary_cloud:_DAP4_Checksum_CRC32 = 1007455905;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_enum_2.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_enum_2.nc.ncdump
@@ -6,6 +6,7 @@ netcdf test_enum_2 {
     variables:
       enum cloud_class_t primary_cloud;
         string primary_cloud:_FillValue = "Missing";
+        primary_cloud:_DAP4_Checksum_CRC32 = 1007455905;
 
   }
 

--- a/dap4/src/test/data/resources/baselineremote/test_enum_3.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_enum_3.nc.ncdump
@@ -5,6 +5,7 @@ netcdf test_enum_3 {
   group: h {
     variables:
       enum cloud_class_t primary_cloud;
+        primary_cloud:_DAP4_Checksum_CRC32 = -1526341861;
 
   }
 

--- a/dap4/src/test/data/resources/baselineremote/test_enum_array.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_enum_array.nc.ncdump
@@ -7,6 +7,7 @@ netcdf test_enum_array {
   variables:
     enum cloud_class_t primary_cloud(d5);
       string primary_cloud:_FillValue = "Missing";
+      primary_cloud:_DAP4_Checksum_CRC32 = -1249222022;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_fill.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_fill.nc.ncdump
@@ -1,11 +1,14 @@
 netcdf test_fill {
   variables:
     ubyte uv8;
+      uv8:_DAP4_Checksum_CRC32 = 1874795921;
 
     short v16;
+      v16:_DAP4_Checksum_CRC32 = -921460762;
 
     int uv32;
       uv32:_FillValue = 17;
+      uv32:_DAP4_Checksum_CRC32 = -2076724431;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_fill_2.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_fill_2.nc.ncdump
@@ -7,15 +7,19 @@ netcdf test_fill_2 {
   variables:
     enum cloud_class_t enumvar(d2);
       string enumvar:_FillValue = "Missing";
+      enumvar:_DAP4_Checksum_CRC32 = -1286267696;
 
     int uv32(d2);
       uv32:_FillValue = 17;
+      uv32:_DAP4_Checksum_CRC32 = 1019008870;
 
     ubyte uv8(d2);
       uv8:_FillValue = 120B;
+      uv8:_DAP4_Checksum_CRC32 = 196807244;
 
     short v16(d2);
       v16:_FillValue = -37S;
+      v16:_DAP4_Checksum_CRC32 = 1719923210;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_groups1.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_groups1.nc.ncdump
@@ -9,8 +9,10 @@ netcdf test_groups1 {
         dim3 = 7;
       variables:
         int v1(dim1);
+          v1:_DAP4_Checksum_CRC32 = 488449836;
 
         float v2(dim2);
+          v2:_DAP4_Checksum_CRC32 = 266808643;
 
     }
 
@@ -19,8 +21,10 @@ netcdf test_groups1 {
         dim3 = 7;
       variables:
         int v1(dim1);
+          v1:_DAP4_Checksum_CRC32 = -1447780101;
 
         float v3(dim3);
+          v3:_DAP4_Checksum_CRC32 = 703718162;
 
     }
 

--- a/dap4/src/test/data/resources/baselineremote/test_misc1.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_misc1.nc.ncdump
@@ -7,12 +7,15 @@ netcdf test_misc1 {
   variables:
     float var(unlim);
       var:_ChunkSizes = 1024;
+      var:_DAP4_Checksum_CRC32 = -1062079627;
 
     float lon(lon);
+      lon:_DAP4_Checksum_CRC32 = -947018072;
       string lon:units = "degrees_east";
       string lon:_CoordinateAxisType = "Lon";
 
     float lat(lat);
+      lat:_DAP4_Checksum_CRC32 = -1521140044;
       string lat:units = "degrees_north";
       string lat:_CoordinateAxisType = "Lat";
 

--- a/dap4/src/test/data/resources/baselineremote/test_one_var.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_one_var.nc.ncdump
@@ -1,6 +1,7 @@
 netcdf test_one_var {
   variables:
     int t;
+      t:_DAP4_Checksum_CRC32 = -907939866;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_one_vararray.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_one_vararray.nc.ncdump
@@ -3,6 +3,7 @@ netcdf test_one_vararray {
     d2 = 2;
   variables:
     int t(d2);
+      t:_DAP4_Checksum_CRC32 = 1121956304;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_opaque.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_opaque.nc.ncdump
@@ -1,6 +1,7 @@
 netcdf test_opaque {
   variables:
     opaque vo1;
+      vo1:_DAP4_Checksum_CRC32 = -766649635;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_opaque_array.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_opaque_array.nc.ncdump
@@ -3,6 +3,7 @@ netcdf test_opaque_array {
     d2 = 2;
   variables:
     opaque vo2(d2, d2);
+      vo2:_DAP4_Checksum_CRC32 = -1856496422;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_struct1.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_struct1.nc.ncdump
@@ -3,10 +3,13 @@ netcdf test_struct1 {
 
     Structure {
       int x;
+        x:_DAP4_Checksum_CRC32 = 0;
         string x:_CoordinateAxisType = "GeoX";
       int y;
+        y:_DAP4_Checksum_CRC32 = 0;
         string y:_CoordinateAxisType = "GeoY";
     } s;
+    s:_DAP4_Checksum_CRC32 = -812672911;
 
 
   // global attributes:

--- a/dap4/src/test/data/resources/baselineremote/test_struct_array.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_struct_array.nc.ncdump
@@ -6,10 +6,13 @@ netcdf test_struct_array {
 
     Structure {
       int x;
+        x:_DAP4_Checksum_CRC32 = 0;
         string x:_CoordinateAxisType = "GeoX";
       int y;
+        y:_DAP4_Checksum_CRC32 = 0;
         string y:_CoordinateAxisType = "GeoY";
     } s(dx, dy);
+    s:_DAP4_Checksum_CRC32 = 788761034;
 
 
   // global attributes:

--- a/dap4/src/test/data/resources/baselineremote/test_struct_nested.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_struct_nested.nc.ncdump
@@ -5,18 +5,25 @@ netcdf test_struct_nested {
 
       Structure {
         int x;
+          x:_DAP4_Checksum_CRC32 = 0;
           string x:_CoordinateAxisType = "GeoX";
         int y;
+          y:_DAP4_Checksum_CRC32 = 0;
           string y:_CoordinateAxisType = "GeoY";
       } field1;
+      field1:_DAP4_Checksum_CRC32 = 0;
 
 
       Structure {
         int x;
+          x:_DAP4_Checksum_CRC32 = 0;
         int y;
+          y:_DAP4_Checksum_CRC32 = 0;
       } field2;
+      field2:_DAP4_Checksum_CRC32 = 0;
 
     } x;
+    x:_DAP4_Checksum_CRC32 = -542685669;
 
 
   // global attributes:

--- a/dap4/src/test/data/resources/baselineremote/test_struct_nested3.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_struct_nested3.nc.ncdump
@@ -7,11 +7,15 @@ netcdf test_struct_nested3 {
 
         Structure {
           int field1;
+            field1:_DAP4_Checksum_CRC32 = 0;
         } field2;
+        field2:_DAP4_Checksum_CRC32 = 0;
 
       } field3;
+      field3:_DAP4_Checksum_CRC32 = 0;
 
     } x;
+    x:_DAP4_Checksum_CRC32 = -907939866;
 
 
   // global attributes:

--- a/dap4/src/test/data/resources/baselineremote/test_struct_type.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_struct_type.nc.ncdump
@@ -3,10 +3,13 @@ netcdf test_struct_type {
 
     Structure {
       int x;
+        x:_DAP4_Checksum_CRC32 = 0;
         string x:_CoordinateAxisType = "GeoX";
       int y;
+        y:_DAP4_Checksum_CRC32 = 0;
         string y:_CoordinateAxisType = "GeoY";
     } s;
+    s:_DAP4_Checksum_CRC32 = -812672911;
 
 
   // global attributes:

--- a/dap4/src/test/data/resources/baselineremote/test_test.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_test.nc.ncdump
@@ -4,6 +4,7 @@ netcdf test_test {
 
   variables:
     enum enum_t v1;
+      v1:_DAP4_Checksum_CRC32 = -1526341861;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_unlim.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_unlim.nc.ncdump
@@ -5,21 +5,25 @@ netcdf test_unlim {
     lat = 3;
   variables:
     float lon(lon);
+      lon:_DAP4_Checksum_CRC32 = 27072276;
       string lon:units = "degrees_east";
       string lon:_CoordinateAxisType = "Lon";
 
     float pr(time, lat, lon);
       pr:_ChunkSizes = 1, 3, 2;
+      pr:_DAP4_Checksum_CRC32 = 826391215;
       string pr:standard_name = "air_pressure_at_sea_level";
       string pr:units = "hPa";
       string pr:_CoordinateAxisType = "Pressure";
 
     double time(time);
       time:_ChunkSizes = 512;
+      time:_DAP4_Checksum_CRC32 = -1907298714;
       string time:units = "seconds since 2009-01-01";
       string time:_CoordinateAxisType = "Time";
 
     float lat(lat);
+      lat:_DAP4_Checksum_CRC32 = 431075914;
       string lat:units = "degrees_north";
       string lat:_CoordinateAxisType = "Lat";
 

--- a/dap4/src/test/data/resources/baselineremote/test_unlim1.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_unlim1.nc.ncdump
@@ -5,21 +5,25 @@ netcdf test_unlim1 {
     time = 2;
   variables:
     float lon(lon);
+      lon:_DAP4_Checksum_CRC32 = 27072276;
       string lon:units = "degrees_east";
       string lon:_CoordinateAxisType = "Lon";
 
     float pr(time, lat, lon);
       pr:_ChunkSizes = 1, 3, 2;
+      pr:_DAP4_Checksum_CRC32 = 826391215;
       string pr:standard_name = "air_pressure_at_sea_level";
       string pr:units = "hPa";
       string pr:_CoordinateAxisType = "Pressure";
 
     double time(time);
       time:_ChunkSizes = 512;
+      time:_DAP4_Checksum_CRC32 = -1907298714;
       string time:units = "seconds since 2009-01-01";
       string time:_CoordinateAxisType = "Time";
 
     float lat(lat);
+      lat:_DAP4_Checksum_CRC32 = 431075914;
       string lat:units = "degrees_north";
       string lat:_CoordinateAxisType = "Lat";
 

--- a/dap4/src/test/data/resources/baselineremote/test_utf8.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_utf8.nc.ncdump
@@ -3,6 +3,7 @@ netcdf test_utf8 {
     d2 = 2;
   variables:
     string vs(d2);
+      vs:_DAP4_Checksum_CRC32 = -52179672;
 
   // global attributes:
   :_DAP4_Little_Endian = 1B;

--- a/dap4/src/test/data/resources/baselineremote/test_vlen1.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_vlen1.nc.ncdump
@@ -3,9 +3,11 @@ netcdf test_vlen1 {
 
     Sequence {
       int x;
+        x:_DAP4_Checksum_CRC32 = 0;
         string x:_CoordinateAxisType = "GeoX";
     } x(*);
     x:_FillValue = 0;
+    x:_DAP4_Checksum_CRC32 = -972676669;
 
 
   // global attributes:

--- a/dap4/src/test/data/resources/baselineremote/test_vlen11.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_vlen11.nc.ncdump
@@ -3,8 +3,10 @@ netcdf test_vlen11 {
 
     Sequence {
       int v;
+        v:_DAP4_Checksum_CRC32 = 0;
     } v(*);
     v:_FillValue = 0;
+    v:_DAP4_Checksum_CRC32 = -1061524850;
 
 
   // global attributes:

--- a/dap4/src/test/data/resources/baselineremote/test_zerodim.nc.ncdump
+++ b/dap4/src/test/data/resources/baselineremote/test_zerodim.nc.ncdump
@@ -7,12 +7,15 @@ netcdf test_zerodim {
   variables:
     float var(unlim);
       var:_ChunkSizes = 1024;
+      var:_DAP4_Checksum_CRC32 = -1062079627;
 
     float lon(lon);
+      lon:_DAP4_Checksum_CRC32 = -947018072;
       string lon:units = "degrees_east";
       string lon:_CoordinateAxisType = "Lon";
 
     float lat(lat);
+      lat:_DAP4_Checksum_CRC32 = -1521140044;
       string lat:units = "degrees_north";
       string lat:_CoordinateAxisType = "Lat";
 


### PR DESCRIPTION
## Description of Changes
The DAP4 specification says how to properly handle checksums, but this was improperly implemented in netcdf-java. This PR makes some changes to handle checksums.

WARNING: The merging of this PR needs to be synchronized with the following netcdf-java PR: XXXX.
So after both PRs are reviewed and approved, both need to be merged one right after the other.

Note also that their are still unresolved ambiguities about checksums in the DAP4 specification that need resolution. See [here](https://github.com/OPENDAP/dap4-specification/discussions/6) for example. So at the moment, accessing non-thredds servers via DAP4 requires special treatment.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) until ready for review
- [X] Make sure GitHub tests pass
- [X] Make sure Jenkins tests pass
- [ ] Mark PR as "Ready for Review"

## DAP4 Changes
1. Properly compute and apply checksums in the DAP and DMR responses.
2. Fix tests that require the _DAP4_Checksum_CRC32 attribute.

## Non-DAP4 Changes
The only controversial change is that to ucar.ma2.Index, about line 573. The change is as follows:
````
    int prefixrank = (hasvlen ? rank: rank - 1);
to
    int prefixrank = (hasvlen ? rank - 1 : rank);
````
The original line is clearly an error under the assumption that "*" dimensions are always the last dimension for an array.  I was worried about this causing follow-on failures, but not surprisingly because vlen is so screwed up, no follow-on failures have appeared.
