### PR TITLE
Use ncml in datasetscan

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -283,13 +283,14 @@ public class NcmlReader {
    * @throws IOException on read error
    */
   public static NetcdfDataset.Builder mergeNcml(NetcdfFile ref, @Nullable Element ncmlElem) throws IOException {
-    NetcdfDataset.Builder targetDS = NetcdfDataset.builder(ref); // no enhance
+    NetcdfDataset.Builder targetDS = NetcdfDataset.builder(ref);
 
     if (ncmlElem != null) {
       NcmlReader reader = new NcmlReader();
       reader.readGroup(targetDS, null, null, ncmlElem);
     }
 
+    setEnhanceMode(targetDS, ncmlElem, null);
     return targetDS;
   }
 
@@ -540,6 +541,18 @@ public class NcmlReader {
       throw new IllegalArgumentException("NcML had fatal errors:" + errors);
     }
 
+    setEnhanceMode(builder, netcdfElem, cancelTask);
+
+    /*
+     * LOOK optionally add record structure to netcdf-3
+     * String addRecords = netcdfElem.getAttributeValue("addRecords");
+     * if ("true".equalsIgnoreCase(addRecords))
+     * targetDS.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
+     */
+  }
+
+  private static void setEnhanceMode(NetcdfDataset.Builder builder, Element netcdfElem, @Nullable CancelTask cancelTask)
+      throws IOException {
     // enhance means do scale/offset and/or add CoordSystems
     Set<NetcdfDataset.Enhance> mode = parseEnhanceMode(netcdfElem.getAttributeValue("enhance"));
     if (mode != null) {
@@ -550,13 +563,6 @@ public class NcmlReader {
         builder.setEnhanceMode(mode);
       }
     }
-
-    /*
-     * LOOK optionally add record structure to netcdf-3
-     * String addRecords = netcdfElem.getAttributeValue("addRecords");
-     * if ("true".equalsIgnoreCase(addRecords))
-     * targetDS.sendIospMessage(NetcdfFile.IOSP_MESSAGE_ADD_RECORD_STRUCTURE);
-     */
   }
 
   /**

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReader.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlReader.java
@@ -1,19 +1,21 @@
 package ucar.nc2.internal.ncml;
 
 import static com.google.common.truth.Truth.assertThat;
+import static ucar.ma2.MAMath.nearlyEquals;
 
 import java.io.IOException;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
-import org.junit.Assert;
 import org.junit.Test;
+import ucar.ma2.Array;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dataset.VariableDS;
+import ucar.nc2.ncml.TestEnhanceStandardizer;
 import ucar.nc2.ncml.TestNcmlRead;
 import ucar.unidata.util.test.TestDir;
 
@@ -24,7 +26,7 @@ public class TestNcmlReader {
     final String filename = TestDir.cdmLocalTestDataDir + "example1.nc";
 
     try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(filename, null)) {
-      final NetcdfDataset netcdfDataset = NcmlReader.mergeNcml(netcdfFile, getNcmlElement()).build();
+      final NetcdfDataset netcdfDataset = NcmlReader.mergeNcml(netcdfFile, getNcmlElement("modifyVars.xml")).build();
 
       final Variable ncmlVariable = netcdfDataset.findVariable("deltaLat");
       assertThat((Object) ncmlVariable).isInstanceOf(VariableDS.class);
@@ -34,8 +36,23 @@ public class TestNcmlReader {
     }
   }
 
-  private static Element getNcmlElement() throws IOException, JDOMException {
-    final String ncml = TestNcmlRead.topDir + "modifyVars.xml";
+  @Test
+  public void shouldMergeNcmlWithEnhancements() throws IOException, JDOMException {
+    final String filename = TestDir.cdmLocalTestDataDir + "example1.nc";
+
+    try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(filename, null)) {
+      final NetcdfDataset netcdfDataset =
+          NcmlReader.mergeNcml(netcdfFile, getNcmlElement("enhance/testStandardizer.ncml")).build();
+
+      final Variable ncmlVariable = netcdfDataset.findVariable("doublevar");
+      assertThat((Object) ncmlVariable).isNotNull();
+      Array dataDoubles = ncmlVariable.read();
+      assertThat(nearlyEquals(dataDoubles, TestEnhanceStandardizer.DATA_DOUBLES)).isTrue();
+    }
+  }
+
+  private static Element getNcmlElement(String filename) throws IOException, JDOMException {
+    final String ncml = TestNcmlRead.topDir + filename;
 
     SAXBuilder saxBuilder = new SAXBuilder();
     saxBuilder.setExpandEntities(false);


### PR DESCRIPTION
## Description of Changes

This fixes https://github.com/Unidata/tds/issues/403 (TDS tests in https://github.com/Unidata/tds/pull/404).

NetCDF datasetScan datasets opened through cdmremote, wms or opendap use this `mergeNcml` function to add ncml to the dataset. This does not apply enhancements even if the ncml has `enhance="all"`. This PR would parse and use enhancements set in ncml.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
