### PR TITLE
Fix canonical order of coverage axes

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/constants/AxisType.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/AxisType.java
@@ -12,7 +12,7 @@ package ucar.nc2.constants;
  */
 public enum AxisType {
   RunTime(0, "R"), // runtime / reference time
-  Ensemble(2, "E"), Time(1, "T"), GeoX(5, "X"), GeoY(4, "Y"), GeoZ(3, "Z"), // typically "dimensionless" vertical
+  Ensemble(1, "E"), Time(2, "T"), GeoX(5, "X"), GeoY(4, "Y"), GeoZ(3, "Z"), // typically "dimensionless" vertical
                                                                             // coordinate
   Lat(4, "Y"), Lon(5, "X"), Height(3, "Z"), // vertical height coordinate
   Pressure(3, "Z"), // vertical pressure coordinate

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestCoordinateAxis.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestCoordinateAxis.java
@@ -1,0 +1,40 @@
+package ucar.nc2.dataset;
+
+import static com.google.common.truth.Truth.assertThat;
+import static ucar.nc2.TestUtils.makeDummyGroup;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import ucar.ma2.DataType;
+import ucar.nc2.constants.AxisType;
+
+public class TestCoordinateAxis {
+
+  @Test
+  public void shouldSortIntoCanonicalOrder() {
+    CoordinateAxis lat = createCoordAxis(AxisType.Lat);
+    CoordinateAxis lon = createCoordAxis(AxisType.Lon);
+    CoordinateAxis height = createCoordAxis(AxisType.Height);
+    CoordinateAxis runtime = createCoordAxis(AxisType.RunTime);
+    CoordinateAxis ensemble = createCoordAxis(AxisType.Ensemble);
+    CoordinateAxis time = createCoordAxis(AxisType.Time);
+
+    List<CoordinateAxis> sortedAxes = Arrays.asList(lat, lon, height, runtime, ensemble, time);
+    sortedAxes.sort(new CoordinateAxis.AxisComparator());
+
+    List<CoordinateAxis> canonicalOrderAxes = Arrays.asList(runtime, ensemble, time, height, lat, lon);
+    assertThat(sortedAxes.size()).isEqualTo(canonicalOrderAxes.size());
+
+    for (int i = 0; i < sortedAxes.size(); i++) {
+      assertThat(sortedAxes.get(i).getAxisType()).isEqualTo(canonicalOrderAxes.get(i).getAxisType());
+    }
+  }
+
+  private static CoordinateAxis createCoordAxis(AxisType type) {
+    VariableDS.Builder<?> vdsBuilder = VariableDS.builder().setName("name").setDataType(DataType.FLOAT)
+        .setUnits("units").setDesc("desc").setEnhanceMode(NetcdfDataset.getEnhanceAll());
+
+    return CoordinateAxis.fromVariableDS(vdsBuilder).setAxisType(type).build(makeDummyGroup());
+  }
+}

--- a/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
+++ b/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
@@ -1215,6 +1215,7 @@ public class GribCoverageDataset implements CoverageReader, CoordAxisReader {
       }
     }
 
+    Collections.sort(coordsSetAxes);
     List<CoverageCoordAxis> geoArrayAxes = new ArrayList<>(coordsSetAxes); // for GeoReferencedArray
     geoArrayAxes.add(subsetCoordSys.getYAxis());
     geoArrayAxes.add(subsetCoordSys.getXAxis());


### PR DESCRIPTION
## Description of Changes

This resolves https://github.com/Unidata/netcdf-java/issues/1220

Coverages with both a time and an ensemble axis do not work due to a mismatch in the canonical order `canonical order: (rt, e, t, z, y, x)` used in `DTCoverage::calcPermuteIndex()` and the sort order for the `AxisType` enums used for ordering the CoordinateAxes in the coverage coordinate system. This would cause errors upon reading/writing due to index out of bounds.

This PR would use the `canonical order: (rt, e, t, z, y, x)` for the `AxisType` enum as well. There is a comment saying not to change the enum order due to its use in protobuf messages. The only proto that I see this used in is the `cdmrFeature.proto` which actually has the order I just updated `AxisType` to have. It seems that cmdrFeature is removed in TDS and so I am not sure how important it is to test that.

Additional TDS tests added in https://github.com/Unidata/tds/pull/411.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
