### PR TITLE
Fix projection units

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/Geostationary.java
@@ -78,21 +78,6 @@ public class Geostationary extends AbstractTransformBuilder implements HorizTran
     return TransformType.Projection;
   }
 
-  private double getScaleFactor(String geoCoordinateUnits) {
-    // default value of -1.0 interpreted as no scaling in the class
-    // ucar.unidata.geoloc.projection.sat.Geostationary
-    double scaleFactor = defaultScaleFactor;
-    String neededMapCoordinateUnit = "radian";
-
-    if (SimpleUnit.isCompatible(geoCoordinateUnits, neededMapCoordinateUnit)) {
-      scaleFactor = SimpleUnit.getConversionFactor(geoCoordinateUnits, neededMapCoordinateUnit);
-    }
-
-    logger.debug("geoCoordinateUnits {}, scaleFactor {}", geoCoordinateUnits, scaleFactor);
-
-    return scaleFactor;
-  }
-
   public ProjectionCT makeCoordinateTransform(AttributeContainer ctv, String geoCoordinateUnits) {
     readStandardParams(ctv, geoCoordinateUnits);
 
@@ -145,13 +130,8 @@ public class Geostationary extends AbstractTransformBuilder implements HorizTran
       isSweepX = fixed_angle.equals("y");
     }
 
-    // scales less than zero indicate no scaling of axis (i.e. map coords have units of radians)
-    double geoCoordinateScaleFactor;
-
-    geoCoordinateScaleFactor = getScaleFactor(geoCoordinateUnits);
-
     ProjectionImpl proj = new ucar.unidata.geoloc.projection.sat.Geostationary(subLonDegrees, perspective_point_height,
-        semi_minor_axis, semi_major_axis, inv_flattening, isSweepX, geoCoordinateScaleFactor);
+        semi_minor_axis, semi_major_axis, inv_flattening, isSweepX);
 
     return new ProjectionCT(ctv.getName(), "FGDC", proj);
   }

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -235,7 +235,8 @@ public class HorizCoordSys {
           if (isProjection) {
             // we have to transform latlon to projection coordinates
             ProjectionImpl proj = transform.getProjection();
-            final ProjectionRect projectionRectInDefaultUnits = proj.latLonToProjBB(llbb); // allow projection to override
+            final ProjectionRect projectionRectInDefaultUnits = proj.latLonToProjBB(llbb); // allow projection to
+                                                                                           // override
             final double xMinInCorrectUnits = convertFromDefaultUnits(projectionRectInDefaultUnits.getMinX());
             final double xMaxInCorrectUnits = convertFromDefaultUnits(projectionRectInDefaultUnits.getMaxX());
             opt = xAxis.subset(xMinInCorrectUnits, xMaxInCorrectUnits, horizStride);

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/HorizCoordSys.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.*;
+import ucar.nc2.units.SimpleUnit;
 import ucar.nc2.util.Optional;
 import ucar.unidata.geoloc.*;
 import javax.annotation.concurrent.Immutable;
@@ -58,6 +59,8 @@ public class HorizCoordSys {
   private final boolean isProjection;
   private final boolean isLatLon1D;
   private boolean isLatLon2D; // isProjection and isLatLon2D may both be "true".
+  // scale factor for x, y axis if they have different units than the projection's default units
+  private final double coordinateConversionFactor;
 
   protected HorizCoordSys(CoverageCoordAxis1D xAxis, CoverageCoordAxis1D yAxis, CoverageCoordAxis latAxis,
       CoverageCoordAxis lonAxis, CoverageTransform transform) {
@@ -68,6 +71,7 @@ public class HorizCoordSys {
     this.isLatLon1D = latAxis instanceof CoverageCoordAxis1D && lonAxis instanceof CoverageCoordAxis1D;
     this.isLatLon2D = latAxis instanceof LatLonAxis2D && lonAxis instanceof LatLonAxis2D;
     assert isProjection || isLatLon1D || isLatLon2D : "missing horiz coordinates (x,y,projection or lat,lon)";
+    coordinateConversionFactor = getCoordinateConversionFactor();
 
     if (isProjection && isLatLon2D) {
       boolean ok = true;
@@ -163,16 +167,14 @@ public class HorizCoordSys {
 
           // we have to transform latlon to projection coordinates
           ProjectionImpl proj = transform.getProjection();
-          final ProjectionPoint projectionPointInKm = proj.latLonToProj(latlon);
-          final double xInCorrectUnits = convertFromKm(projectionPointInKm.getX(), xAxis.units, xAxis.name);
-          optb = xhelper.subsetContaining(xInCorrectUnits);
+          final ProjectionPoint projectionRectInDefaultUnits = proj.latLonToProj(latlon);
+          optb = xhelper.subsetContaining(convertFromDefaultUnits(projectionRectInDefaultUnits.getX()));
           if (optb.isPresent())
             xaxisSubset = new CoverageCoordAxis1D(optb.get());
           else
             errMessages.format("xaxis: %s;%n", optb.getErrorMessage());
 
-          final double yInCorrectUnits = convertFromKm(projectionPointInKm.getY(), yAxis.units, yAxis.name);
-          optb = yhelper.subsetContaining(yInCorrectUnits);
+          optb = yhelper.subsetContaining(convertFromDefaultUnits(projectionRectInDefaultUnits.getY()));
           if (optb.isPresent())
             yaxisSubset = new CoverageCoordAxis1D(optb.get());
           else
@@ -233,17 +235,17 @@ public class HorizCoordSys {
           if (isProjection) {
             // we have to transform latlon to projection coordinates
             ProjectionImpl proj = transform.getProjection();
-            final ProjectionRect projectionRectInKm = proj.latLonToProjBB(llbb); // allow projection to override
-            final double xMinInCorrectUnits = convertFromKm(projectionRectInKm.getMinX(), xAxis.units, xAxis.name);
-            final double xMaxInCorrectUnits = convertFromKm(projectionRectInKm.getMaxX(), xAxis.units, xAxis.name);
+            final ProjectionRect projectionRectInDefaultUnits = proj.latLonToProjBB(llbb); // allow projection to override
+            final double xMinInCorrectUnits = convertFromDefaultUnits(projectionRectInDefaultUnits.getMinX());
+            final double xMaxInCorrectUnits = convertFromDefaultUnits(projectionRectInDefaultUnits.getMaxX());
             opt = xAxis.subset(xMinInCorrectUnits, xMaxInCorrectUnits, horizStride);
             if (opt.isPresent())
               xaxisSubset = (CoverageCoordAxis1D) opt.get();
             else
               errMessages.format("xaxis: %s;%n", opt.getErrorMessage());
 
-            final double yMinInCorrectUnits = convertFromKm(projectionRectInKm.getMinY(), yAxis.units, yAxis.name);
-            final double yMaxInCorrectUnits = convertFromKm(projectionRectInKm.getMaxY(), yAxis.units, yAxis.name);
+            final double yMinInCorrectUnits = convertFromDefaultUnits(projectionRectInDefaultUnits.getMinY());
+            final double yMaxInCorrectUnits = convertFromDefaultUnits(projectionRectInDefaultUnits.getMaxY());
             opt = yAxis.subset(yMinInCorrectUnits, yMaxInCorrectUnits, horizStride);
             if (opt.isPresent())
               yaxisSubset = (CoverageCoordAxis1D) opt.get();
@@ -319,9 +321,7 @@ public class HorizCoordSys {
       double x = xAxis.getCoordMidpoint(xindex);
       double y = yAxis.getCoordMidpoint(yindex);
       ProjectionImpl proj = transform.getProjection();
-      final double xInKm = convertToKm(x, xAxis.units, xAxis.name);
-      final double yInKm = convertToKm(y, yAxis.units, yAxis.name);
-      return proj.projToLatLon(xInKm, yInKm);
+      return proj.projToLatLon(convertToDefaultUnits(x), convertToDefaultUnits(y));
     } else {
       double lat = latAxis.getCoordMidpoint(yindex);
       double lon = lonAxis.getCoordMidpoint(xindex);
@@ -662,8 +662,7 @@ public class HorizCoordSys {
 
     for (ProjectionPoint projPoint : projPoints) {
       final ProjectionPoint projPointInKm =
-          ProjectionPoint.create(convertToKm(projPoint.getX(), xAxis.units, xAxis.name),
-              convertToKm(projPoint.getY(), yAxis.units, yAxis.name));
+          ProjectionPoint.create(convertToDefaultUnits(projPoint.getX()), convertToDefaultUnits(projPoint.getY()));
 
       final LatLonPoint latLonPoint = transform.getProjection().projToLatLon(projPointInKm);
       if (!Double.isNaN(latLonPoint.getLatitude()) && !Double.isNaN(latLonPoint.getLongitude())) {
@@ -674,27 +673,22 @@ public class HorizCoordSys {
     return latLonPoints;
   }
 
-  // TODO is there a better place to handle units?
-  // Some projections are actually just rotations (RotatedPole)
-  // so the "projection" coordinates have units "degrees" and don't need to be converted
-  private static double convertToKm(double coordinate, String unit, String axisName) {
-    if (unit.equals("km") || unit.equals("kilometers")) {
-      return coordinate;
-    } else if (unit.equals("m") || unit.equals("meters")) {
-      return 0.001 * coordinate;
-    } else {
-      return coordinate;
+  private double getCoordinateConversionFactor() {
+    if (!isProjection) {
+      return 1.0;
     }
+
+    final String defaultUnits = transform.getProjection().getDefaultUnits();
+    final String unit = xAxis.getUnits();
+    return SimpleUnit.isCompatible(unit, defaultUnits) ? SimpleUnit.getConversionFactor(unit, defaultUnits) : 1.0;
   }
 
-  private static double convertFromKm(double coordinateInKm, String desiredUnit, String axisName) {
-    if (desiredUnit.equals("km") || desiredUnit.equals("kilometers")) {
-      return coordinateInKm;
-    } else if (desiredUnit.equals("m") || desiredUnit.equals("meters")) {
-      return 1000 * coordinateInKm;
-    } else {
-      return coordinateInKm;
-    }
+  private double convertToDefaultUnits(double coordinate) {
+    return coordinate * coordinateConversionFactor;
+  }
+
+  private double convertFromDefaultUnits(double coordinateInDefaultUnit) {
+    return coordinateInDefaultUnit / coordinateConversionFactor;
   }
 
   private List<LatLonPoint> calcLatLon2DBoundaryPoints(int maxPointsInYEdge, int maxPointsInXEdge) {

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/ProjectionImpl.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/ProjectionImpl.java
@@ -74,6 +74,11 @@ public abstract class ProjectionImpl implements Projection, java.io.Serializable
   protected String name; // LOOK should be final, IDV needs setName()
 
   /**
+   * name of the default units for this projection
+   */
+  protected String defaultUnits;
+
+  /**
    * flag for latlon
    */
   protected final boolean isLatLon;
@@ -95,6 +100,12 @@ public abstract class ProjectionImpl implements Projection, java.io.Serializable
    *         TODO return Projection in ver6
    */
   public abstract ProjectionImpl constructCopy();
+
+  protected ProjectionImpl(String name, String defaultUnits, boolean isLatLon) {
+    this.name = name;
+    this.defaultUnits = defaultUnits;
+    this.isLatLon = isLatLon;
+  }
 
   protected ProjectionImpl(String name, boolean isLatLon) {
     this.name = name;
@@ -207,6 +218,15 @@ public abstract class ProjectionImpl implements Projection, java.io.Serializable
   @Deprecated
   public void setName(String name) {
     this.name = name;
+  }
+
+  /**
+   * Get the name of the default units for this projection
+   *
+   * @return the name of the default units
+   */
+  public String getDefaultUnits() {
+    return defaultUnits;
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
@@ -24,7 +24,7 @@ import ucar.unidata.util.Parameter;
 
 public class LambertConformal extends ProjectionImpl {
   private static final String NAME = "LambertConformal";
-  private static String DEFAULT_UNITS = "km";
+  private static final String DEFAULT_UNITS = "km";
 
   private final double earth_radius;
   private double lat0, lon0; // lat/lon in radians

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertConformal.java
@@ -23,6 +23,9 @@ import ucar.unidata.util.Parameter;
  */
 
 public class LambertConformal extends ProjectionImpl {
+  private static final String NAME = "LambertConformal";
+  private static String DEFAULT_UNITS = "km";
+
   private final double earth_radius;
   private double lat0, lon0; // lat/lon in radians
   private double par1, par2; // standard parallel 1 and 2 degrees
@@ -100,7 +103,7 @@ public class LambertConformal extends ProjectionImpl {
   public LambertConformal(double lat0, double lon0, double par1, double par2, double false_easting,
       double false_northing, double earth_radius) {
 
-    super("LambertConformal", false);
+    super(NAME, DEFAULT_UNITS, false);
 
     this._lat0 = lat0;
     this._lon0 = lon0;

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -75,6 +75,7 @@ public class Geostationary extends ProjectionImpl {
   private static final String NAME = CF.GEOSTATIONARY;
   private static final String DEFAULT_UNITS = "radians";
 
+  // Remove in v6.x
   private boolean scaleGeoCoordinate;
   private double geoCoordinateScaleFactor = Double.MIN_VALUE;
 
@@ -83,10 +84,15 @@ public class Geostationary extends ProjectionImpl {
   public Geostationary(double subLonDegrees, double perspective_point_height, double semi_minor_axis,
       double semi_major_axis, double inv_flattening, boolean isSweepX) {
 
-    // scale factors (last two doubles in the sig) less than zero indicate no scaling of map x, y coordinates
+    // scale factors less than zero indicate no scaling of map x, y coordinates
     this(subLonDegrees, perspective_point_height, semi_minor_axis, semi_major_axis, inv_flattening, isSweepX, -1.0);
   }
 
+  /**
+   * @deprecated Remove in v6.x.
+   *             Use constructor without geoCoordinateScaleFactor as units are handled outside of projection classes
+   */
+  @Deprecated
   public Geostationary(double subLonDegrees, double perspective_point_height, double semi_minor_axis,
       double semi_major_axis, double inv_flattening, boolean isSweepX, double geoCoordinateScaleFactor) {
     super(NAME, DEFAULT_UNITS, false);
@@ -139,6 +145,11 @@ public class Geostationary extends ProjectionImpl {
     makePP();
   }
 
+  /**
+   * @deprecated Remove in v6.x.
+   *             Use constructor without geoCoordinateScaleFactor as units are handled outside of projection classes
+   */
+  @Deprecated
   public Geostationary(double subLonDegrees, String sweepAngleAxis, double geoCoordinateScaleFactor) {
     super(NAME, DEFAULT_UNITS, false);
 
@@ -166,6 +177,11 @@ public class Geostationary extends ProjectionImpl {
     addParameter(CF.SEMI_MINOR_AXIS, navigation.r_pol * 1000.0);
   }
 
+  /**
+   * @deprecated Remove in v6.x.
+   *             Units are handled outside of projection classes
+   */
+  @Deprecated
   private boolean isGeoCoordinateScaled() {
     return scaleGeoCoordinate && geoCoordinateScaleFactor > Double.MIN_VALUE;
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -73,7 +73,7 @@ public class Geostationary extends ProjectionImpl {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Geostationary.class);
 
   private static final String NAME = CF.GEOSTATIONARY;
-  private static String DEFAULT_UNITS = "radians";
+  private static final String DEFAULT_UNITS = "radians";
 
   private boolean scaleGeoCoordinate;
   private double geoCoordinateScaleFactor = Double.MIN_VALUE;

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/sat/Geostationary.java
@@ -73,6 +73,8 @@ public class Geostationary extends ProjectionImpl {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Geostationary.class);
 
   private static final String NAME = CF.GEOSTATIONARY;
+  private static String DEFAULT_UNITS = "radians";
+
   private boolean scaleGeoCoordinate;
   private double geoCoordinateScaleFactor = Double.MIN_VALUE;
 
@@ -87,7 +89,7 @@ public class Geostationary extends ProjectionImpl {
 
   public Geostationary(double subLonDegrees, double perspective_point_height, double semi_minor_axis,
       double semi_major_axis, double inv_flattening, boolean isSweepX, double geoCoordinateScaleFactor) {
-    super(NAME, false);
+    super(NAME, DEFAULT_UNITS, false);
 
     String sweepAngleAxis = "y";
     if (isSweepX) {
@@ -112,19 +114,19 @@ public class Geostationary extends ProjectionImpl {
   }
 
   public Geostationary() {
-    super(NAME, false);
+    super(NAME, DEFAULT_UNITS, false);
     navigation = new GEOSTransform();
     makePP();
   }
 
   public Geostationary(double subLonDegrees) {
-    super(NAME, false);
+    super(NAME, DEFAULT_UNITS, false);
     navigation = new GEOSTransform(subLonDegrees, GEOSTransform.GOES);
     makePP();
   }
 
   public Geostationary(double subLonDegrees, boolean isSweepX) {
-    super(NAME, false);
+    super(NAME, DEFAULT_UNITS, false);
 
     String sweepAngleAxis = "y";
     if (isSweepX) {
@@ -138,7 +140,7 @@ public class Geostationary extends ProjectionImpl {
   }
 
   public Geostationary(double subLonDegrees, String sweepAngleAxis, double geoCoordinateScaleFactor) {
-    super(NAME, false);
+    super(NAME, DEFAULT_UNITS, false);
 
     String scanGeometry = GEOSTransform.sweepAngleAxisToScanGeom(sweepAngleAxis);
 


### PR DESCRIPTION
## Description of Changes

Some NCSS requests are failing for satellite data (geostationary projection) when the x/y axes have units micro radians. This PR fixes this by moving the unit handling out of the projection class, into the `HorizCoordSys` class that is used by coverages. This PR contains:
- Add test
- Generalize unit handling in `HorizCoordSys` using the `SimpleUnits` to work for more than just km/m, given that a projection specifies its default unit.
- Remove/deprecate code in `Geostationary` related to unit handling.
- Add default unit to `Geostationary` and `LambertConformal` classes.
