### PR TITLE
Handle text on lines in ECMWF BUFR templates

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/tables/BufrTables.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/tables/BufrTables.java
@@ -1320,6 +1320,13 @@ public class BufrTables {
         continue;
 
       try {
+        // Delete everything in line that is not a space or a digit
+        // This handles cases where numbers are followed by text. Examples:
+        // 307046 5 020060 Metar/speci visibility
+        // or
+        // 307048 Trend forecast
+        line = line.replaceAll("[^\\d\\s]", "").trim();
+
         String fxys;
         // Need to do fixed-width parsing since, spaces can disappear (if
         // middle number is triple digits, it can end up right against the


### PR DESCRIPTION
## Description of Changes

Fixes line parsing for ECMWF BUFR templates.

I was parsing BUFR files and noticed that even the included ecmwf.D0000000000098013001.TXT file failed to be parsed due to comments after the three sections of numbers in some lines.

For the BUFR files I am parsing I'm using other templates which have the same problem - so I worked around that by cutting off the lines before handing them to tablelookup.csv and calling NetcdfFiles.openInMemory(filename)

However with this fix no such workaround is needed and since its also a problem for the file already in netcdf-java/bufr/src/main/resources/resources/bufrTables/local/ecmwf.D0000000000098013001.TXT I thought it would be good to include for all.

For unittest I tried including the file in netcdf-java/bufr/src/test/data but that makes the unittest fail - I suspect due missing bufr templates. If you have other ideas to try please let me know.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
