### PR TITLE
Fix disk cache cleanup sort errors caused by files being altered during sorting

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
@@ -348,7 +348,8 @@ public class DiskCache {
     }
 
     public int compare(File f1, File f2) {
-      return lastModified.getOrDefault(f2, DateTime.now().getMillis()).compareTo(lastModified.getOrDefault(f1, DateTime.now().getMillis()));
+      return lastModified.getOrDefault(f2, DateTime.now().getMillis())
+          .compareTo(lastModified.getOrDefault(f1, DateTime.now().getMillis()));
     }
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
@@ -342,7 +342,7 @@ public class DiskCache {
   private static class FileAgeComparator implements Comparator<File> {
     static Map<File, Long> lastModified;
 
-    public FileAgeComparator (List<File> fileList) {
+    public FileAgeComparator(List<File> fileList) {
       fileList.stream().forEach(file -> lastModified.put(file, file.lastModified()));
     }
 

--- a/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
@@ -291,13 +291,53 @@ public class DiskCache {
    * @param sbuff write results here, null is ok.
    */
   public static void cleanCache(long maxBytes, StringBuilder sbuff) {
-    cleanCache(maxBytes, new FileAgeComparator(), sbuff);
+    if (sbuff != null)
+      sbuff.append("DiskCache clean maxBytes= ").append(maxBytes).append("on dir ").append(root).append("\n");
+
+    File dir = new File(root);
+    long total = 0, total_delete = 0;
+
+    final File[] files = dir.listFiles();
+
+    if (files != null) {
+      final List<File> fileList = Arrays.asList(files);
+      final Map<File, Long> lastModifiedLut = new HashMap<File, Long>();
+      for (final File f : fileList) {
+        lastModifiedLut.put(f, f.lastModified());
+      }
+
+      Collections.sort(fileList, new Comparator<File>() {
+        @Override
+        public int compare(final File f1, final File f2) {
+          return lastModifiedLut.get(f2).compareTo(lastModifiedLut.get(f1));
+        }
+      });
+
+      for (File file : fileList) {
+        if (file.length() + total > maxBytes) {
+          total_delete += file.length();
+          if (sbuff != null)
+            sbuff.append(" delete ").append(file).append(" (").append(file.length()).append(")\n");
+          if (!file.delete() && sbuff != null)
+            sbuff.append("Error deleting ").append(file).append("\n");
+        } else {
+          total += file.length();
+        }
+      }
+    }
+    if (sbuff != null) {
+      sbuff.append("Total bytes deleted= ").append(total_delete).append("\n");
+      sbuff.append("Total bytes left in cache= ").append(total).append("\n");
+    }
   }
 
   /**
    * Remove files if needed to make cache have less than maxBytes bytes file sizes.
    * This will remove files in sort order defined by fileComparator.
    * The first files in the sort order are kept, until the max bytes is exceeded, then they are deleted.
+   *
+   * If a property of a file being compared changes while they are being sorted, the sort may not be correct due
+   * to what is a essentially a race condition. Java verions newer than 6 may detect this and throw an exception.
    *
    * @param maxBytes max number of bytes in cache.
    * @param fileComparator sort files first with this
@@ -330,15 +370,6 @@ public class DiskCache {
     if (sbuff != null) {
       sbuff.append("Total bytes deleted= ").append(total_delete).append("\n");
       sbuff.append("Total bytes left in cache= ").append(total).append("\n");
-    }
-  }
-
-  // reverse sort - latest come first
-  private static class FileAgeComparator implements Comparator<File> {
-    public int compare(File f1, File f2) {
-      long f1Age = f1.lastModified();
-      long f2Age = f2.lastModified();
-      return Long.compare(f2Age, f1Age); // Steve Ansari 6/3/2010
     }
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
@@ -6,6 +6,7 @@ package ucar.nc2.util;
 
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
+import org.joda.time.DateTime;
 import ucar.unidata.util.StringUtil2;
 import java.io.*;
 import java.util.*;
@@ -347,7 +348,7 @@ public class DiskCache {
     }
 
     public int compare(File f1, File f2) {
-      return lastModified.get(f2).compareTo(lastModified.get(f1));
+      return lastModified.getOrDefault(f2, DateTime.now().getMillis()).compareTo(lastModified.getOrDefault(f1, DateTime.now().getMillis()));
     }
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/DiskCache.java
@@ -341,7 +341,7 @@ public class DiskCache {
 
   // reverse sort - latest come first
   private static class FileAgeComparator implements Comparator<File> {
-    static Map<File, Long> lastModified;
+    static final Map<File, Long> lastModified = new HashMap<>();
 
     public FileAgeComparator(List<File> fileList) {
       fileList.stream().forEach(file -> lastModified.put(file, file.lastModified()));


### PR DESCRIPTION
## Description of Changes

Java versions newer than 6 check that the sort invariant is maintained. If a cached file is modified during sort, then the modified time changes, violating the invariant and causing an exception to be thrown. Previously, this would have silently caused the resulting sort to be incorrect.

Neither of these results are ideal, but throwing an exception causes the cache cleanup to fail, which can lead to unexpectedly high cache usage.

A quick and nasty hack to revert to Java 6 behaviour is to insert `System.setProperty("java.util.Arrays.useLegacyMergeSort", "true");` somewhere, but it is better to fix the sort completely.

This PR caches the file modification times and looks them up during the sort.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] ~Link to any issues that the PR addresses~
- [ ] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
