### PR TITLE
Fix rounding when computing time offsets

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionTimeUnits.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionTimeUnits.java
@@ -63,9 +63,9 @@ public class TestGribCollectionTimeUnits {
         MIXED_UNITS_SPEC, null, null, null, "file", null);
 
     setTimeUnitConversionFromMinutesToHours(config);
-    // hours get rounded down due to refdate being on the half hour
-    final double[] valuesInHours = new double[] {5.0, 11.0, 17.0, 23.0, 29.0, 35.0, 41.0, 47.0, 53.0, 59.0, 65.0, 71.0};
-    checkVariableNameAndTimeAxis(config, "6_Hour", "time2", "Hour", valuesInHours);
+    // hours get rounded up due to refdate being on the half hour
+    final double[] valuesInHours = new double[] {6.0, 13.0, 19.0, 25.0, 31.0, 37.0, 43.0, 49.0, 55.0, 61.0, 67.0, 73.0};
+    checkVariableNameAndTimeAxis(config, "6_Hour", "time4", "Hour", valuesInHours);
   }
 
   private void setTimeUnitConversionFromMinutesToHours(FeatureCollectionConfig config) {

--- a/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
+++ b/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
@@ -167,7 +167,7 @@ public class CalendarPeriod {
 
   /**
    * Subtract two dates, return difference in units of this period.
-   * If not even, will round down (take the floor)
+   * If not even, will round to nearest int
    * 
    * @param start start date
    * @param end end date
@@ -176,7 +176,8 @@ public class CalendarPeriod {
   public int subtract(CalendarDate start, CalendarDate end) {
     long diff = end.getDifferenceInMsecs(start);
     int thislen = millisecs();
-    return (int) Math.floor(diff / (float) thislen);
+    int signOfDiff = (int) (diff / Math.abs(diff));
+    return signOfDiff * Math.round(Math.abs(diff) / (float) thislen);
   }
 
   /**
@@ -234,7 +235,7 @@ public class CalendarPeriod {
 
   // offset from start to end, in these units
   // start + offset = end
-  // takes the floor when rounding
+  // rounds to nearest int
   public int getOffset(CalendarDate start, CalendarDate end) {
     if (start.equals(end)) {
       return 0;

--- a/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
+++ b/cdm/core/src/main/java/ucar/nc2/time/CalendarPeriod.java
@@ -175,6 +175,9 @@ public class CalendarPeriod {
    */
   public int subtract(CalendarDate start, CalendarDate end) {
     long diff = end.getDifferenceInMsecs(start);
+    if (diff == 0) {
+      return 0;
+    }
     int thislen = millisecs();
     int signOfDiff = (int) (diff / Math.abs(diff));
     return signOfDiff * Math.round(Math.abs(diff) / (float) thislen);

--- a/cdm/core/src/test/java/ucar/nc2/time/TestCalendarPeriod.java
+++ b/cdm/core/src/test/java/ucar/nc2/time/TestCalendarPeriod.java
@@ -16,4 +16,18 @@ public class TestCalendarPeriod {
     assertThat(offset).isEqualTo(3);
   }
 
+  @Test
+  public void shouldGiveSymmetricResultsWhenRounding() {
+    final CalendarPeriod calendarPeriod = CalendarPeriod.of(1, Field.Hour);
+    final CalendarDate start = CalendarDate.parseISOformat(null, "2000-01-01T00:00:00Z");
+
+    final CalendarDate end = CalendarDate.parseISOformat(null, "2000-01-01T00:10:00Z");
+    assertThat(calendarPeriod.subtract(start, end)).isEqualTo(-calendarPeriod.subtract(end, start));
+
+    final CalendarDate end2 = CalendarDate.parseISOformat(null, "2000-01-01T00:50:00Z");
+    assertThat(calendarPeriod.subtract(start, end2)).isEqualTo(-calendarPeriod.subtract(end2, start));
+
+    final CalendarDate end3 = CalendarDate.parseISOformat(null, "2000-01-01T00:30:00Z");
+    assertThat(calendarPeriod.subtract(start, end3)).isEqualTo(-calendarPeriod.subtract(end3, start));
+  }
 }

--- a/cdm/core/src/test/java/ucar/nc2/time/TestCalendarPeriod.java
+++ b/cdm/core/src/test/java/ucar/nc2/time/TestCalendarPeriod.java
@@ -1,15 +1,19 @@
 package ucar.nc2.time;
 
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
 import ucar.nc2.time.CalendarPeriod.Field;
 
 public class TestCalendarPeriod {
 
-  public void testStuff() {
-    CalendarPeriod cp = CalendarPeriod.of(1, Field.Day);
-    CalendarDate start = CalendarDate.parseUdunits(null, "3 days since 1970-01-01 12:00");
-    CalendarDate end = CalendarDate.parseUdunits(null, "6 days since 1970-01-01 12:00");
-    int offset = cp.getOffset(start, end);
-    System.out.printf("offset=%d%n", offset);
+  @Test
+  public void shouldGetOffset() {
+    final CalendarPeriod cp = CalendarPeriod.of(1, Field.Day);
+    final CalendarDate start = CalendarDate.parseUdunits(null, "3 days since 1970-01-01 12:00");
+    final CalendarDate end = CalendarDate.parseUdunits(null, "6 days since 1970-01-01 12:00");
+    final int offset = cp.getOffset(start, end);
+    assertThat(offset).isEqualTo(3);
   }
 
 }

--- a/grib/src/main/java/ucar/nc2/grib/coord/TimeCoordIntvDateValue.java
+++ b/grib/src/main/java/ucar/nc2/grib/coord/TimeCoordIntvDateValue.java
@@ -60,7 +60,7 @@ public class TimeCoordIntvDateValue implements Comparable<TimeCoordIntvDateValue
       throw new IllegalArgumentException("null time unit");
     }
     int startOffset = timeUnit.getOffset(refDate, start); // LOOK wrong - not dealing with value ??
-    int endOffset = timeUnit.getOffset(refDate, end);
+    int endOffset = timeUnit.getOffset(start, end) + startOffset;
     return new TimeCoordIntvValue(startOffset, endOffset);
   }
 

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
@@ -33,8 +33,8 @@ public class TestTimeCoord {
 
     final CalendarDate refDate = CalendarDate.parseISOformat(null, "2022-08-16T00:30:00Z");
     final TimeCoordIntvValue timeCoordIntvValue = timeCoordIntvDateValue.convertReferenceDate(refDate, timeUnit);
-    assertThat(timeCoordIntvValue.getBounds1()).isEqualTo(0);
-    assertThat(timeCoordIntvValue.getBounds2()).isEqualTo(11);
+    assertThat(timeCoordIntvValue.getBounds1()).isEqualTo(1);
+    assertThat(timeCoordIntvValue.getBounds2()).isEqualTo(12);
     assertThat(timeCoordIntvValue.getIntervalSize()).isEqualTo(11);
 
     final CalendarDate refDate2 = CalendarDate.parseISOformat(null, "2022-08-16T00:40:00Z");
@@ -45,8 +45,8 @@ public class TestTimeCoord {
 
     final CalendarDate refDate3 = CalendarDate.parseISOformat(null, "2022-08-16T00:20:00Z");
     final TimeCoordIntvValue timeCoordIntvValue3 = timeCoordIntvDateValue.convertReferenceDate(refDate3, timeUnit);
-    assertThat(timeCoordIntvValue3.getBounds1()).isEqualTo(0);
-    assertThat(timeCoordIntvValue3.getBounds2()).isEqualTo(11);
+    assertThat(timeCoordIntvValue3.getBounds1()).isEqualTo(1);
+    assertThat(timeCoordIntvValue3.getBounds2()).isEqualTo(12);
     assertThat(timeCoordIntvValue3.getIntervalSize()).isEqualTo(11);
   }
 
@@ -71,8 +71,8 @@ public class TestTimeCoord {
 
     final CalendarDate refDate3 = CalendarDate.parseISOformat(null, "2022-08-16T01:20:00Z");
     final TimeCoordIntvValue timeCoordIntvValue3 = timeCoordIntvDateValue.convertReferenceDate(refDate3, timeUnit);
-    assertThat(timeCoordIntvValue3.getBounds1()).isEqualTo(-1);
-    assertThat(timeCoordIntvValue3.getBounds2()).isEqualTo(10);
+    assertThat(timeCoordIntvValue3.getBounds1()).isEqualTo(0);
+    assertThat(timeCoordIntvValue3.getBounds2()).isEqualTo(11);
     assertThat(timeCoordIntvValue3.getIntervalSize()).isEqualTo(11);
   }
 }

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
@@ -3,12 +3,9 @@ package ucar.nc2.grib.coord;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarPeriod;
 
-@RunWith(JUnit4.class)
 public class TestTimeCoord {
 
   @Test

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestTimeCoord.java
@@ -29,14 +29,25 @@ public class TestTimeCoord {
     final CalendarDate start = CalendarDate.parseISOformat(null, "2022-08-16T01:00:00Z");
     final CalendarDate end = CalendarDate.parseISOformat(null, "2022-08-16T12:00:00Z");
     final TimeCoordIntvDateValue timeCoordIntvDateValue = new TimeCoordIntvDateValue(start, end);
-
-    final CalendarDate refDate = CalendarDate.parseISOformat(null, "2022-08-16T00:30:00Z");
     final CalendarPeriod timeUnit = CalendarPeriod.of("Hour");
 
+    final CalendarDate refDate = CalendarDate.parseISOformat(null, "2022-08-16T00:30:00Z");
     final TimeCoordIntvValue timeCoordIntvValue = timeCoordIntvDateValue.convertReferenceDate(refDate, timeUnit);
     assertThat(timeCoordIntvValue.getBounds1()).isEqualTo(0);
     assertThat(timeCoordIntvValue.getBounds2()).isEqualTo(11);
     assertThat(timeCoordIntvValue.getIntervalSize()).isEqualTo(11);
+
+    final CalendarDate refDate2 = CalendarDate.parseISOformat(null, "2022-08-16T00:40:00Z");
+    final TimeCoordIntvValue timeCoordIntvValue2 = timeCoordIntvDateValue.convertReferenceDate(refDate2, timeUnit);
+    assertThat(timeCoordIntvValue2.getBounds1()).isEqualTo(0);
+    assertThat(timeCoordIntvValue2.getBounds2()).isEqualTo(11);
+    assertThat(timeCoordIntvValue2.getIntervalSize()).isEqualTo(11);
+
+    final CalendarDate refDate3 = CalendarDate.parseISOformat(null, "2022-08-16T00:20:00Z");
+    final TimeCoordIntvValue timeCoordIntvValue3 = timeCoordIntvDateValue.convertReferenceDate(refDate3, timeUnit);
+    assertThat(timeCoordIntvValue3.getBounds1()).isEqualTo(0);
+    assertThat(timeCoordIntvValue3.getBounds2()).isEqualTo(11);
+    assertThat(timeCoordIntvValue3.getIntervalSize()).isEqualTo(11);
   }
 
   @Test
@@ -44,14 +55,25 @@ public class TestTimeCoord {
     final CalendarDate start = CalendarDate.parseISOformat(null, "2022-08-16T01:00:00Z");
     final CalendarDate end = CalendarDate.parseISOformat(null, "2022-08-16T12:00:00Z");
     final TimeCoordIntvDateValue timeCoordIntvDateValue = new TimeCoordIntvDateValue(start, end);
-
-    final CalendarDate refDate = CalendarDate.parseISOformat(null, "2022-08-16T01:30:00Z");
     final CalendarPeriod timeUnit = CalendarPeriod.of("Hour");
 
+    final CalendarDate refDate = CalendarDate.parseISOformat(null, "2022-08-16T01:30:00Z");
     final TimeCoordIntvValue timeCoordIntvValue = timeCoordIntvDateValue.convertReferenceDate(refDate, timeUnit);
     assertThat(timeCoordIntvValue.getBounds1()).isEqualTo(-1);
     assertThat(timeCoordIntvValue.getBounds2()).isEqualTo(10);
     assertThat(timeCoordIntvValue.getIntervalSize()).isEqualTo(11);
+
+    final CalendarDate refDate2 = CalendarDate.parseISOformat(null, "2022-08-16T01:40:00Z");
+    final TimeCoordIntvValue timeCoordIntvValue2 = timeCoordIntvDateValue.convertReferenceDate(refDate2, timeUnit);
+    assertThat(timeCoordIntvValue2.getBounds1()).isEqualTo(-1);
+    assertThat(timeCoordIntvValue2.getBounds2()).isEqualTo(10);
+    assertThat(timeCoordIntvValue2.getIntervalSize()).isEqualTo(11);
+
+    final CalendarDate refDate3 = CalendarDate.parseISOformat(null, "2022-08-16T01:20:00Z");
+    final TimeCoordIntvValue timeCoordIntvValue3 = timeCoordIntvDateValue.convertReferenceDate(refDate3, timeUnit);
+    assertThat(timeCoordIntvValue3.getBounds1()).isEqualTo(-1);
+    assertThat(timeCoordIntvValue3.getBounds2()).isEqualTo(10);
+    assertThat(timeCoordIntvValue3.getIntervalSize()).isEqualTo(11);
   }
 }
 


### PR DESCRIPTION
## Description of Changes

Accessing MRMS data through NCSS leads to NaNs for all values at certain times. This happens due to the computed offset being incorrect (in `CoordsSet::addAdjustedTimeCoords`), due to the fact that `CalendarPeriod::subtract` does not have the property `subtract(a, b) = - subtract(b, a)`. This error was introduced by https://github.com/Unidata/netcdf-java/pull/1099, where I changed the rounding from `(int)` to `Math.floor`. Of course, we could fix this issue at the call site of `subtract`, but it seems less error prone to fix `subtract` itself. There are two ways to fix this-- go back to casting to `int` or use `Math.round`. In the MRMS data I was looking at, the offsets are `0.0, 1.99, 4.0, ...` so it just makes more sense to me to round these to `0, 2, 4` rather than truncate to ints.

This change again messes up interval lengths when the reftime is after the start of the interval. This is fixed by the change in `TimeCoordIntvDateValue::convertReferenceDate`.
