### PR TITLE
Update bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Non-security related issues regarding this software
-title: ""
 labels: [bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,27 +1,18 @@
 name: Bug Report
 description: Non-security related issues regarding this software
-title: "[VERSION]: "
+title: ""
 labels: [bug]
 body:
   - type: markdown
     attributes:
-      value: |
-        :point_up: **Please edit the title above to include the highest version, of which you are aware, of netCDF-Java impacted by this bug in the title of the issue.**
-        
+      value: |        
         Thank you for taking the time to fill out this bug report! If you have a question, suggestion, or feature request, please use the project [GitHub Discussions forum](https://github.com/Unidata/netcdf-java/discussions/).
         
-  - type: dropdown
+  - type: textarea
     id: versions
     attributes:
       label: Versions impacted by the bug
       description: Which version(s) of netCDF-Java are impacted by this bug? If you have only tried with one version, that is ok!
-      multiple: true
-      options:
-        - v5.x
-        - v6.x
-        - v7.x
-    validations:
-      required: true
   - type: textarea
     id: report-details
     attributes:


### PR DESCRIPTION
## Description of Changes

Remove mentions of v6, v7 from bug issue template and the "[VERSION]: " from issue template's title.

You can sort of preview this change better if you look at my branch here: https://github.com/tdrwenski/netcdf-java/blob/update-issue-template/.github/ISSUE_TEMPLATE/bug_report.yml

compared to on maint-5.x: https://github.com/Unidata/netcdf-java/blob/maint-5.x/.github/ISSUE_TEMPLATE/bug_report.yml