### PR TITLE
Do not create reftime scalar dimension in individual grib file

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
@@ -6,6 +6,7 @@ package ucar.nc2.grib;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -16,6 +17,7 @@ import thredds.featurecollection.FeatureCollectionConfig;
 import thredds.featurecollection.FeatureCollectionType;
 import thredds.inventory.CollectionUpdateType;
 import ucar.ma2.ArrayDouble;
+import ucar.nc2.Dimension;
 import ucar.nc2.Variable;
 import ucar.nc2.dataset.*;
 import ucar.nc2.grib.collection.*;
@@ -153,6 +155,15 @@ public class TestGribCollectionCoordinates {
     assertThat(ok).isTrue();
   }
 
+  @Test
+  public void shouldNotAddScalarReftimeDimension() throws IOException {
+    final String path = TestDir.cdmUnitTestDir + "gribCollections/mrms/MRMS_CONUS_BaseReflectivity_20230918_1700.grib2";
 
-
+    try (NetcdfDataset ds = NetcdfDatasets.openDataset(path)) {
+      final List<Dimension> dimensions = ds.getRootGroup().getDimensions();
+      for (Dimension dimension : dimensions) {
+        assertThat(dimension.getName()).doesNotContain("reftime");
+      }
+    }
+  }
 }

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
@@ -50,32 +50,6 @@ public class TestGribCollectionCoordinates {
   @AfterClass
   public static void after() {
     Grib.setDebugFlags(new DebugFlagsImpl());
-    /*
-     * Formatter out = new Formatter(System.out);
-     * 
-     * FileCacheIF cache = GribCdmIndex.gribCollectionCache;
-     * if (cache != null) {
-     * cache.showTracking(out);
-     * cache.showCache(out);
-     * cache.clearCache(false);
-     * }
-     * 
-     * FileCacheIF rafCache = RandomAccessFile.getGlobalFileCache();
-     * if (rafCache != null) {
-     * rafCache.showCache(out);
-     * }
-     * 
-     * System.out.printf("            countGC=%7d%n", GribCollectionImmutable.countGC);
-     * System.out.printf("            countPC=%7d%n", PartitionCollectionImmutable.countPC);
-     * System.out.printf("    countDataAccess=%7d%n", GribIosp.debugIndexOnlyCount);
-     * System.out.printf(" total files needed=%7d%n", GribCollectionImmutable.countGC +
-     * PartitionCollectionImmutable.countPC + GribIosp.debugIndexOnlyCount);
-     * 
-     * FileCache.shutdown();
-     * RandomAccessFile.setGlobalFileCache(null);
-     * TestDir.checkLeaks();
-     * RandomAccessFile.setDebugLeaks(false);
-     */
   }
 
   /////////////////////////////////////////////////////////

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
@@ -66,7 +66,7 @@ public class TestGribCollectionCoordinates {
     boolean changed = GribCdmIndex.updateGribCollection(config, CollectionUpdateType.always, logger);
     String topLevelIndex = GribCdmIndex.getTopIndexFileFromConfig(config).getAbsolutePath();
 
-    System.out.printf("changed = %s%n", changed);
+    logger.debug("changed = {}", changed);
 
     boolean ok = true;
 
@@ -76,7 +76,7 @@ public class TestGribCollectionCoordinates {
         if (!stdname.equalsIgnoreCase("time"))
           continue;
 
-        System.out.printf(" %s == %s%n", vds.getFullName(), vds.getClass().getName());
+        logger.debug(" {} == {}", vds.getFullName(), vds.getClass().getName());
         assert vds instanceof CoordinateAxis : vds.getFullName();
 
         // test that zero Intervals are removed
@@ -86,7 +86,7 @@ public class TestGribCollectionCoordinates {
             for (int i = 0; i < axis.getSize(); i++) {
               double[] bound = axis.getCoordBounds(i);
               if (bound[0] == bound[1]) {
-                System.out.printf("ERR1 %s(%d) = [%f,%f]%n", vds.getFullName(), i, bound[0], bound[1]);
+                logger.debug("ERR1 {}({}) = [{},{}]", vds.getFullName(), i, bound[0], bound[1]);
                 ok = false;
               }
             }
@@ -101,7 +101,7 @@ public class TestGribCollectionCoordinates {
                 double start = bounds.get(i, j, 0);
                 double end = bounds.get(i, j, 1);
                 if (start == end) {
-                  System.out.printf("ERR2 %s(%d,%d) = [%f,%f]%n", vds.getFullName(), i, j, start, end);
+                  logger.debug("ERR2 {}({},{}) = [{},{}]", vds.getFullName(), i, j, start, end);
                   ok = false;
                 }
               }
@@ -121,7 +121,7 @@ public class TestGribCollectionCoordinates {
             TestDir.cdmUnitTestDir + "gribCollections/gfs_2p5deg/.*grib2", null, null, null, "file", null);
 
     boolean changed = GribCdmIndex.updateGribCollection(config, updateMode, logger);
-    System.out.printf("changed = %s%n", changed);
+    logger.debug("changed = {}", changed);
     String topLevelIndex = GribCdmIndex.getTopIndexFileFromConfig(config).getAbsolutePath();
     boolean ok = true;
 
@@ -131,7 +131,7 @@ public class TestGribCollectionCoordinates {
         if (!stdname.equalsIgnoreCase("forecast_reference_time"))
           continue;
 
-        System.out.printf(" %s == %s%n", vds.getFullName(), vds.getClass().getName());
+        logger.debug(" {} == {}", vds.getFullName(), vds.getClass().getName());
         assert vds instanceof CoordinateAxis1D : vds.getFullName();
         CoordinateAxis1D axis = (CoordinateAxis1D) vds;
 
@@ -140,7 +140,7 @@ public class TestGribCollectionCoordinates {
         for (int i = 0; i < axis.getSize(); i++) {
           double val = axis.getCoordValue(i);
           if (i > 0 && (val < last)) {
-            System.out.printf("  %s(%d) == %f < %f%n", vds.getFullName(), i, val, last);
+            logger.debug("  {}({}) == {} < {}", vds.getFullName(), i, val, last);
             ok = false;
           }
           last = val;

--- a/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
+++ b/cdm-test/src/test/java/ucar/nc2/grib/TestGribCollectionCoordinates.java
@@ -4,6 +4,8 @@
  */
 package ucar.nc2.grib;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -77,7 +79,7 @@ public class TestGribCollectionCoordinates {
           continue;
 
         logger.debug(" {} == {}", vds.getFullName(), vds.getClass().getName());
-        assert vds instanceof CoordinateAxis : vds.getFullName();
+        assertThat((Object) vds).isInstanceOf(CoordinateAxis.class);
 
         // test that zero Intervals are removed
         if (vds instanceof CoordinateAxis1D) {
@@ -110,7 +112,7 @@ public class TestGribCollectionCoordinates {
       }
     }
 
-    assert ok;
+    assertThat(ok).isTrue();
   }
 
   // make sure Best reftimes always increase
@@ -132,7 +134,7 @@ public class TestGribCollectionCoordinates {
           continue;
 
         logger.debug(" {} == {}", vds.getFullName(), vds.getClass().getName());
-        assert vds instanceof CoordinateAxis1D : vds.getFullName();
+        assertThat((Object) vds).isInstanceOf(CoordinateAxis.class);
         CoordinateAxis1D axis = (CoordinateAxis1D) vds;
 
         // test that values are monotonic
@@ -148,7 +150,7 @@ public class TestGribCollectionCoordinates {
       }
     }
 
-    assert ok;
+    assertThat(ok).isTrue();
   }
 
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIosp.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIosp.java
@@ -535,7 +535,9 @@ public abstract class GribIosp extends AbstractIOServiceProvider {
     boolean isScalar = (n == 1); // this is the case of runtime[1]
     String tcName = rtc.getName();
     String dims = isScalar ? null : rtc.getName(); // null means scalar
-    ncfile.addDimension(g, new Dimension(tcName, n));
+    if (!isScalar) {
+      ncfile.addDimension(g, new Dimension(tcName, n));
+    }
 
     Variable v = ncfile.addVariable(g, new Variable(ncfile, g, null, tcName, DataType.DOUBLE, dims));
     v.addAttribute(new Attribute(CDM.UNITS, rtc.getUnit()));

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
@@ -357,8 +357,9 @@ class GribIospBuilder {
     boolean isScalar = (n == 1); // this is the case of runtime[1]
     String tcName = rtc.getName();
     String dims = isScalar ? null : rtc.getName(); // null means scalar
-    g.addDimension(new Dimension(tcName, n));
-
+    if (!isScalar) {
+      g.addDimension(new Dimension(tcName, n));
+    }
 
     Variable.Builder<?> v = Variable.builder().setName(tcName).setDataType(DataType.DOUBLE).setParentGroupBuilder(g)
         .setDimensionsByName(dims);


### PR DESCRIPTION
## Description of Changes

Should resolve https://github.com/Unidata/tds/issues/370 though I could not reproduce the error in xarray (see [comment](https://github.com/Unidata/tds/issues/370#issuecomment-1739857813)). 

This PR:
- Do not create a scalar reftime dimension that is not used anyways
- Test with MRMS data
- Test cleanups

Passes on Jenkins: https://jenkins-aws.unidata.ucar.edu/view/Users/job/tara-netcdf-java/31/