### PR TITLE
Fix renamed variable reading in aggregations

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDataset.java
@@ -145,6 +145,10 @@ class AggDataset implements Comparable<AggDataset> {
         return null;
 
       Variable v = findVariable(ncd, mainv);
+      if (v == null) {
+        Aggregation.logger.error("AggDataset can't find " + mainv.getFullName() + " in " + ncd.getLocation());
+        throw new IllegalArgumentException("Variable '" + mainv.getFullName() + "' does not exist in aggregation.");
+      }
       if (debugRead)
         System.out.printf("Agg.read %s from %s in %s%n", mainv.getNameAndDimensions(), v.getNameAndDimensions(),
             getLocation());

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
@@ -285,10 +285,8 @@ class AggDatasetOuter extends AggDataset {
 
       Variable v = findVariable(ncd, mainv);
       if (v == null) {
-        Aggregation.logger.error("AggOuterDimension cant find " + mainv.getFullName() + " in " + ncd.getLocation()
-            + "; return all zeroes!!!");
-        return Array.factory(mainv.getDataType(), new Section(section).getShape()); // all zeros LOOK need missing
-                                                                                    // value
+        Aggregation.logger.error("AggOuterDimension can't find " + mainv.getFullName() + " in " + ncd.getLocation());
+        throw new IllegalArgumentException("Variable '" + mainv.getFullName() + "' does not exist in aggregation.");
       }
 
       if (Aggregation.debugRead) {

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -989,7 +989,7 @@ public class NcmlReader {
             .orElseThrow(() -> new IllegalStateException("Cant find variable " + nameInFile));
       }
     }
-    vb.setName(name).setDataType(dtype);
+    vb.setOriginalName(nameInFile).setName(name).setDataType(dtype);
     if (typedefS != null) {
       vb.setEnumTypeName(typedefS);
     }

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestRenameVariableInAggregation.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestRenameVariableInAggregation.java
@@ -1,0 +1,67 @@
+package ucar.nc2.internal.ncml;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.io.StringReader;
+import org.junit.Test;
+import ucar.ma2.Array;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.Section;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+
+public class TestRenameVariableInAggregation {
+  private static final double TOLERANCE = 1.0e-6;
+
+  @Test
+  public void shouldRenameVariableUsedInAggregation() throws IOException, InvalidRangeException {
+    final String ncml = "<?xml version='1.0' encoding='UTF-8'?>\n" // leavit
+        + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" // leavit
+        + "  <variable name='temperature' orgName='T' />\n" // leavit
+        + "  <aggregation  dimName='time' type='joinNew'>\n" // leavit
+        + "    <variableAgg name='T'/>\n" // leavit
+        + "    <netcdf location='src/test/data/ncml/nc/scalarTime0.nc'/>\n" // leavit
+        + "    <netcdf location='src/test/data/ncml/nc/scalarTime1.nc'/>\n" // leavit
+        + "    <netcdf location='src/test/data/ncml/nc/scalarTime2.nc'/>\n" // leavit
+        + "  </aggregation>\n" // leavit
+        + "</netcdf>"; // leavit
+
+    checkNcmlDataset(ncml);
+  }
+
+  @Test
+  public void shouldRenameVariableUsedInAggregationWithScan() throws IOException, InvalidRangeException {
+    final String ncml = "<?xml version='1.0' encoding='UTF-8'?>\n" // leavit
+        + "<netcdf xmlns='http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2'>\n" // leavit
+        + "  <variable name='temperature' orgName='T' />\n" // leavit
+        + "  <aggregation  dimName='time' type='joinNew'>\n" // leavit
+        + "    <variableAgg name='T'/>\n" // leavit
+        + "    <scan location='src/test/data/ncml/nc/' subdirs='false' regExp='scalarTime.*nc'/>\n" // leavit
+        + "  </aggregation>\n" // leavit
+        + "</netcdf>"; // leavit
+
+    checkNcmlDataset(ncml);
+  }
+
+  private static void checkNcmlDataset(String ncml) throws InvalidRangeException, IOException {
+    try (NetcdfFile ncfile = NcmlReader.readNcml(new StringReader(ncml), null, null).build()) {
+      final Variable oldVariable = ncfile.findVariable("T");
+      assertThat((Object) oldVariable).isNull();
+      final Variable newVariable = ncfile.findVariable("temperature");
+      assertThat((Object) newVariable).isNotNull();
+
+      final Array partialArray = newVariable.read(new Section("0:2, 0:0, 0:0"));
+      assertThat(partialArray.getSize()).isEqualTo(3);
+      assertThat(partialArray.getDouble(0)).isWithin(TOLERANCE).of(0.0);
+      assertThat(partialArray.getDouble(1)).isWithin(TOLERANCE).of(100.0);
+      assertThat(partialArray.getDouble(2)).isWithin(TOLERANCE).of(200.0);
+
+      final Array array = newVariable.read();
+      assertThat(array.getSize()).isEqualTo(36);
+      assertThat(array.getDouble(0)).isWithin(TOLERANCE).of(0.0);
+      assertThat(array.getDouble(12)).isWithin(TOLERANCE).of(100.0);
+      assertThat(array.getDouble(24)).isWithin(TOLERANCE).of(200.0);
+    }
+  }
+}


### PR DESCRIPTION
## Description of Changes

- Fix a bug that caused variables that are both renamed and used in an aggregation to not be found. The fix for this is just adding the original name to the variable builder. This bug only affected aggregations with a list of locations, and not aggregations with a scan.
- Add tests for variables renamed and used in aggregation and aggregation with scan.
- Throw exception for variables not found in an aggregation-- previously it would either give a nullptr exception or return all zeros for that variable depending if all or part of data was requested.
