### PR TITLE
Fix handling of the dap4: protocol.

### DIFF
--- a/dap4/build.gradle
+++ b/dap4/build.gradle
@@ -32,11 +32,9 @@ test {
   include 'dap4/test/TestParserCE.class'
   include 'dap4/test/TestRaw.class'
   include 'dap4/test/TestDap4Url.class'
-if(false) { // disable selected dap4 tests for now
   include 'dap4/test/TestRemote.class'
   include 'dap4/test/TestConstraints.class'
   include 'dap4/test/TestHyrax.class'
-}
 
   dependsOn('farmBeforeIntegrationTest')
   finalizedBy('farmAfterIntegrationTest')

--- a/dap4/src/main/java/dap4/core/util/XURI.java
+++ b/dap4/src/main/java/dap4/core/util/XURI.java
@@ -266,6 +266,19 @@ public class XURI {
   }
 
   /**
+   * Allow fragment fields to be inserted
+   *
+   * @param key
+   * @param newval
+   * @return previous value or this value if key not set
+   */
+  public void insertFragmentField(String key, String newval) {
+    // Watch out in case there is no query
+    this.fragfields = insertAmpField(key, newval, parent.getFragment());
+    rebuildQuery();
+  }
+
+  /**
    * Allow queryfields to be removed
    *
    * @param key

--- a/dap4/src/main/java/dap4/dap4lib/cdm/nc2/DapNetcdfFile.java
+++ b/dap4/src/main/java/dap4/dap4lib/cdm/nc2/DapNetcdfFile.java
@@ -128,6 +128,13 @@ public class DapNetcdfFile extends NetcdfFile {
     } catch (URISyntaxException use) {
       throw new IOException(use);
     }
+    // We need to convert the protocol to #dap4
+    if ("dap4".equalsIgnoreCase(xuri.getScheme())) {
+      xuri.setScheme("https"); // Note that this should be https, but
+                               // test.opendap.org still uses http; one
+                               // hopes that other servers are setup to
+                               // redirect http: to https:
+    }
     this.dsplocation = xuri.assemble(XURI.URLQUERY);
     cancel = (cancelTask == null ? nullcancel : cancelTask);
 


### PR DESCRIPTION
re: Issue https://github.com/Unidata/netcdf-java/issues/985

## Description of Changes
The DAP4 code was improperly handling the use of the "dap4:" protocol in a URL. This PR fixes it by detecting that protocol and doing two actions:
1. Convert the protocol to "http:".
2. Add the fragment "#dap4" to end of the URL.

Note that in action 1, this should really be https, but test.opendap.org (a Hyrax server) still accepts only http; one hopes that other servers are setup to redirect http: to https:

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) until ready for review
- [X] Make sure GitHub tests pass
- [X] Mark PR as "Ready for Review"
