### PR TITLE
[5.5.3] Fix GRIB IOSP time coords from intervals, for 2-D time FMRC Best datasets

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribIospBuilder.java
@@ -552,13 +552,12 @@ class GribIospBuilder {
     v.addAttribute(new Attribute(CDM.LONG_NAME, Grib.GRIB_VALID_TIME));
     v.addAttribute(new Attribute(CF.CALENDAR, Calendar.proleptic_gregorian.toString()));
 
-    double[] data = new double[ntimes];
-    int count = 0;
-
-    for (TimeCoordIntvValue tinv : coordTime.getTimeIntervals()) {
-      data[count++] = tinv.getCoordValue();
-    }
-    v.setCachedData(Array.factory(DataType.DOUBLE, new int[] {ntimes}, data), false);
+    double[] timeCoordValues = new double[ntimes];
+    double[] timeCoordBoundsValues = new double[ntimes * 2];
+    int count = GribTimeCoordIntervalUtils.generateTimeCoordValuesFromTimeCoordIntervals(coordTime.getTimeIntervals(),
+        timeCoordValues, timeCoordBoundsValues, 0, coordTime.getTimeUnit().getValue(), 0);
+    assert (count == ntimes);
+    v.setCachedData(Array.factory(DataType.DOUBLE, new int[] {ntimes}, timeCoordValues), false);
 
     // bounds
     String bounds_name = tcName + "_bounds";
@@ -569,13 +568,7 @@ class GribIospBuilder {
     bounds.addAttribute(new Attribute(CDM.UNITS, units));
     bounds.addAttribute(new Attribute(CDM.LONG_NAME, "bounds for " + tcName));
 
-    data = new double[ntimes * 2];
-    count = 0;
-    for (TimeCoordIntvValue tinv : coordTime.getTimeIntervals()) {
-      data[count++] = tinv.getBounds1();
-      data[count++] = tinv.getBounds2();
-    }
-    bounds.setCachedData(Array.factory(DataType.DOUBLE, new int[] {ntimes, 2}, data), false);
+    bounds.setCachedData(Array.factory(DataType.DOUBLE, new int[] {ntimes, 2}, timeCoordBoundsValues), false);
 
     makeTimeAuxReference(g, tcName, units, coordTime);
   }

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestDiscontiguousInterval.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestDiscontiguousInterval.java
@@ -111,7 +111,7 @@ public class TestDiscontiguousInterval {
 
   @Test
   @Category(NeedsCdmUnitTest.class)
-  public void testFeatureColectionBest_isStrictlyMonotonicallyIncreasing() throws IOException {
+  public void testFeatureCollectionBest_isStrictlyMonotonicallyIncreasing() throws IOException {
     final String spec =
         TestDir.cdmUnitTestDir + "/gribCollections/gfs_conus80/20231027/GFS_CONUS_80km_#yyyyMMdd_HHmm#\\.grib1$";
     final FeatureCollectionConfig config = new FeatureCollectionConfig("testFeatureCollectionBest", "path",

--- a/grib/src/test/java/ucar/nc2/grib/coord/TestDiscontiguousInterval.java
+++ b/grib/src/test/java/ucar/nc2/grib/coord/TestDiscontiguousInterval.java
@@ -1,10 +1,16 @@
 package ucar.nc2.grib.coord;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import thredds.featurecollection.FeatureCollectionConfig;
+import thredds.featurecollection.FeatureCollectionType;
+import thredds.inventory.CollectionUpdateType;
 import ucar.ma2.Array;
 import ucar.nc2.*;
+import ucar.nc2.grib.collection.GribCdmIndex;
 import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
@@ -103,10 +109,30 @@ public class TestDiscontiguousInterval {
     checkTimeCoord2D_fromIntervals_isStrictlyMonotonicallyIncreasing(testfile, varName);
   }
 
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testFeatureColectionBest_isStrictlyMonotonicallyIncreasing() throws IOException {
+    final String spec =
+        TestDir.cdmUnitTestDir + "/gribCollections/gfs_conus80/20231027/GFS_CONUS_80km_#yyyyMMdd_HHmm#\\.grib1$";
+    final FeatureCollectionConfig config = new FeatureCollectionConfig("testFeatureCollectionBest", "path",
+        FeatureCollectionType.GRIB1, spec, null, null, null, "file", null);
+    final boolean changed = GribCdmIndex.updateGribCollection(config, CollectionUpdateType.always, null);
+    assertThat(changed).isTrue();
+    final String topLevelIndex = GribCdmIndex.getTopIndexFileFromConfig(config).getAbsolutePath();
+
+    final String varName = "Total_precipitation_surface_Mixed_intervals_Accumulation";
+    checkTimeCoord2D_fromIntervals_isStrictlyMonotonicallyIncreasing(topLevelIndex, varName, "Best/");
+  }
+
   private void checkTimeCoord2D_fromIntervals_isStrictlyMonotonicallyIncreasing(String testfile, String varName)
       throws IOException {
+    checkTimeCoord2D_fromIntervals_isStrictlyMonotonicallyIncreasing(testfile, varName, "");
+  }
+
+  private void checkTimeCoord2D_fromIntervals_isStrictlyMonotonicallyIncreasing(String testfile, String varName,
+      String groupName) throws IOException {
     try (NetcdfFile nc = NetcdfFiles.open(testfile)) {
-      Variable dataVar = nc.findVariable(varName);
+      Variable dataVar = nc.findVariable(groupName + varName);
       Assert.assertNotNull(dataVar);
 
       Dimension timeDim = null;
@@ -116,7 +142,7 @@ public class TestDiscontiguousInterval {
           break;
         }
       }
-      Variable timeCoordVar = nc.findVariable(timeDim.getShortName());
+      Variable timeCoordVar = nc.findVariable(groupName + timeDim.getShortName());
       Assert.assertNotNull(timeCoordVar);
 
       Attribute att = timeCoordVar.findAttribute("bounds");


### PR DESCRIPTION
## Description of Changes

Fix generation of time coordinate variables from time intervals for 2-D time FMRC Best datasets. Ensure resulting time coordinate variables are strictly monotonically increasing. Handle when time intervals are irregular and overlapping.

See issue #1060.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [ ] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
