### PR TITLE
Don't use deprecated code in grib collections

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFileSubclass.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFileSubclass.java
@@ -16,7 +16,9 @@ import java.io.IOException;
  *
  * @author caron
  * @since 10/29/2014
+ * @deprecated Use NetcdfFile.builder(). Remove in v6
  */
+@Deprecated
 public class NetcdfFileSubclass extends NetcdfFile {
 
   public NetcdfFileSubclass() {}

--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -805,7 +805,7 @@ public class NetcdfFiles {
     return null;
   }
 
-  private static NetcdfFile build(IOServiceProvider spi, ucar.unidata.io.RandomAccessFile raf, String location,
+  public static NetcdfFile build(IOServiceProvider spi, ucar.unidata.io.RandomAccessFile raf, String location,
       ucar.nc2.util.CancelTask cancelTask) throws IOException {
 
     NetcdfFile.Builder builder = NetcdfFile.builder().setIosp((AbstractIOServiceProvider) spi).setLocation(location);

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib1Collection.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib1Collection.java
@@ -6,6 +6,7 @@
 package ucar.nc2.grib.collection;
 
 import javax.annotation.Nullable;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.grib.coord.CoordinateTimeAbstract;
 import ucar.nc2.*;
 import ucar.nc2.constants.DataFormatType;
@@ -22,6 +23,7 @@ import ucar.nc2.grib.grib1.Grib1Parameter;
 import ucar.nc2.grib.grib1.tables.Grib1Customizer;
 import java.io.IOException;
 import java.util.Formatter;
+import ucar.unidata.io.RandomAccessFile;
 
 /**
  * Grib1-specific subclass of GribCollection.
@@ -41,8 +43,9 @@ public class Grib1Collection extends GribCollectionImmutable {
       FeatureCollectionConfig gribConfig, Formatter errlog, org.slf4j.Logger logger) throws IOException {
     if (filename == null) {
       Grib1Iosp iosp = new Grib1Iosp(group, ds.getType());
-      NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-      return new NetcdfDataset(ncfile);
+      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+      return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
 
     } else {
       MFile wantFile = findMFileByName(filename);
@@ -53,8 +56,9 @@ public class Grib1Collection extends GribCollectionImmutable {
           return null;
 
         Grib1Iosp iosp = new Grib1Iosp(gc);
-        NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-        return new NetcdfDataset(ncfile);
+        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+        return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
       }
       return null;
     }
@@ -66,8 +70,9 @@ public class Grib1Collection extends GribCollectionImmutable {
       FeatureCollectionConfig gribConfig, Formatter errlog, org.slf4j.Logger logger) throws IOException {
     if (filename == null) {
       Grib1Iosp iosp = new Grib1Iosp(group, ds.getType());
-      NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation() + "#" + group.getId(), null);
-      NetcdfDataset ncd = new NetcdfDataset(ncfile);
+      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation() + "#" + group.getId(), null);
+      NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
       return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
 
     } else {
@@ -79,8 +84,9 @@ public class Grib1Collection extends GribCollectionImmutable {
           return null;
 
         Grib1Iosp iosp = new Grib1Iosp(gc);
-        NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-        NetcdfDataset ncd = new NetcdfDataset(ncfile);
+        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+        NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
         return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
       }
       return null;

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib1Collection.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib1Collection.java
@@ -6,7 +6,6 @@
 package ucar.nc2.grib.collection;
 
 import javax.annotation.Nullable;
-import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.grib.coord.CoordinateTimeAbstract;
 import ucar.nc2.*;
 import ucar.nc2.constants.DataFormatType;
@@ -23,7 +22,6 @@ import ucar.nc2.grib.grib1.Grib1Parameter;
 import ucar.nc2.grib.grib1.tables.Grib1Customizer;
 import java.io.IOException;
 import java.util.Formatter;
-import ucar.unidata.io.RandomAccessFile;
 
 /**
  * Grib1-specific subclass of GribCollection.
@@ -43,9 +41,7 @@ public class Grib1Collection extends GribCollectionImmutable {
       FeatureCollectionConfig gribConfig, Formatter errlog, org.slf4j.Logger logger) throws IOException {
     if (filename == null) {
       Grib1Iosp iosp = new Grib1Iosp(group, ds.getType());
-      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-      return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+      return buildNetcdfDataset(iosp, getLocation());
 
     } else {
       MFile wantFile = findMFileByName(filename);
@@ -56,9 +52,7 @@ public class Grib1Collection extends GribCollectionImmutable {
           return null;
 
         Grib1Iosp iosp = new Grib1Iosp(gc);
-        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-        return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+        return buildNetcdfDataset(iosp, getLocation());
       }
       return null;
     }
@@ -70,9 +64,7 @@ public class Grib1Collection extends GribCollectionImmutable {
       FeatureCollectionConfig gribConfig, Formatter errlog, org.slf4j.Logger logger) throws IOException {
     if (filename == null) {
       Grib1Iosp iosp = new Grib1Iosp(group, ds.getType());
-      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation() + "#" + group.getId(), null);
-      NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+      NetcdfDataset ncd = buildNetcdfDataset(iosp, getLocation() + "#" + group.getId());
       return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
 
     } else {
@@ -84,9 +76,7 @@ public class Grib1Collection extends GribCollectionImmutable {
           return null;
 
         Grib1Iosp iosp = new Grib1Iosp(gc);
-        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-        NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+        NetcdfDataset ncd = buildNetcdfDataset(iosp, getLocation());
         return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
       }
       return null;

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib1Partition.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib1Partition.java
@@ -10,11 +10,13 @@ import ucar.nc2.constants.DataFormatType;
 import thredds.featurecollection.FeatureCollectionConfig;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.ft2.coverage.CoverageCollection;
 import ucar.nc2.grib.GribUtils;
 import ucar.nc2.grib.coverage.GribCoverageDataset;
 import java.io.IOException;
 import java.util.Formatter;
+import ucar.unidata.io.RandomAccessFile;
 
 /**
  * PartitionCollection for Grib1.
@@ -33,8 +35,9 @@ public class Grib1Partition extends PartitionCollectionImmutable {
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib1Iosp iosp = new ucar.nc2.grib.collection.Grib1Iosp(group, ds.getType());
-    NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-    return new NetcdfDataset(ncfile);
+    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+    return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
   }
 
   @Override
@@ -42,8 +45,9 @@ public class Grib1Partition extends PartitionCollectionImmutable {
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib1Iosp iosp = new ucar.nc2.grib.collection.Grib1Iosp(group, ds.getType());
-    NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-    NetcdfDataset ncd = new NetcdfDataset(ncfile);
+    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+    NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
     return new ucar.nc2.dt.grid.GridDataset(ncd);
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib1Partition.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib1Partition.java
@@ -10,13 +10,11 @@ import ucar.nc2.constants.DataFormatType;
 import thredds.featurecollection.FeatureCollectionConfig;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.ft2.coverage.CoverageCollection;
 import ucar.nc2.grib.GribUtils;
 import ucar.nc2.grib.coverage.GribCoverageDataset;
 import java.io.IOException;
 import java.util.Formatter;
-import ucar.unidata.io.RandomAccessFile;
 
 /**
  * PartitionCollection for Grib1.
@@ -35,9 +33,7 @@ public class Grib1Partition extends PartitionCollectionImmutable {
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib1Iosp iosp = new ucar.nc2.grib.collection.Grib1Iosp(group, ds.getType());
-    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-    return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+    return buildNetcdfDataset(iosp, getLocation());
   }
 
   @Override
@@ -45,9 +41,7 @@ public class Grib1Partition extends PartitionCollectionImmutable {
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib1Iosp iosp = new ucar.nc2.grib.collection.Grib1Iosp(group, ds.getType());
-    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-    NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+    NetcdfDataset ncd = buildNetcdfDataset(iosp, getLocation());
     return new ucar.nc2.dt.grid.GridDataset(ncd);
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Collection.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Collection.java
@@ -6,7 +6,6 @@
 package ucar.nc2.grib.collection;
 
 import javax.annotation.Nullable;
-import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.grib.coord.CoordinateTimeAbstract;
 import ucar.ma2.Array;
 import ucar.nc2.*;
@@ -21,7 +20,6 @@ import ucar.nc2.grib.GribNumbers;
 import ucar.nc2.grib.GribTables;
 import ucar.nc2.grib.coverage.GribCoverageDataset;
 import ucar.nc2.grib.grib2.table.Grib2Tables;
-import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.util.StringUtil2;
 import java.io.IOException;
 import java.util.Formatter;
@@ -45,9 +43,7 @@ public class Grib2Collection extends GribCollectionImmutable {
 
     if (filename == null) {
       Grib2Iosp iosp = new Grib2Iosp(group, ds.getType());
-      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-      return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+      return buildNetcdfDataset(iosp, getLocation());
 
     } else {
       MFile wantFile = findMFileByName(filename);
@@ -58,9 +54,7 @@ public class Grib2Collection extends GribCollectionImmutable {
           return null;
 
         Grib2Iosp iosp = new Grib2Iosp(gc);
-        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-        return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+        return buildNetcdfDataset(iosp, getLocation());
       }
       return null;
     }
@@ -73,9 +67,7 @@ public class Grib2Collection extends GribCollectionImmutable {
 
     if (filename == null) {
       Grib2Iosp iosp = new Grib2Iosp(group, ds.getType());
-      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation() + "#" + group.getId(), null);
-      NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+      NetcdfDataset ncd = buildNetcdfDataset(iosp, getLocation() + "#" + group.getId());
       return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
 
     } else {
@@ -87,9 +79,7 @@ public class Grib2Collection extends GribCollectionImmutable {
           return null;
 
         Grib2Iosp iosp = new Grib2Iosp(gc);
-        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-        NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+        NetcdfDataset ncd = buildNetcdfDataset(iosp, getLocation());
         return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
       }
       return null;

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Collection.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Collection.java
@@ -6,6 +6,7 @@
 package ucar.nc2.grib.collection;
 
 import javax.annotation.Nullable;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.grib.coord.CoordinateTimeAbstract;
 import ucar.ma2.Array;
 import ucar.nc2.*;
@@ -20,6 +21,7 @@ import ucar.nc2.grib.GribNumbers;
 import ucar.nc2.grib.GribTables;
 import ucar.nc2.grib.coverage.GribCoverageDataset;
 import ucar.nc2.grib.grib2.table.Grib2Tables;
+import ucar.unidata.io.RandomAccessFile;
 import ucar.unidata.util.StringUtil2;
 import java.io.IOException;
 import java.util.Formatter;
@@ -43,8 +45,9 @@ public class Grib2Collection extends GribCollectionImmutable {
 
     if (filename == null) {
       Grib2Iosp iosp = new Grib2Iosp(group, ds.getType());
-      NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-      return new NetcdfDataset(ncfile);
+      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+      return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
 
     } else {
       MFile wantFile = findMFileByName(filename);
@@ -55,8 +58,9 @@ public class Grib2Collection extends GribCollectionImmutable {
           return null;
 
         Grib2Iosp iosp = new Grib2Iosp(gc);
-        NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-        return new NetcdfDataset(ncfile);
+        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+        return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
       }
       return null;
     }
@@ -69,8 +73,9 @@ public class Grib2Collection extends GribCollectionImmutable {
 
     if (filename == null) {
       Grib2Iosp iosp = new Grib2Iosp(group, ds.getType());
-      NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation() + "#" + group.getId(), null);
-      NetcdfDataset ncd = new NetcdfDataset(ncfile);
+      RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+      NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation() + "#" + group.getId(), null);
+      NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
       return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
 
     } else {
@@ -82,8 +87,9 @@ public class Grib2Collection extends GribCollectionImmutable {
           return null;
 
         Grib2Iosp iosp = new Grib2Iosp(gc);
-        NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-        NetcdfDataset ncd = new NetcdfDataset(ncfile);
+        RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+        NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+        NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
         return new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK - replace with custom GridDataset??
       }
       return null;

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Partition.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Partition.java
@@ -11,15 +11,11 @@ import java.util.Formatter;
 import thredds.featurecollection.FeatureCollectionConfig;
 import ucar.nc2.Attribute;
 import ucar.nc2.AttributeContainer;
-import ucar.nc2.NetcdfFile;
-import ucar.nc2.NetcdfFiles;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.DataFormatType;
 import ucar.nc2.dataset.NetcdfDataset;
-import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.ft2.coverage.CoverageCollection;
 import ucar.nc2.grib.coverage.GribCoverageDataset;
-import ucar.unidata.io.RandomAccessFile;
 
 /**
  * PartitionCollection for Grib2.
@@ -38,9 +34,7 @@ public class Grib2Partition extends PartitionCollectionImmutable implements Clos
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib2Iosp iosp = new ucar.nc2.grib.collection.Grib2Iosp(group, ds.getType());
-    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-    return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+    return buildNetcdfDataset(iosp, getLocation());
   }
 
   @Override
@@ -48,9 +42,7 @@ public class Grib2Partition extends PartitionCollectionImmutable implements Clos
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib2Iosp iosp = new ucar.nc2.grib.collection.Grib2Iosp(group, ds.getType());
-    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
-    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
-    NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
+    NetcdfDataset ncd = buildNetcdfDataset(iosp, getLocation());
     return new ucar.nc2.dt.grid.GridDataset(ncd);
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/Grib2Partition.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/Grib2Partition.java
@@ -12,12 +12,14 @@ import thredds.featurecollection.FeatureCollectionConfig;
 import ucar.nc2.Attribute;
 import ucar.nc2.AttributeContainer;
 import ucar.nc2.NetcdfFile;
-import ucar.nc2.NetcdfFileSubclass;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.DataFormatType;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.ft2.coverage.CoverageCollection;
 import ucar.nc2.grib.coverage.GribCoverageDataset;
+import ucar.unidata.io.RandomAccessFile;
 
 /**
  * PartitionCollection for Grib2.
@@ -36,8 +38,9 @@ public class Grib2Partition extends PartitionCollectionImmutable implements Clos
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib2Iosp iosp = new ucar.nc2.grib.collection.Grib2Iosp(group, ds.getType());
-    NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-    return new NetcdfDataset(ncfile);
+    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+    return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
   }
 
   @Override
@@ -45,8 +48,9 @@ public class Grib2Partition extends PartitionCollectionImmutable implements Clos
       FeatureCollectionConfig config, Formatter errlog, org.slf4j.Logger logger) throws IOException {
 
     ucar.nc2.grib.collection.Grib2Iosp iosp = new ucar.nc2.grib.collection.Grib2Iosp(group, ds.getType());
-    NetcdfFile ncfile = new NetcdfFileSubclass(iosp, null, getLocation(), null);
-    NetcdfDataset ncd = new NetcdfDataset(ncfile);
+    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, getLocation(), null);
+    NetcdfDataset ncd = NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
     return new ucar.nc2.dt.grid.GridDataset(ncd);
   }
 

--- a/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionImmutable.java
+++ b/grib/src/main/java/ucar/nc2/grib/collection/GribCollectionImmutable.java
@@ -14,9 +14,13 @@ import thredds.inventory.MFile;
 import ucar.nc2.Attribute;
 import ucar.nc2.AttributeContainer;
 import ucar.nc2.AttributeContainerMutable;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.ft2.coverage.CoverageCollection;
 import ucar.nc2.ft2.coverage.SubsetParams;
 import ucar.nc2.grib.*;
@@ -31,6 +35,7 @@ import ucar.nc2.grib.coord.VertCoordValue;
 import ucar.nc2.grib.grib1.Grib1Variable;
 import ucar.nc2.grib.grib1.tables.Grib1Customizer;
 import ucar.nc2.grib.grib2.table.Grib2Tables;
+import ucar.nc2.iosp.AbstractIOServiceProvider;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.util.cache.FileCacheIF;
@@ -1111,6 +1116,13 @@ public abstract class GribCollectionImmutable implements Closeable, FileCacheabl
   String getDataRafFilename(int fileno) {
     MFile mfile = fileMap.get(fileno);
     return mfile.getPath();
+  }
+
+  protected static NetcdfDataset buildNetcdfDataset(AbstractIOServiceProvider iosp, String location)
+      throws IOException {
+    RandomAccessFile raf = (RandomAccessFile) iosp.sendIospMessage(NetcdfFile.IOSP_MESSAGE_RANDOM_ACCESS_FILE);
+    NetcdfFile ncfile = NetcdfFiles.build(iosp, raf, location, null);
+    return NetcdfDatasets.enhance(ncfile, NetcdfDataset.getDefaultEnhanceMode(), null);
   }
 
   ///////////////////////


### PR DESCRIPTION
## Description of Changes
- Deprecate the `NetcdfFileSubclass` class. This class uses deprecated `NetcdfFile` constructors in all its constructors.
- Create `NetcdfDataset`s in the grib collection code using non deprecated methods-- `NetcdfFiles.build` and `NetcdfDatasets.enhance` instead of the `NetcdfFileSubclass`.
- In order to achieve the above point, I made the `NetcdfFile::build` method public.
- [Jenkins tests passing](https://jenkins-aws.unidata.ucar.edu/view/Users/job/tara-netcdf-java/39/)