### PR TITLE
Update visad mcidas library to fix resource leak

### DIFF
--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     api 'org.jsoup:jsoup:1.11.2' // HTML scraper used in GRIB
 
     // cdm-mcidas (GEMPAK and McIDAS IOSPs)
-    api 'edu.wisc.ssec:visad-mcidas-slim-ucar-ns:20200507-2'
+    api 'edu.wisc.ssec:visad-mcidas-slim-ucar-ns:20231121'
 
     // cdm-vis5d (vis5d IOSP)
     api 'edu.wisc.ssec:visad:2.0-20130124'


### PR DESCRIPTION
## Description of Changes

Update the visad-mcidas library. The updated version contains a [fix](https://github.com/Unidata/visad/pull/2) for a resource leak that caused a file lock issue in https://github.com/Unidata/netcdf-java/discussions/1257.
