### PR TITLE
Improve cache cleanup

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/util/cache/FileCache.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/cache/FileCache.java
@@ -4,6 +4,8 @@
  */
 package ucar.nc2.util.cache;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import ucar.nc2.dataset.DatasetUrl;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateFormatter;
@@ -697,13 +699,11 @@ public class FileCache implements FileCacheIF {
   synchronized void cleanup(int maxElements) {
 
     try {
-      /*
-       * int size = counter.get();
-       * int fsize = files.size();
-       * if (debug && (size != fsize)) {
-       * log.warn("FileCache " + name + " counter " + size + " doesnt match files().size=" + fsize);
-       * }
-       */
+      for (CacheElement.CacheFile cacheFile : files.values()) {
+        if (!Files.exists(Paths.get(cacheFile.ncfile.getLocation()))) {
+          remove(cacheFile);
+        }
+      }
 
       int size = files.size();
       if (size <= minElements)

--- a/cdm/core/src/test/java/ucar/nc2/util/cache/TestRandomAccessFileCacheCleanup.java
+++ b/cdm/core/src/test/java/ucar/nc2/util/cache/TestRandomAccessFileCacheCleanup.java
@@ -1,0 +1,43 @@
+package ucar.nc2.util.cache;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ucar.unidata.io.RandomAccessFile;
+
+public class TestRandomAccessFileCacheCleanup {
+
+  @ClassRule
+  public static final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static FileCache cache;
+
+  @BeforeClass
+  public static void enableCache() {
+    cache = new FileCache("RandomAccessFile", 0, 1, 1, 0);
+    RandomAccessFile.setGlobalFileCache(cache);
+  }
+
+  @AfterClass
+  public static void shutdownCache() {
+    RandomAccessFile.setGlobalFileCache(null);
+  }
+
+  @Test
+  public void shouldReleaseDeletedFileDuringCleanup() throws IOException {
+    final File toDelete = tempFolder.newFile();
+    RandomAccessFile.acquire(toDelete.getAbsolutePath());
+    RandomAccessFile.acquire(tempFolder.newFile().getAbsolutePath());
+    assertThat(cache.showCache().size()).isEqualTo(2);
+
+    assertThat(toDelete.delete()).isTrue();
+    cache.cleanup(1);
+    assertThat(cache.showCache().size()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
## Description of Changes

The RandomAccessFileCache puts a read lock on files which sometimes causes issues for people who are trying to delete a file that's cached. 

When a cleanup is performed, check if any of the cached files were deleted and if so remove them. The cleanups are scheduled to happen at regular intervals for the NetcdfFile and RandomAccessFile caches (by default every 10 min in TDS). 

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
