### PR TITLE
Fix s3 ncml

### DIFF
--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
@@ -53,7 +53,7 @@ public class MFileOS implements MFile {
   }
 
   public MFileOS(String filename) {
-    this.file = new File(filename);
+    this.file = new File(filename.replaceFirst("^file:", ""));
     this.lastModified = file.lastModified();
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/DatasetUrl.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/DatasetUrl.java
@@ -13,6 +13,8 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.Multimap;
 import thredds.client.catalog.ServiceType;
+import thredds.inventory.MFile;
+import thredds.inventory.MFiles;
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
 import ucar.nc2.util.EscapeStrings;
@@ -59,9 +61,11 @@ public class DatasetUrl {
     StringBuilder buf = new StringBuilder(url);
     // If there are any leading protocols, then they must stop at the first '/'.
     int slashpos = buf.indexOf("/");
-    // Check special case of file:<path> with no slashes after file:
+    // Check special cases of file:<path> or cdms3:<path> with no slashes after:
     if (url.startsWith("file:") && "/\\".indexOf(url.charAt(5)) < 0) {
       allprotocols.add("file");
+    } else if (url.startsWith("cdms3:") && "/\\".indexOf(url.charAt(6)) < 0) {
+      allprotocols.add("cdms3");
     } else if (slashpos >= 0) {
       // Remove everything after the first slash
       buf.delete(slashpos + 1, buf.length());
@@ -128,7 +132,7 @@ public class DatasetUrl {
     }
     pos = location.lastIndexOf('?');
     String query = null;
-    if (pos >= 0) {
+    if (pos >= 0 && !leadProtocol.equals("cdms3")) {
       query = trueUrl.substring(pos + 1);
       trueUrl = trueUrl.substring(0, pos);
     }
@@ -147,9 +151,9 @@ public class DatasetUrl {
       // - we have file://<path> or file:<path>; we need to see if
       // the extension can help, otherwise, start defaulting.
       // - we have a simple url: e.g. http://... ; contact the server
-      if (leadProtocol.equals("file")) {
+      if (leadProtocol.equals("file") || leadProtocol.equals("cdms3")) {
         serviceType = decodePathExtension(trueUrl); // look at the path extension
-        if (serviceType == null && checkIfNcml(new File(location))) {
+        if (serviceType == null && checkIfNcml(MFiles.create(location))) {
           serviceType = ServiceType.NCML;
         }
       } else {
@@ -163,11 +167,10 @@ public class DatasetUrl {
         }
       }
     }
-
     if (serviceType == ServiceType.NCML) { // ??
       // If lead protocol was null, then pretend it was a file
       // Note that technically, this should be 'file://'
-      trueUrl = (allProtocols.isEmpty() ? "file:" + trueUrl : location);
+      trueUrl = (allProtocols.isEmpty() ? "file:" + trueUrl : trueUrl);
     }
 
     // Add back the query and fragment (if any)
@@ -511,12 +514,12 @@ public class DatasetUrl {
     return false;
   }
 
-  private static boolean checkIfNcml(File file) throws IOException {
-    if (!file.exists()) {
+  private static boolean checkIfNcml(MFile mFile) throws IOException {
+    if (!mFile.exists()) {
       return false;
     }
 
-    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file), NUM_BYTES_TO_DETERMINE_NCML)) {
+    try (BufferedInputStream in = new BufferedInputStream(mFile.getInputStream(), NUM_BYTES_TO_DETERMINE_NCML)) {
       byte[] bytes = new byte[NUM_BYTES_TO_DETERMINE_NCML];
       int bytesRead = in.read(bytes);
 

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -18,13 +18,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.net.URL;
 import javax.annotation.Nullable;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.Namespace;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.XMLOutputter;
+import thredds.inventory.MFile;
+import thredds.inventory.MFiles;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.nc2.Attribute;
@@ -346,16 +347,11 @@ public class NcmlReader {
    */
   public static NetcdfDataset.Builder readNcml(String ncmlLocation, String referencedDatasetUri, CancelTask cancelTask)
       throws IOException {
-    URL url = new URL(ncmlLocation);
+    MFile mFile = MFiles.create(ncmlLocation);
 
     if (debugURL) {
       System.out.println(" NcmlReader open " + ncmlLocation);
-      System.out.println("   URL = " + url);
-      System.out.println("   external form = " + url.toExternalForm());
-      System.out.println("   protocol = " + url.getProtocol());
-      System.out.println("   host = " + url.getHost());
-      System.out.println("   path = " + url.getPath());
-      System.out.println("  file = " + url.getFile());
+      System.out.println("   Path = " + mFile.getPath());
     }
 
     org.jdom2.Document doc;
@@ -363,9 +359,9 @@ public class NcmlReader {
       SAXBuilder builder = new SAXBuilder();
       builder.setExpandEntities(false);
       if (debugURL) {
-        System.out.println(" NetcdfDataset URL = <" + url + ">");
+        System.out.println(" NetcdfDataset path = <" + mFile.getPath() + ">");
       }
-      doc = builder.build(url);
+      doc = builder.build(mFile.getInputStream());
     } catch (JDOMException e) {
       throw new IOException(e.getMessage());
     }

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestDatasetUrl.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestDatasetUrl.java
@@ -112,5 +112,16 @@ public class TestDatasetUrl {
     testFind(
         "dynamic:http://thredds.ucar.edu:8080/thredds/fmrc/NCEP/GFS/CONUS_95km/files/GFS_CONUS_95km_20070319_0600.grib1",
         null);
+
+    testFind("file:/path/to/file.ncml", ServiceType.NCML);
+    testFind("/path/to/file.ncml", ServiceType.NCML);
+    testFind("file:/path/to/file.xml", ServiceType.NCML);
+    testFind("/path/to/file.xml", ServiceType.NCML);
+
+    testFind("cdms3:thredds-test-data?testStandalone.ncml#delimiter=/", ServiceType.NCML);
+    testFind("cdms3:thredds-test-data?testStandalone.ncml", ServiceType.NCML);
+    testFind("cdms3:thredds-test-data?ncml/testStandalone.ncml#delimiter=/", ServiceType.NCML);
+    testFind("cdms3:thredds-test-data?ncml/testStandalone.ncml", ServiceType.NCML);
+    testFind("cdms3://profile_name@my.endpoint.edu/bucket-name?super/long/key.ncml#delimiter=/", ServiceType.NCML);
   }
 }

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestDatasetUrl.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestDatasetUrl.java
@@ -21,7 +21,6 @@ import thredds.client.catalog.ServiceType;
  */
 public class TestDatasetUrl {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  static final boolean show = true;
 
   protected void protocheck(String path, String expected) {
     if (expected == null)
@@ -32,11 +31,6 @@ public class TestDatasetUrl {
     StringBuffer buff = new StringBuffer();
     protocols.forEach(p -> buff.append(p).append(":"));
     String result = buff.toString();
-    boolean ok = expected.equals(result);
-    if (show || !ok)
-      System.out.printf(" %s <- %s%n", result, path);
-    if (!ok)
-      System.out.printf("  !!!EXPECTED '%s'%n", expected);
     assertThat(result).isEqualTo(expected);
   }
 
@@ -76,11 +70,6 @@ public class TestDatasetUrl {
 
   protected void testFind(String path, ServiceType expected) throws IOException {
     DatasetUrl result = DatasetUrl.findDatasetUrl(path);
-    boolean ok = (expected == null) ? result.serviceType == null : expected == result.serviceType;
-    if (show || !ok)
-      System.out.printf(" %s <- %s%n", result.serviceType, path);
-    if (!ok)
-      System.out.printf("  !!!EXPECTED '%s'%n", expected);
     assertThat(result.serviceType).isEqualTo(expected);
   }
 


### PR DESCRIPTION
## Description of Changes

Fixes reading ncml files stored on S3 (Resolves https://github.com/Unidata/netcdf-java/issues/1231). This requires fixing logic used by the NcmlReader to use `MFile`s instead of `File`s and `URL`s. Unfortunately it also requires several special cases, checking for `cdms3` protocols-- this isn't the nicest but I am not seeing another way to fix this without refactoring all this code.

Add unit tests to test the `DatasetURL` code. Integration tests will be added to the TDS (https://github.com/Unidata/tds/pull/438)

Jenkins tests passing: https://jenkins-aws.unidata.ucar.edu/view/Users/job/tara-netcdf-java/40/