### PR TITLE
Fix unit conversion for projection

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordSysBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordSysBuilder.java
@@ -951,7 +951,7 @@ public class CoordSysBuilder implements CoordSysBuilderIF {
   }
 
   protected CoordinateTransform makeCoordinateTransform(NetcdfDataset ds, Variable ctv) {
-    return CoordTransBuilder.makeCoordinateTransform(ds, ctv, parseInfo, userAdvice, ds.getCoordinateAxes());
+    return CoordTransBuilder.makeCoordinateTransform(ds, ctv, parseInfo, userAdvice);
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordSysBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordSysBuilder.java
@@ -951,7 +951,7 @@ public class CoordSysBuilder implements CoordSysBuilderIF {
   }
 
   protected CoordinateTransform makeCoordinateTransform(NetcdfDataset ds, Variable ctv) {
-    return CoordTransBuilder.makeCoordinateTransform(ds, ctv, parseInfo, userAdvice);
+    return CoordTransBuilder.makeCoordinateTransform(ds, ctv, parseInfo, userAdvice, ds.getCoordinateAxes());
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordTransBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordTransBuilder.java
@@ -162,7 +162,7 @@ public class CoordTransBuilder {
    */
   @Nullable
   public static CoordinateTransform makeCoordinateTransform(NetcdfDataset ds, AttributeContainer ctv,
-                                                            Formatter parseInfo, Formatter errInfo) {
+      Formatter parseInfo, Formatter errInfo) {
     return makeCoordinateTransform(ds, ctv, parseInfo, errInfo, ds.getCoordinateAxes());
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordTransBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordTransBuilder.java
@@ -153,11 +153,28 @@ public class CoordTransBuilder {
   /**
    * Make a CoordinateTransform object from the parameters in a Coordinate Transform Variable, using an intrinsic or
    * registered CoordTransBuilder.
+   *
+   * @param ds enclosing dataset, only used for vertical transforms
+   * @param ctv the Coordinate Transform Variable - container for the transform parameters
+   * @param parseInfo pass back information about the parsing.
+   * @param errInfo pass back error information.
+   * @return CoordinateTransform, or null if failure.
+   */
+  @Nullable
+  public static CoordinateTransform makeCoordinateTransform(NetcdfDataset ds, AttributeContainer ctv,
+                                                            Formatter parseInfo, Formatter errInfo) {
+    return makeCoordinateTransform(ds, ctv, parseInfo, errInfo, ds.getCoordinateAxes());
+  }
+
+  /**
+   * Make a CoordinateTransform object from the parameters in a Coordinate Transform Variable, using an intrinsic or
+   * registered CoordTransBuilder.
    * 
    * @param ds enclosing dataset, only used for vertical transforms
    * @param ctv the Coordinate Transform Variable - container for the transform parameters
    * @param parseInfo pass back information about the parsing.
    * @param errInfo pass back error information.
+   * @param coordAxes any precomputed coordinate axes
    * @return CoordinateTransform, or null if failure.
    */
   @Nullable

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordTransBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordTransBuilder.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Formatter;
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
 import ucar.ma2.DataType;
 import ucar.ma2.Array;
 import ucar.nc2.AttributeContainer;
@@ -160,7 +162,7 @@ public class CoordTransBuilder {
    */
   @Nullable
   public static CoordinateTransform makeCoordinateTransform(NetcdfDataset ds, AttributeContainer ctv,
-      Formatter parseInfo, Formatter errInfo) {
+      Formatter parseInfo, Formatter errInfo, ImmutableList<CoordinateAxis> coordAxes) {
     // standard name
     String transform_name = ctv.findAttributeString("transform_name", null);
     if (null == transform_name)
@@ -220,7 +222,7 @@ public class CoordTransBuilder {
     } else if (builderObject instanceof HorizTransformBuilderIF) {
       HorizTransformBuilderIF horizBuilder = (HorizTransformBuilderIF) builderObject;
       horizBuilder.setErrorBuffer(errInfo);
-      String units = AbstractTransformBuilder.getGeoCoordinateUnits(ds, ctv); // barfola
+      String units = AbstractTransformBuilder.getGeoCoordinateUnits(ds, ctv, coordAxes); // barfola
       ct = horizBuilder.makeCoordinateTransform(ctv, units);
 
     } else {

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
@@ -244,6 +244,10 @@ public class CoordinateTransform implements Comparable<CoordinateTransform> {
       return self();
     }
 
+    public CoordinateTransform build(NetcdfDataset ncd) {
+      return build(ncd, ncd.getCoordinateAxes());
+    }
+
     public CoordinateTransform build(NetcdfDataset ncd, ImmutableList<CoordinateAxis> coordAxes) {
       if (built)
         throw new IllegalStateException("already built " + name);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
@@ -177,7 +177,7 @@ public class CoordinateTransform implements Comparable<CoordinateTransform> {
     this.attributeContainer.addAll(builder.attributeContainer);
 
     CoordinateTransform ct =
-        CoordTransBuilder.makeCoordinateTransform(ncd, builder.attributeContainer, new Formatter(), new Formatter(), ncd.getCoordinateAxes());
+        CoordTransBuilder.makeCoordinateTransform(ncd, builder.attributeContainer, new Formatter(), new Formatter());
     ct.attributeContainer = new AttributeContainerMutable(this.name);
     ct.attributeContainer.addAll(builder.attributeContainer);
   }

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
@@ -177,7 +177,7 @@ public class CoordinateTransform implements Comparable<CoordinateTransform> {
     this.attributeContainer.addAll(builder.attributeContainer);
 
     CoordinateTransform ct =
-        CoordTransBuilder.makeCoordinateTransform(ncd, builder.attributeContainer, new Formatter(), new Formatter());
+        CoordTransBuilder.makeCoordinateTransform(ncd, builder.attributeContainer, new Formatter(), new Formatter(), ncd.getCoordinateAxes());
     ct.attributeContainer = new AttributeContainerMutable(this.name);
     ct.attributeContainer.addAll(builder.attributeContainer);
   }
@@ -244,7 +244,7 @@ public class CoordinateTransform implements Comparable<CoordinateTransform> {
       return self();
     }
 
-    public CoordinateTransform build(NetcdfDataset ncd) {
+    public CoordinateTransform build(NetcdfDataset ncd, ImmutableList<CoordinateAxis> coordAxes) {
       if (built)
         throw new IllegalStateException("already built " + name);
       built = true;
@@ -255,7 +255,7 @@ public class CoordinateTransform implements Comparable<CoordinateTransform> {
 
       // All this trouble because we need ncd before we can build.
       CoordinateTransform ct =
-          CoordTransBuilder.makeCoordinateTransform(ncd, attributeContainer, new Formatter(), new Formatter());
+          CoordTransBuilder.makeCoordinateTransform(ncd, attributeContainer, new Formatter(), new Formatter(), coordAxes);
       if (ct != null) {
         // ct.name = this.name; // LOOK why is this commented out? Dont know name until this point? Not going to
         // work....

--- a/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/CoordinateTransform.java
@@ -254,8 +254,8 @@ public class CoordinateTransform implements Comparable<CoordinateTransform> {
       }
 
       // All this trouble because we need ncd before we can build.
-      CoordinateTransform ct =
-          CoordTransBuilder.makeCoordinateTransform(ncd, attributeContainer, new Formatter(), new Formatter(), coordAxes);
+      CoordinateTransform ct = CoordTransBuilder.makeCoordinateTransform(ncd, attributeContainer, new Formatter(),
+          new Formatter(), coordAxes);
       if (ct != null) {
         // ct.name = this.name; // LOOK why is this commented out? Dont know name until this point? Not going to
         // work....

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
@@ -41,6 +41,10 @@ public abstract class AbstractTransformBuilder {
     return getFalseEastingScaleFactor(units);
   }
 
+  public static String getGeoCoordinateUnits(NetcdfDataset ds, AttributeContainer ctv) {
+    return getGeoCoordinateUnits(ds, ctv, ds.getCoordinateAxes());
+  }
+
   public static String getGeoCoordinateUnits(NetcdfDataset ds, AttributeContainer ctv, ImmutableList<CoordinateAxis> coordAxes) {
     String units = ctv.findAttributeString(CDM.UNITS, null);
     if (units != null && !units.equals("")) {

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
@@ -48,11 +48,13 @@ public abstract class AbstractTransformBuilder {
     }
 
     for (CoordinateAxis axis : coordAxes) {
-      if (axis.getAxisType() == AxisType.GeoX) { // kludge - what if there's multiple ones?
-        Variable v = axis.getOriginalVariable(); // LOOK why original variable ?
-        units = (v == null) ? axis.getUnitsString() : v.getUnitsString();
-        break;
+      if (axis.getAxisType() != AxisType.GeoX) { // kludge - what if there's multiple ones?
+        continue;
       }
+
+      Variable v = axis.getOriginalVariable(); // LOOK why original variable ?
+      units = (v == null) ? axis.getUnitsString() : v.getUnitsString();
+      break;
     }
 
     if (units != null) {

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
@@ -45,7 +45,8 @@ public abstract class AbstractTransformBuilder {
     return getGeoCoordinateUnits(ds, ctv, ds.getCoordinateAxes());
   }
 
-  public static String getGeoCoordinateUnits(NetcdfDataset ds, AttributeContainer ctv, ImmutableList<CoordinateAxis> coordAxes) {
+  public static String getGeoCoordinateUnits(NetcdfDataset ds, AttributeContainer ctv,
+      ImmutableList<CoordinateAxis> coordAxes) {
     String units = ctv.findAttributeString(CDM.UNITS, null);
     if (units != null && !units.equals("")) {
       return units;

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
@@ -6,6 +6,8 @@
 package ucar.nc2.dataset.transform;
 
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
@@ -35,27 +37,31 @@ public abstract class AbstractTransformBuilder {
    * (projection_y_coordinate).
    */
   public static double getFalseEastingScaleFactor(NetcdfDataset ds, AttributeContainer ctv) {
-    String units = getGeoCoordinateUnits(ds, ctv);
+    String units = getGeoCoordinateUnits(ds, ctv, ds.getCoordinateAxes());
     return getFalseEastingScaleFactor(units);
   }
 
-  public static String getGeoCoordinateUnits(NetcdfDataset ds, AttributeContainer ctv) {
+  public static String getGeoCoordinateUnits(NetcdfDataset ds, AttributeContainer ctv, ImmutableList<CoordinateAxis> coordAxes) {
     String units = ctv.findAttributeString(CDM.UNITS, null);
-    if (units == null) {
-      List<CoordinateAxis> axes = ds.getCoordinateAxes();
-      for (CoordinateAxis axis : axes) {
-        if (axis.getAxisType() == AxisType.GeoX) { // kludge - what if there's multiple ones?
-          Variable v = axis.getOriginalVariable(); // LOOK why original variable ?
-          units = (v == null) ? axis.getUnitsString() : v.getUnitsString();
-          break;
-        }
+    if (units != null && !units.equals("")) {
+      return units;
+    }
+
+    for (CoordinateAxis axis : coordAxes) {
+      if (axis.getAxisType() == AxisType.GeoX) { // kludge - what if there's multiple ones?
+        Variable v = axis.getOriginalVariable(); // LOOK why original variable ?
+        units = (v == null) ? axis.getUnitsString() : v.getUnitsString();
+        break;
       }
-      if (units == null) {
-        Variable xvar = ds.findVariableByAttribute(null, _Coordinate.AxisType.toString(), AxisType.GeoX.toString());
-        if (xvar != null) {
-          units = xvar.getUnitsString();
-        }
-      }
+    }
+
+    if (units != null) {
+      return units;
+    }
+
+    Variable xvar = ds.findVariableByAttribute(null, _Coordinate.AxisType.toString(), AxisType.GeoX.toString());
+    if (xvar != null) {
+      units = xvar.getUnitsString();
     }
     return units;
   }

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordinatesHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordinatesHelper.java
@@ -58,8 +58,8 @@ public class CoordinatesHelper {
     addAxes(ncd.getRootGroup(), axes);
     coordAxes = ImmutableList.copyOf(axes);
 
-    coordTransforms =
-        builder.coordTransforms.stream().map(ct -> ct.build(ncd, coordAxes)).filter(Objects::nonNull).collect(Collectors.toList());
+    coordTransforms = builder.coordTransforms.stream().map(ct -> ct.build(ncd, coordAxes)).filter(Objects::nonNull)
+        .collect(Collectors.toList());
 
     coordTransforms.addAll(builder.verticalCTBuilders.stream().map(ct -> ct.makeVerticalCT(ncd))
         .filter(Objects::nonNull).collect(Collectors.toList()));

--- a/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordinatesHelper.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/dataset/CoordinatesHelper.java
@@ -59,7 +59,7 @@ public class CoordinatesHelper {
     coordAxes = ImmutableList.copyOf(axes);
 
     coordTransforms =
-        builder.coordTransforms.stream().map(ct -> ct.build(ncd)).filter(Objects::nonNull).collect(Collectors.toList());
+        builder.coordTransforms.stream().map(ct -> ct.build(ncd, coordAxes)).filter(Objects::nonNull).collect(Collectors.toList());
 
     coordTransforms.addAll(builder.verticalCTBuilders.stream().map(ct -> ct.makeVerticalCT(ncd))
         .filter(Objects::nonNull).collect(Collectors.toList()));


### PR DESCRIPTION
## Description of Changes

Due to an issue with the codebase, the units of the x and y axes cannot be checked until the classes handling projection are already initialized. This results in the issue that the projection conversion always assumes that units are in km, when they might not be (see #1278).
This PR is a fix for this issue, but it definitely needs to be replaced with a better approach some time later. As mentioned, this seems to be a rather deeply rooted issue with the way a NetcdfDataset gets initialized. Judging by some comments, this also [isn't a new problem](https://github.com/Unidata/netcdf-java/blob/f2ad9739f2faa446315f7197f194e966887f228a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java#L1616C1-L1619C59).

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [ ] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
