### PR TITLE
Avoid FileNotFound exception when URL points to a directory

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/DatasetUrl.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/DatasetUrl.java
@@ -516,7 +516,7 @@ public class DatasetUrl {
   }
 
   private static boolean checkIfNcml(File file) throws IOException {
-    if (!file.exists()) {
+    if (!file.exists() || file.isDirectory()) {
       return false;
     }
 

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestDatasetUrl.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestDatasetUrl.java
@@ -124,4 +124,9 @@ public class TestDatasetUrl {
     testFind("cdms3:thredds-test-data?ncml/testStandalone.ncml", ServiceType.NCML);
     testFind("cdms3://profile_name@my.endpoint.edu/bucket-name?super/long/key.ncml#delimiter=/", ServiceType.NCML);
   }
+
+  @Test
+  public void shouldReturnNullForDirectory() throws IOException {
+    testFind(System.getProperty("user.dir"), null);
+  }
 }


### PR DESCRIPTION
Ensure an existing file is not a directory to avoid `FileNotFound` exception with opening `FileInputStream`

## Description of Changes

_Erase this and add a general description of changes, heads-up on any tricky parts, etc., here._

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
