### PR TITLE
Fix Zarr last modified

### DIFF
--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -227,7 +227,8 @@ public class ZarrHeader {
 
   private List<Attribute> makeAttributes(RandomAccessDirectoryItem item) {
     // get RandomAccessFile for JSON parsing
-    try (RandomAccessFile raf = item.getOrOpenRaf()) {
+    try {
+      RandomAccessFile raf = item.getOrOpenRaf();
       // read attributes from file
       raf.seek(0);
       Map<String, Object> attrMap = objectMapper.readValue(raf, HashMap.class);

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrIosp.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrIosp.java
@@ -139,4 +139,9 @@ public class ZarrIosp extends AbstractIOServiceProvider {
     }
     return fillValue;
   }
+
+  @Override
+  public long getLastModified() {
+    return raf.getLastModified();
+  }
 }

--- a/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrIosp.java
+++ b/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrIosp.java
@@ -296,4 +296,12 @@ public class TestZarrIosp {
     assertThat(double_ninf.getDouble(0)).isEqualTo(Double.NEGATIVE_INFINITY);
   }
 
+  @Test
+  public void testLastModified() throws IOException {
+    for (String uri : stores) {
+      try (NetcdfFile ncfile = NetcdfFiles.open(uri)) {
+        assertThat(ncfile.getLastModified()).isNotEqualTo(0);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description of Changes

Changes needed for https://github.com/Unidata/tds/issues/444:

- add `getLastModified` override to `ZarrIosp` which uses the `raf`'s last modified. This is instead of using the default one which creates an `MFile` based on the path, which doesn't work correctly for local zips and S3 zarr "directories".
- Fix issue in the `ZarrHeader` that the `raf` belonging to the `item` is closed while `item` is still in use.
- Add test
