### PR TITLE
Update nearly equals

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/util/Misc.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/Misc.java
@@ -98,7 +98,9 @@ public class Misc {
 
   /** RelativeDifference is less than maxRelDiff. */
   public static boolean nearlyEquals(float a, float b, float maxRelDiff) {
-    return DoubleMath.fuzzyEquals(a, b, maxRelDiff);
+    double maxAbsValue = Math.max(Math.abs(a), Math.abs(b));
+    double maxAbsDiff = maxRelDiff * maxAbsValue;
+    return DoubleMath.fuzzyEquals(a, b, maxAbsDiff);
   }
 
   /** RelativeDifference is less than {@link #defaultMaxRelativeDiffDouble}. */
@@ -108,7 +110,9 @@ public class Misc {
 
   /** RelativeDifference is less than maxRelDiff. */
   public static boolean nearlyEquals(double a, double b, double maxRelDiff) {
-    return DoubleMath.fuzzyEquals(a, b, maxRelDiff);
+    double maxAbsValue = Math.max(Math.abs(a), Math.abs(b));
+    double maxAbsDiff = maxRelDiff * maxAbsValue;
+    return DoubleMath.fuzzyEquals(a, b, maxAbsDiff);
   }
 
   /** AbsoluteDifference is less than maxAbsDiff. */

--- a/cdm/core/src/main/java/ucar/nc2/util/Misc.java
+++ b/cdm/core/src/main/java/ucar/nc2/util/Misc.java
@@ -113,12 +113,12 @@ public class Misc {
 
   /** AbsoluteDifference is less than maxAbsDiff. */
   public static boolean nearlyEqualsAbs(float a, float b, float maxAbsDiff) {
-    return absoluteDifference(a, b) <= Math.abs(maxAbsDiff);
+    return DoubleMath.fuzzyEquals(a, b, maxAbsDiff);
   }
 
   /** AbsoluteDifference is less than maxAbsDiff. */
   public static boolean nearlyEqualsAbs(double a, double b, double maxAbsDiff) {
-    return absoluteDifference(a, b) <= Math.abs(maxAbsDiff);
+    return DoubleMath.fuzzyEquals(a, b, maxAbsDiff);
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/cdm/core/src/test/java/ucar/nc2/util/TestMisc.java
+++ b/cdm/core/src/test/java/ucar/nc2/util/TestMisc.java
@@ -1,0 +1,32 @@
+package ucar.nc2.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static ucar.nc2.util.Misc.nearlyEquals;
+import static ucar.nc2.util.Misc.nearlyEqualsAbs;
+
+import org.junit.Test;
+
+public class TestMisc {
+
+  @Test
+  public void shouldCompareWithRelativeDifference() {
+    assertThat(nearlyEquals(100.0, 99.0, 1)).isTrue();
+    assertThat(nearlyEquals(100.0, 99.0, 0.01)).isTrue();
+    assertThat(nearlyEquals(100.0, 99.0, 0.001)).isFalse();
+
+    assertThat(nearlyEquals(100.0f, 99.0f, 1)).isTrue();
+    assertThat(nearlyEquals(100.0f, 99.0f, 0.01)).isTrue();
+    assertThat(nearlyEquals(100.0f, 99.0f, 0.001)).isFalse();
+  }
+
+  @Test
+  public void shouldCompareWithAbsoluteDifference() {
+    assertThat(nearlyEqualsAbs(100.0, 99.0, 1)).isTrue();
+    assertThat(nearlyEqualsAbs(100.0, 99.0, 0.01)).isFalse();
+    assertThat(nearlyEqualsAbs(100.0, 99.0, 0.001)).isFalse();
+
+    assertThat(nearlyEqualsAbs(100.0f, 99.0f, 1)).isTrue();
+    assertThat(nearlyEqualsAbs(100.0f, 99.0f, 0.01)).isFalse();
+    assertThat(nearlyEqualsAbs(100.0f, 99.0f, 0.001)).isFalse();
+  }
+}


### PR DESCRIPTION
## Description of Changes

- Change `nearlyEquals` back to comparing with a relative difference instead of absolute difference. I believe this is the correct behavior for if `ConvertMissing` uses this `nearlyEquals` comparison after a `ScaleOffset` has been applied and possible changed the values by several orders of magnitude.
- Use `fuzzyEquals` library function also for the absolution difference helpers.
- Add tests