### PR TITLE
Fix zarr last modified

### DIFF
--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrIosp.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrIosp.java
@@ -142,6 +142,13 @@ public class ZarrIosp extends AbstractIOServiceProvider {
 
   @Override
   public long getLastModified() {
+    if (raf == null) {
+      try {
+        reacquire();
+      } catch (IOException e) {
+        return 0;
+      }
+    }
     return raf.getLastModified();
   }
 }


### PR DESCRIPTION
Fix to zarr last modified function added in https://github.com/Unidata/netcdf-java/pull/1285 to avoid nullptr exception when cache is used. If the zarr file is put in the cache the `raf` is closed. For zarr, the `raf` (in this case `RandomAccessDirectory`) is the only class capable of computing the last modified correctly for zarr so we need to reacquire the `raf` to check this last modified. This is a bit sub optimal since the if the file is changed, the cache will reacquire the `raf` again.

Test added in TDS: https://github.com/Unidata/tds/pull/450