### PR TITLE
Optimization for inflating data

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
@@ -71,8 +71,8 @@ public class Deflate extends Filter {
   public byte[] decode(byte[] dataIn) throws IOException {
     int len = Math.min(8 * dataIn.length, MAX_ARRAY_LEN);
     try (ByteArrayInputStream in = new ByteArrayInputStream(dataIn);
-    InflaterInputStream iis = new InflaterInputStream(in, new Inflater(), dataIn.length);
-    ByteArrayOutputStream os = new ByteArrayOutputStream(len)) {
+        InflaterInputStream iis = new InflaterInputStream(in, new Inflater(), dataIn.length);
+        ByteArrayOutputStream os = new ByteArrayOutputStream(len)) {
 
       IO.copyB(iis, os, IO.default_socket_buffersize);
 

--- a/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
@@ -68,16 +68,14 @@ public class Deflate extends Filter {
 
   @Override
   public byte[] decode(byte[] dataIn) throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream(dataIn);
+    try (ByteArrayInputStream in = new ByteArrayInputStream(dataIn);
     InflaterInputStream iis = new InflaterInputStream(in, new Inflater(), dataIn.length);
+    ByteArrayOutputStream os = new ByteArrayOutputStream()) {
 
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    IO.copyB(iis, os, IO.default_socket_buffersize);
-    // close everything and return
-    in.close();
-    iis.close();
-    os.close();
-    return os.toByteArray();
+      IO.copyB(iis, os, IO.default_socket_buffersize);
+
+      return os.toByteArray();
+    }
   }
 
   public static class Provider implements FilterProvider {

--- a/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
@@ -19,6 +19,7 @@ import ucar.nc2.util.IO;
  * Filter implementation of zlib compression.
  */
 public class Deflate extends Filter {
+  private static final int MAX_ARRAY_LEN = Integer.MAX_VALUE - 8;
 
   private static final String name = "zlib";
 
@@ -68,9 +69,10 @@ public class Deflate extends Filter {
 
   @Override
   public byte[] decode(byte[] dataIn) throws IOException {
+    int len = Math.min(8 * dataIn.length, MAX_ARRAY_LEN);
     try (ByteArrayInputStream in = new ByteArrayInputStream(dataIn);
     InflaterInputStream iis = new InflaterInputStream(in, new Inflater(), dataIn.length);
-    ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+    ByteArrayOutputStream os = new ByteArrayOutputStream(len)) {
 
       IO.copyB(iis, os, IO.default_socket_buffersize);
 


### PR DESCRIPTION
## Description of Changes

A possible performance improvement of `Deflate::decode`.

- Use try with resources to ensure resources are always closed
- Initialize `ByteArrayOutputStream` with approximate capacity to avoid extra resizes (this is the capacity used in TDS 4.x)

