### PR TITLE
cdm-radial: sigmet fixes

### DIFF
--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/Ray.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/Ray.java
@@ -332,7 +332,7 @@ public class Ray {
           if (ddx == null)
             ii.setDoubleNext(SigmetVolumeScan.MISSING_VALUE_DOUBLE);
           else {
-            int ddx2 = dd[offset+1];
+            int ddx2 = dd[offset + 1];
             int rawValue = (ddx & 0xFF) | ((ddx2 & 0xFF) << 8);
             ii.setDoubleNext(SigmetIOServiceProvider.calcData(SigmetIOServiceProvider.recHdr, dty, rawValue));
           }

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/Ray.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/Ray.java
@@ -332,7 +332,7 @@ public class Ray {
           if (ddx == null)
             ii.setDoubleNext(SigmetVolumeScan.MISSING_VALUE_DOUBLE);
           else {
-            int ddx2 = dd[2];
+            int ddx2 = dd[offset+1];
             int rawValue = (ddx & 0xFF) | ((ddx2 & 0xFF) << 8);
             ii.setDoubleNext(SigmetIOServiceProvider.calcData(SigmetIOServiceProvider.recHdr, dty, rawValue));
           }

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/Ray.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/Ray.java
@@ -268,7 +268,7 @@ public class Ray {
           break;
         }
         raf.seek(cur_len);
-        for (int i = 0; i < dataRead1; i++) {
+        for (int i = 0; i < dataRead1 && nb < bins; i++) {
           dd[posInRay_absolute] = raf.readByte();
           posInRay_absolute++;
           if (posInRay_absolute % bytesPerBin == 0)
@@ -288,14 +288,15 @@ public class Ray {
       } else if (a00 > 0 & a00 != 1) {
         int num_zero = a00 * 2;
         int dataRead1 = num_zero;
-        for (int k = 0; k < dataRead1; k++) {
+        for (int k = 0; k < dataRead1 && nb < bins; k++) {
           dd[posInRay_absolute] = 0;
           posInRay_absolute++;
           if (posInRay_absolute % bytesPerBin == 0)
             nb++;
-        }
-        if (cur_len % SigmetVolumeScan.REC_SIZE == 0) {
-          break;
+
+          if (cur_len % SigmetVolumeScan.REC_SIZE == 0) {
+            break;
+          }
         }
       }
 

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
@@ -121,8 +121,8 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
   /**
    * Open existing file, and populate ncfile with it.
    */
-  public void open(RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile,
-                   ucar.nc2.util.CancelTask cancelTask) throws IOException {
+  public void open(RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile, ucar.nc2.util.CancelTask cancelTask)
+      throws IOException {
     super.open(raf, ncfile, cancelTask);
     // java.util.Map<String, Number> recHdr=new java.util.HashMap<String, Number>();
     Map<String, String> hdrNames = new java.util.HashMap<>();
@@ -275,8 +275,7 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
    * @param hdrNames java.util.Map with values for "StationName.." Attributes
    * @return ArrayList of Variables of ncfile
    */
-  public ArrayList<Variable> init(RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile,
-                                  Map<String, String> hdrNames) {
+  public ArrayList<Variable> init(RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile, Map<String, String> hdrNames) {
     // prepare attribute values
     String[] data_name = SigmetVolumeScan.data_name;
     String[] unit = SigmetVolumeScan.data_unit;
@@ -782,7 +781,7 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
     if (posSweep > 0)
       groupName = groupName.substring(0, posSweep);
     if (groupName.startsWith(RAW_VARIABLE_PREFIX))
-        groupName = groupName.substring(RAW_VARIABLE_PREFIX.length());
+      groupName = groupName.substring(RAW_VARIABLE_PREFIX.length());
 
     groups = volScan.getGroup(groupName);
     if (groups == null)
@@ -871,8 +870,7 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
    * @param channel WritableByteChannel object - channel that can write bytes.
    * @return the number of bytes written, possibly zero.
    */
-  public long readToByteChannel11(Variable v2, Section section, WritableByteChannel channel)
-      throws IOException {
+  public long readToByteChannel11(Variable v2, Section section, WritableByteChannel channel) throws IOException {
     Array data = readData(v2, section);
     float[] ftdata = new float[(int) data.getSize()];
     byte[] bytedata = new byte[(int) data.getSize() * 4];
@@ -1036,7 +1034,7 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         // doing no rounding in this case as below for the other cases
         BigDecimal bd = new BigDecimal(temp);
         return bd.floatValue();
-        //logger.warn("calcData: unimplemented 1 byte data type = " + dty + " " + SigmetVolumeScan.data_name[dty]);
+      // logger.warn("calcData: unimplemented 1 byte data type = " + dty + " " + SigmetVolumeScan.data_name[dty]);
     }
     BigDecimal bd = new BigDecimal(temp);
     // this should be reviewed, not sure why would you want a loss of precision here?
@@ -1086,7 +1084,7 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         // TODO implement for more SigmetVolumeScan.data_name (only 2 bytes)
         // using only the raw value
         temp = data;
-        //logger.warn("calcData: unimplemented 2 byte data type = " + dty + " " + SigmetVolumeScan.data_name[dty]);
+        // logger.warn("calcData: unimplemented 2 byte data type = " + dty + " " + SigmetVolumeScan.data_name[dty]);
         break;
     }
 

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
@@ -617,11 +617,23 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         rgp = volScan.getGroup("Reflectivity");
       if (rgp == null || rgp.isEmpty())
         rgp = volScan.getGroup("Reflectivity_2");
-      List[] sgp = new ArrayList[number_sweeps];
-      for (int i = 0; i < number_sweeps; i++) {
-        sgp[i] = (List) rgp.get((short) i);
-      }
 
+      List[] sgp = new ArrayList[number_sweeps];
+      for (int sweepMinus1 = 0; sweepMinus1 < number_sweeps; sweepMinus1++) {
+        List<Ray> found = null;
+        // in case some rays are missing/empty this is a safer way to find them
+        for (int i = 0; i < rgp.size() && found == null; i++) {
+          List<Ray> rlist = (List<Ray>) rgp.get(i);
+          if (rlist.size() > 0) {
+            Ray r = rlist.get(0);
+            if (r.getNsweep() == sweepMinus1 + 1) {
+              found = rlist;
+            }
+          }
+        }
+
+        sgp[sweepMinus1] = found;
+      }
 
       Variable[] time = new Variable[number_sweeps];
       ArrayInt.D1[] timeArr = new ArrayInt.D1[number_sweeps];
@@ -641,13 +653,18 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         timeArr[i] = (ArrayInt.D1) Array.factory(DataType.INT, time[i].getShape());
         timeIndex[i] = timeArr[i].getIndex();
         List rlist = sgp[i];
-        int num_rays_actual = Math.min(num_rays, rlist.size());
-
-        for (int jj = 0; jj < num_rays_actual; jj++) {
-          rtemp[jj] = (Ray) rlist.get(jj);
-        } // ray[i][jj]; }
-        for (int jj = 0; jj < num_rays_actual; jj++) {
-          timeArr[i].setInt(timeIndex[i].set(jj), rtemp[jj].getTime());
+        if (rlist == null) {
+          for (int jj = 0; jj < num_rays; jj++) {
+            timeArr[i].setInt(timeIndex[i].set(jj), -999);
+          }
+        } else {
+          int num_rays_actual = Math.min(num_rays, rlist.size());
+          for (int jj = 0; jj < num_rays_actual; jj++) {
+            rtemp[jj] = (Ray) rlist.get(jj);
+          } // ray[i][jj]; }
+          for (int jj = 0; jj < num_rays_actual; jj++) {
+            timeArr[i].setInt(timeIndex[i].set(jj), rtemp[jj].getTime());
+          }
         }
       }
 
@@ -668,13 +685,18 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         azimArr[i] = (ArrayFloat.D1) Array.factory(DataType.FLOAT, azimuthR[i].getShape());
         azimIndex[i] = azimArr[i].getIndex();
         List rlist = sgp[i];
-        int num_rays_actual = Math.min(num_rays, rlist.size());
-
-        for (int jj = 0; jj < num_rays_actual; jj++) {
-          rtemp[jj] = (Ray) rlist.get(jj);
-        } // ray[i][jj]; }
-        for (int jj = 0; jj < num_rays_actual; jj++) {
-          azimArr[i].setFloat(azimIndex[i].set(jj), rtemp[jj].getAz());
+        if (rlist == null) {
+          for (int jj = 0; jj < num_rays; jj++) {
+            azimArr[i].setFloat(azimIndex[i].set(jj), -999.99f);
+          }
+        } else {
+          int num_rays_actual = Math.min(num_rays, rlist.size());
+          for (int jj = 0; jj < num_rays_actual; jj++) {
+            rtemp[jj] = (Ray) rlist.get(jj);
+          } // ray[i][jj]; }
+          for (int jj = 0; jj < num_rays_actual; jj++) {
+            azimArr[i].setFloat(azimIndex[i].set(jj), rtemp[jj].getAz());
+          }
         }
       }
 
@@ -695,13 +717,18 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         elevArr[i] = (ArrayFloat.D1) Array.factory(DataType.FLOAT, elevationR[i].getShape());
         elevIndex[i] = elevArr[i].getIndex();
         List rlist = sgp[i];
-        int num_rays_actual = Math.min(num_rays, rlist.size());
-
-        for (int jj = 0; jj < num_rays_actual; jj++) {
-          rtemp[jj] = (Ray) rlist.get(jj);
-        } // ray[i][jj]; }
-        for (int jj = 0; jj < num_rays_actual; jj++) {
-          elevArr[i].setFloat(elevIndex[i].set(jj), rtemp[jj].getElev());
+        if (rlist == null) {
+          for (int jj = 0; jj < num_rays; jj++) {
+            elevArr[i].setFloat(elevIndex[i].set(jj), -999.99f);
+          }
+        } else {
+          int num_rays_actual = Math.min(num_rays, rlist.size());
+          for (int jj = 0; jj < num_rays_actual; jj++) {
+            rtemp[jj] = (Ray) rlist.get(jj);
+          } // ray[i][jj]; }
+          for (int jj = 0; jj < num_rays_actual; jj++) {
+            elevArr[i].setFloat(elevIndex[i].set(jj), rtemp[jj].getElev());
+          }
         }
       }
 
@@ -719,13 +746,16 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
 
       for (int i = 0; i < number_sweeps; i++) {
         List rlist = sgp[i];
-        int num_rays_actual = Math.min(num_rays, rlist.size());
-
-        for (int jj = 0; jj < num_rays_actual; jj++) {
-          rtemp[jj] = (Ray) rlist.get(jj);
-        } // ray[i][jj]; }
-        ngates = rtemp[0].getBins();
-        gatesArr.setInt(gatesIndex.set(i), ngates);
+        if (rlist == null) {
+          gatesArr.setInt(gatesIndex.set(i), -999);
+        } else {
+          int num_rays_actual = Math.min(num_rays, rlist.size());
+          for (int jj = 0; jj < num_rays_actual; jj++) {
+            rtemp[jj] = (Ray) rlist.get(jj);
+          } // ray[i][jj]; }
+          ngates = rtemp[0].getBins();
+          gatesArr.setInt(gatesIndex.set(i), ngates);
+        }
       }
 
       for (int i = 0; i < number_sweeps; i++) {

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetIOServiceProvider.java
@@ -386,7 +386,7 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         builder.setDimensions(dims2).addAttribute(new Attribute(CDM.LONG_NAME, var_name))
             .addAttribute(new Attribute(CDM.UNITS, unit[dty]))
             .addAttribute(new Attribute(_Coordinate.Axes, "time elevationR azimuthR distanceR"));
-        v[j][jj] = builder.build(null);
+        v[j][jj] = builder.build(ncfile.getRootGroup());
         ncfile.addVariable(null, v[j][jj]);
         varList.add(v[j][jj]);
         dims2.clear();
@@ -1065,7 +1065,7 @@ public class SigmetIOServiceProvider extends AbstractIOServiceProvider {
         if (bytes == 1)
           return DataType.BYTE;
 
-        return DataType.OBJECT;
+        return DataType.OPAQUE;
     }
   }
 

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetVolumeScan.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetVolumeScan.java
@@ -27,115 +27,109 @@ public class SigmetVolumeScan {
    * if suffix is "_2" it means a two byte value instead of just one byte
    * (2 bytes are experimental at this point - didn't have a file to test)
    */
-  public static final String[] data_name = {
-          "ExtendedHeaders", // ? bytes
-          "TotalPower", "Reflectivity", "Velocity", "Width", "DifferentialReflectivity", "[6]", "CorrectedReflectivity", // 1 byte
-          "TotalPower_2", "Reflectivity_2", "Velocity_2", "Width_2", "DifferentialReflectivity_2", // 2 bytes
-          "RainfallRate_2" /* 2 bytes */, "KDPDifferentialPhase" /* 1 byte */, "KDPDifferentialPhase_2" /* 2 bytes */,
-          "PhiDPDifferentialPhase" /* 1 byte */, "CorrectedVelocity" /* 1 byte */, "SQI" /* 1 byte */,
-          "RhoHV" /* 1 byte */, "RhoHV_2" /* 2 bytes */,
-          "CorrectedReflectivity_2" /* 2 bytes */, "CorrectedVelocity_2" /* 2 bytes */, "SQI_2" /* 2 bytes */,
-          "PhiDPDifferentialPhase_2" /* 2 bytes */,
-          "LDRH" /* 1 byte */, "LDRH_2" /* 2 bytes */, "LDRV" /* 1 byte */, "LDRV_2" /* 2 bytes */,
-          "[29]", "[30]", "[31]",
-          "Height" /* 1 byte */, "LinearLiquid_2" /* 2 bytes */, "RawData" /* ? */,
-          "WindShear" /* 1 byte */, "Divergence_2" /* 2 bytes */, "FloatedLiquid_2" /* 2 bytes */,
-          "UserType" /* 1 byte */, "UnspecifiedData" /* 1 byte */, "Deformation_2" /* 2 bytes */,
-          "VerticalVelocity_2" /* 2 bytes */, "HorizontalVelocity_2" /* 2 bytes */,
-          "HorizontalWindDirection_2" /* 2 bytes */, "AxisOfDilatation_2" /* 2 bytes */, "TimeInSeconds_2" /* 2 bytes */,
-          "RHOH" /* 1 byte */, "RHOH_2" /* 2 bytes */, "RHOV" /* 1 byte */, "RHOV_2" /* 2 bytes */,
-          "PHIH" /* 1 byte */, "PHIH_2" /* 2 bytes */, "PHIV" /* 1 byte */, "PHIV_2" /* 2 bytes */,
-          "UserType_2" /* 2 bytes */, "HydrometeorClass" /* 1 byte */, "HydrometeorClass_2" /* 2 bytes */,
-          "CorrectedDifferentialReflectivity" /* 1 byte */, "CorrectedDifferentialReflectivity_2" /* 2 bytes */,
-          // 16 empty
-          "[59]", "[60]", "[61]", "[62]", "[63]", "[64]", "[65]", "[66]", "[67]", "[68]", "[69]", "[70]", "[71]", "[72]", "[73]", "[74]",
-          "PolarimetricMeteoIndex" /* 1 byte */, "PolarimetricMeteoIndex_2" /* 2 bytes */,
-          "LOG8" /* 1 byte */, "LOG16_2" /* 2 bytes */, "CSP8" /* 1 byte */, "CSP16_2" /* 2 bytes */,
-          "CCOR8" /* 1 byte */, "CCOR16_2" /* 2 bytes */, "AH8" /* 1 byte */, "AH16_2" /* 2 bytes */,
-          "AV8" /* 1 byte */, "AV16_2" /* 2 bytes */, "AZDR8" /* 1 byte */, "AZDR16_2" /* 2 bytes */,
-  };
+  public static final String[] data_name = {"ExtendedHeaders", // ? bytes
+      "TotalPower", "Reflectivity", "Velocity", "Width", "DifferentialReflectivity", "[6]", "CorrectedReflectivity", // 1
+                                                                                                                     // byte
+      "TotalPower_2", "Reflectivity_2", "Velocity_2", "Width_2", "DifferentialReflectivity_2", // 2 bytes
+      "RainfallRate_2" /* 2 bytes */, "KDPDifferentialPhase" /* 1 byte */, "KDPDifferentialPhase_2" /* 2 bytes */,
+      "PhiDPDifferentialPhase" /* 1 byte */, "CorrectedVelocity" /* 1 byte */, "SQI" /* 1 byte */, "RhoHV" /* 1 byte */,
+      "RhoHV_2" /* 2 bytes */, "CorrectedReflectivity_2" /* 2 bytes */, "CorrectedVelocity_2" /* 2 bytes */,
+      "SQI_2" /* 2 bytes */, "PhiDPDifferentialPhase_2" /* 2 bytes */, "LDRH" /* 1 byte */, "LDRH_2" /* 2 bytes */,
+      "LDRV" /* 1 byte */, "LDRV_2" /* 2 bytes */, "[29]", "[30]", "[31]", "Height" /* 1 byte */,
+      "LinearLiquid_2" /* 2 bytes */, "RawData" /* ? */, "WindShear" /* 1 byte */, "Divergence_2" /* 2 bytes */,
+      "FloatedLiquid_2" /* 2 bytes */, "UserType" /* 1 byte */, "UnspecifiedData" /* 1 byte */,
+      "Deformation_2" /* 2 bytes */, "VerticalVelocity_2" /* 2 bytes */, "HorizontalVelocity_2" /* 2 bytes */,
+      "HorizontalWindDirection_2" /* 2 bytes */, "AxisOfDilatation_2" /* 2 bytes */, "TimeInSeconds_2" /* 2 bytes */,
+      "RHOH" /* 1 byte */, "RHOH_2" /* 2 bytes */, "RHOV" /* 1 byte */, "RHOV_2" /* 2 bytes */, "PHIH" /* 1 byte */,
+      "PHIH_2" /* 2 bytes */, "PHIV" /* 1 byte */, "PHIV_2" /* 2 bytes */, "UserType_2" /* 2 bytes */,
+      "HydrometeorClass" /* 1 byte */, "HydrometeorClass_2" /* 2 bytes */,
+      "CorrectedDifferentialReflectivity" /* 1 byte */, "CorrectedDifferentialReflectivity_2" /* 2 bytes */,
+      // 16 empty
+      "[59]", "[60]", "[61]", "[62]", "[63]", "[64]", "[65]", "[66]", "[67]", "[68]", "[69]", "[70]", "[71]", "[72]",
+      "[73]", "[74]", "PolarimetricMeteoIndex" /* 1 byte */, "PolarimetricMeteoIndex_2" /* 2 bytes */,
+      "LOG8" /* 1 byte */, "LOG16_2" /* 2 bytes */, "CSP8" /* 1 byte */, "CSP16_2" /* 2 bytes */, "CCOR8" /* 1 byte */,
+      "CCOR16_2" /* 2 bytes */, "AH8" /* 1 byte */, "AH16_2" /* 2 bytes */, "AV8" /* 1 byte */, "AV16_2" /* 2 bytes */,
+      "AZDR8" /* 1 byte */, "AZDR16_2" /* 2 bytes */,};
 
   /*
-    Some units are unknown, some were correlated and assumed by ChatGPT.
-    Not all might be correct!
-    Just extending the initial list here from previous version of SigmetIOServiceProvider
-    // TODO fill and double check
+   * Some units are unknown, some were correlated and assumed by ChatGPT.
+   * Not all might be correct!
+   * Just extending the initial list here from previous version of SigmetIOServiceProvider
+   * // TODO fill and double check
    */
-  public static final String[] data_unit = {
-          "?", // DB_XHDR: Extended Headers
-          "dBm", // DB_DBT: Total Power (1 byte)
-          "dBZ", // DB_DBZ: Reflectivity (1 byte)
-          "m/s", // DB_VEL: Velocity (1 byte)
-          "m/s", // DB_WIDTH: Width (1 byte)
-          "dB", // DB_ZDR: Differential Reflectivity (1 byte)
-          "?", // empty
-          "dBZ", // DB_DBZC: Corrected Reflectivity (1 byte)
-          "dBm", // DB_DBT2: Total Power (2 byte)
-          "dBZ", // DB_DBZ2: Reflectivity (2 byte)
-          "m/s", // DB_VEL2: Velocity (2 byte)
-          "m/s", // DB_WIDTH2: Width (2 byte)
-          "dB", // DB_ZDR2: Differential Reflectivity (2 byte)
-          "mm/hr", // DB_RAINRATE2: Rainfall Rate (2 byte)
-          "°/km", // DB_KDP: KDP (Differential Phase) (1 byte)
-          "°/km", // DB_KDP2: KDP (Differential Phase) (2 byte)
-          "°", // DB_PHIDP: PhiDP (Differential Phase) (1 byte)
-          "m/s", // DB_VELC: Corrected Velocity (1 byte)
-          "?", // DB_SQI: SQI (Signal Quality Index) (1 byte)
-          "?", // DB_RHOHV: RhoHV (1 byte)
-          "?", // DB_RHOHV2: RhoHV (2 byte)
-          "dBZ", // DB_DBZC2: Corrected Reflectivity (2 byte)
-          "m/s", // DB_VELC2: Corrected Velocity (2 byte)
-          "?", // DB_SQI2: SQI (Signal Quality Index) (2 byte)
-          "°", // DB_PHIDP2: PhiDP (Differential Phase) (2 byte)
-          "?", // DB_LDRH: LDR xmt H rcv V (1 byte)
-          "?", // DB_LDRH2: LDR xmt H rcv V (2 byte)
-          "?", // DB_LDRV: LDR xmt V rcv H (1 byte)
-          "?", // DB_LDRV2: LDR xmt V rcv H (2 byte)
-          // 3 empty
-          "?",  "?",  "?",
-          "1/10 km", // DB_HEIGHT: Height (1/10 km) (1 byte)
-          ".001mm", // DB_VIL2: Linear liquid (.001mm) (2 byte)
-          "?", // DB_RAW: Unknown unit or unitless (Raw Data)
-          "m/s", // DB_SHEAR: Shear (Velocity difference)
-          "?", // DB_DIVERGE2: Divergence (2 byte)
-          "mm", // DB_FLIQUID2: Liquid equivalent (2 byte)
-          "?", // DB_USER: User-defined (unit depends on definition)
-          "?", // DB_OTHER: Other data type (unit depends on definition)
-          "1/s", // DB_DEFORM2: Deformation (2 byte)
-          "m/s", // DB_VVEL2: Vertical Velocity (2 byte)
-          "m/s", // DB_HVEL2: Horizontal Velocity (2 byte)
-          "°", // DB_HDIR2: Horizontal Direction (2 byte)
-          "1/s", // DB_AXDIL2: Axis of Dilation (2 byte)
-          "s", // DB_TIME2: Time (2 byte)
-          "?", // DB_RHOH: RhoH (1 byte)
-          "?", // DB_RHOH2: RhoH (2 byte)
-          "?", // DB_RHOV: RhoV (1 byte)
-          "?", // DB_RHOV2: RhoV (2 byte)
-          "°", // DB_PHIH: PhiH (1 byte)
-          "°", // DB_PHIH2: PhiH (2 byte)
-          "°", // DB_PHIV: PhiV (1 byte)
-          "°", // DB_PHIV2: PhiV (2 byte)
-          "?", // DB_USER2: User-defined (2 byte)
-          "?", // DB_HCLASS: Hydrometeor Classification (1 byte)
-          "?", // DB_HCLASS2: Hydrometeor Classification (2 byte)
-          "dB", // DB_ZDRC: Corrected Differential Reflectivity (1 byte)
-          "dB", // DB_ZDRC2: Corrected Differential Reflectivity (2 byte)
-          // 16 empty
-          "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?",
-          "?", // PolarimetricMeteoIndex (1 byte)
-          "?", // PolarimetricMeteoIndex2 (2 bytes)
-          "?", // LOG8 (1 byte)
-          "?", // LOG16 (2 bytes)
-          "?", // CSP8 (1 byte)
-          "?", // CSP16 (2 bytes)
-          "?", // CCOR8 (1 byte)
-          "?", // CCOR16 (2 bytes)
-          "?", // AH8 (1 byte)
-          "?", // AH16 (2 bytes)
-          "?", // AV8 (1 byte)
-          "?", // AV16 (2 bytes)
-          "?", // AZDR8 (1 byte)
-          "?", // AZDR16 (2 bytes)
+  public static final String[] data_unit = {"?", // DB_XHDR: Extended Headers
+      "dBm", // DB_DBT: Total Power (1 byte)
+      "dBZ", // DB_DBZ: Reflectivity (1 byte)
+      "m/s", // DB_VEL: Velocity (1 byte)
+      "m/s", // DB_WIDTH: Width (1 byte)
+      "dB", // DB_ZDR: Differential Reflectivity (1 byte)
+      "?", // empty
+      "dBZ", // DB_DBZC: Corrected Reflectivity (1 byte)
+      "dBm", // DB_DBT2: Total Power (2 byte)
+      "dBZ", // DB_DBZ2: Reflectivity (2 byte)
+      "m/s", // DB_VEL2: Velocity (2 byte)
+      "m/s", // DB_WIDTH2: Width (2 byte)
+      "dB", // DB_ZDR2: Differential Reflectivity (2 byte)
+      "mm/hr", // DB_RAINRATE2: Rainfall Rate (2 byte)
+      "°/km", // DB_KDP: KDP (Differential Phase) (1 byte)
+      "°/km", // DB_KDP2: KDP (Differential Phase) (2 byte)
+      "°", // DB_PHIDP: PhiDP (Differential Phase) (1 byte)
+      "m/s", // DB_VELC: Corrected Velocity (1 byte)
+      "?", // DB_SQI: SQI (Signal Quality Index) (1 byte)
+      "?", // DB_RHOHV: RhoHV (1 byte)
+      "?", // DB_RHOHV2: RhoHV (2 byte)
+      "dBZ", // DB_DBZC2: Corrected Reflectivity (2 byte)
+      "m/s", // DB_VELC2: Corrected Velocity (2 byte)
+      "?", // DB_SQI2: SQI (Signal Quality Index) (2 byte)
+      "°", // DB_PHIDP2: PhiDP (Differential Phase) (2 byte)
+      "?", // DB_LDRH: LDR xmt H rcv V (1 byte)
+      "?", // DB_LDRH2: LDR xmt H rcv V (2 byte)
+      "?", // DB_LDRV: LDR xmt V rcv H (1 byte)
+      "?", // DB_LDRV2: LDR xmt V rcv H (2 byte)
+      // 3 empty
+      "?", "?", "?", "1/10 km", // DB_HEIGHT: Height (1/10 km) (1 byte)
+      ".001mm", // DB_VIL2: Linear liquid (.001mm) (2 byte)
+      "?", // DB_RAW: Unknown unit or unitless (Raw Data)
+      "m/s", // DB_SHEAR: Shear (Velocity difference)
+      "?", // DB_DIVERGE2: Divergence (2 byte)
+      "mm", // DB_FLIQUID2: Liquid equivalent (2 byte)
+      "?", // DB_USER: User-defined (unit depends on definition)
+      "?", // DB_OTHER: Other data type (unit depends on definition)
+      "1/s", // DB_DEFORM2: Deformation (2 byte)
+      "m/s", // DB_VVEL2: Vertical Velocity (2 byte)
+      "m/s", // DB_HVEL2: Horizontal Velocity (2 byte)
+      "°", // DB_HDIR2: Horizontal Direction (2 byte)
+      "1/s", // DB_AXDIL2: Axis of Dilation (2 byte)
+      "s", // DB_TIME2: Time (2 byte)
+      "?", // DB_RHOH: RhoH (1 byte)
+      "?", // DB_RHOH2: RhoH (2 byte)
+      "?", // DB_RHOV: RhoV (1 byte)
+      "?", // DB_RHOV2: RhoV (2 byte)
+      "°", // DB_PHIH: PhiH (1 byte)
+      "°", // DB_PHIH2: PhiH (2 byte)
+      "°", // DB_PHIV: PhiV (1 byte)
+      "°", // DB_PHIV2: PhiV (2 byte)
+      "?", // DB_USER2: User-defined (2 byte)
+      "?", // DB_HCLASS: Hydrometeor Classification (1 byte)
+      "?", // DB_HCLASS2: Hydrometeor Classification (2 byte)
+      "dB", // DB_ZDRC: Corrected Differential Reflectivity (1 byte)
+      "dB", // DB_ZDRC2: Corrected Differential Reflectivity (2 byte)
+      // 16 empty
+      "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", // PolarimetricMeteoIndex (1
+                                                                                           // byte)
+      "?", // PolarimetricMeteoIndex2 (2 bytes)
+      "?", // LOG8 (1 byte)
+      "?", // LOG16 (2 bytes)
+      "?", // CSP8 (1 byte)
+      "?", // CSP16 (2 bytes)
+      "?", // CCOR8 (1 byte)
+      "?", // CCOR16 (2 bytes)
+      "?", // AH8 (1 byte)
+      "?", // AH16 (2 bytes)
+      "?", // AV8 (1 byte)
+      "?", // AV16 (2 bytes)
+      "?", // AZDR8 (1 byte)
+      "?", // AZDR16 (2 bytes)
   };
 
   private HashMap<String, List<List<Ray>>> allGroups = new HashMap<>();
@@ -248,16 +242,17 @@ public class SigmetVolumeScan {
         for (int i = 0; i < nparams; i++) {
           int idh_len = cur_len + 12 + i * 76; // + 12 == skipping over <structure_header>
 
-          /* debug structure_header
-          raf.seek(idh_len-12);
-          // Structure identifier
-          short si = raf.readShort();
-          raf.readShort(); // format version
-          int nob = raf.readInt();
-          if (si != (short)24)
-            throw new IllegalStateException("not a Ingest_header");
-          raf.readShort(); // reserved
-          raf.readShort(); // flags
+          /*
+           * debug structure_header
+           * raf.seek(idh_len-12);
+           * // Structure identifier
+           * short si = raf.readShort();
+           * raf.readShort(); // format version
+           * int nob = raf.readInt();
+           * if (si != (short)24)
+           * throw new IllegalStateException("not a Ingest_header");
+           * raf.readShort(); // reserved
+           * raf.readShort(); // flags
            */
 
           raf.seek(idh_len);
@@ -275,7 +270,7 @@ public class SigmetVolumeScan {
           num_rays_exp[i] = raf.readShort();
           beg += num_rays_exp[i]; // before num_rays_act[i] was used but it does seem not work
           num_rays_act[i] = raf.readShort();
-          //beg += num_rays_act[i]; // idh_len+20
+          // beg += num_rays_act[i]; // idh_len+20
           angl_swp[i] = raf.readShort(); // idh_len+22
           // TODO maybe use in stead of variable twoBytes?
           bin_len[i] = raf.readShort(); // idh_len+24
@@ -455,7 +450,7 @@ public class SigmetVolumeScan {
           nb++;
           if (twoBytes) {
             cur_len++;
-            //i++;?
+            // i++;?
           }
 
           if (cur_len % REC_SIZE == 0) {
@@ -526,7 +521,7 @@ public class SigmetVolumeScan {
             nb = nb + 1;
             if (twoBytes) {
               cur_len++;
-              //ii++;?
+              // ii++;?
             }
 
             if (cur_len % REC_SIZE == 0) {

--- a/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetVolumeScan.java
+++ b/cdm/radial/src/main/java/ucar/nc2/iosp/sigmet/SigmetVolumeScan.java
@@ -6,8 +6,6 @@
 
 package ucar.nc2.iosp.sigmet;
 
-// ~--- non-JDK imports --------------------------------------------------------
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
@@ -160,12 +158,8 @@ public class SigmetVolumeScan {
   /**
    * Read all the values from SIGMET-IRIS file which are necessary to fill in the ncfile.
    *
-   * @param raf ucar.unidata.io.RandomAccessFile corresponds to SIGMET datafile.
-   * @param ncfile an empty NetcdfFile object which will be filled.
-   * @param varList ArrayList of Variables of ncfile
    */
-  SigmetVolumeScan(RandomAccessFile raf, ucar.nc2.NetcdfFile ncfile, ArrayList<Variable> varList)
-      throws java.io.IOException {
+  SigmetVolumeScan(RandomAccessFile raf) throws java.io.IOException {
     int len = 12288; // ---- Read from the 3d record----------- 6144*2=12288
     short nrec = 0, nsweep = 1, nray = 0, byteoff = 0;
     int nwords, end_words, data_read = 0, num_zero, rays_count = 0, nb = 0, posInRay_relative = 0,


### PR DESCRIPTION
- Support for all data types instead of just the basic 5 (power, reflectivity, width, differential reflectivity)
- Universal handling for data types instead of each one separately 
- Most new data types are returned as raw values meaning no normalization/decoding done like for the basic 5 - see chapter 4.4
- This includes support for data types that span more than one byte per bin
- Added comments and small fixes

Ultimately all these changes add support for IDEAM Colombia files

Addresses the github issue Unidata/netcdf-java#1292

I worked with this version of the Sigmet/IRIS specification: IRIS-Programming-Guide-M211318EN.pdf
(not attaching it because of copyright)


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [ ] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
