### PR TITLE
Improve test reliability

### DIFF
--- a/httpservices/src/main/java/ucar/httpservices/HTTPConnections.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPConnections.java
@@ -96,8 +96,14 @@ abstract class HTTPConnections {
     return this.protocolregistry;
   }
 
+  // For testing
   void validate() {
     assert actualconnections == 0;
+  }
+
+  // For testing
+  int getActualConnections() {
+    return actualconnections;
   }
 
   public abstract HttpClientConnectionManager newManager(HTTPMethod m);

--- a/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
+++ b/httpservices/src/main/java/ucar/httpservices/HTTPSession.java
@@ -1116,9 +1116,13 @@ public class HTTPSession implements Closeable {
     return getSessionURI();
   }
 
-  // Obsolete
-  // make package private as only needed for testing
+  // For testing
   static void validatestate() {
     connmgr.validate();
+  }
+
+  // For testing
+  static int getActualConnections() {
+    return connmgr.getActualConnections();
   }
 }

--- a/httpservices/src/test/java/ucar/httpservices/TestThreading.java
+++ b/httpservices/src/test/java/ucar/httpservices/TestThreading.java
@@ -32,6 +32,8 @@
 
 package ucar.httpservices;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -75,6 +77,7 @@ public class TestThreading extends UnitTestCommon {
   protected String[] testurls;
 
   protected int nthreads = DFALTTHREADS;
+  private final int actualConnectionsBefore;
 
   //////////////////////////////////////////////////
 
@@ -92,6 +95,7 @@ public class TestThreading extends UnitTestCommon {
       }
     }
     definetests();
+    actualConnectionsBefore = HTTPSession.getActualConnections();
   }
 
   protected void definetests() {
@@ -152,7 +156,7 @@ public class TestThreading extends UnitTestCommon {
       }
     }
     logger.debug("All threads terminated");
-    HTTPSession.validatestate();
+    assertThat(HTTPSession.getActualConnections()).isEqualTo(actualConnectionsBefore);
   }
 
   @Test
@@ -173,7 +177,7 @@ public class TestThreading extends UnitTestCommon {
       }
     }
     logger.debug("All threads terminated");
-    HTTPSession.validatestate();
+    assertThat(HTTPSession.getActualConnections()).isEqualTo(actualConnectionsBefore);
   }
 
   static class Runner implements Runnable {

--- a/httpservices/src/test/java/ucar/httpservices/TestUrlCreds.java
+++ b/httpservices/src/test/java/ucar/httpservices/TestUrlCreds.java
@@ -7,7 +7,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -21,6 +21,7 @@ public class TestUrlCreds {
   private String username;
   private String password;
   private String host;
+  private final int actualConnectionsBefore;
 
   // Each parameter should be placed as an argument here
   // Every time runner triggers, it will pass the arguments
@@ -30,6 +31,7 @@ public class TestUrlCreds {
     this.username = username;
     this.password = password;
     this.host = host;
+    actualConnectionsBefore = HTTPSession.getActualConnections();
   }
 
   @Parameterized.Parameters
@@ -78,8 +80,8 @@ public class TestUrlCreds {
     }
   }
 
-  @AfterClass
-  public static void checkAllConnectionsClosed() {
-    HTTPSession.validatestate();
+  @After
+  public void checkAllConnectionsClosed() {
+    assertThat(HTTPSession.getActualConnections()).isEqualTo(actualConnectionsBefore);
   }
 }


### PR DESCRIPTION
Improve test reliability by checking the actual connections is same as before and after test instead of checking it is 0. 

The `actualconnections` will increase any time a new `HTTPConnection` is opened, but if this isn't opened with try-with-resources, the connection may not be closed. So if we check if the `actualconnections == 0` in our tests, we are testing that everywhere in the tests run before the `HTTPConnections` have been closed properly, which probably is not always the case.

## Description of Changes

_Erase this and add a general description of changes, heads-up on any tricky parts, etc., here._

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
