### PR TITLE
Improve S3 Zarr performance

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -5,6 +5,7 @@
 
 package ucar.nc2;
 
+import com.google.common.collect.Lists;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -19,6 +20,7 @@ import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.zip.GZIPInputStream;
@@ -788,8 +790,12 @@ public class NetcdfFiles {
       return new N3iospNew();
 
     } else {
-      // look for dynamically loaded IOSPs
-      for (IOServiceProvider loadedSpi : ServiceLoader.load(IOServiceProvider.class)) {
+      // look for dynamically loaded IOSPs, and sort before using
+      final ServiceLoader<IOServiceProvider> iosps = ServiceLoader.load(IOServiceProvider.class);
+      final List<IOServiceProvider> sortedIosps = Lists.newArrayList(iosps);
+      Collections.sort(sortedIosps);
+
+      for (IOServiceProvider loadedSpi : sortedIosps) {
         if (loadedSpi.isValidFile(raf)) {
           Class c = loadedSpi.getClass();
           try {

--- a/cdm/core/src/main/java/ucar/nc2/iosp/IOServiceProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/IOServiceProvider.java
@@ -35,7 +35,7 @@ import ucar.unidata.io.RandomAccessFile;
  *
  * @author caron
  */
-public interface IOServiceProvider {
+public interface IOServiceProvider extends Comparable<IOServiceProvider> {
 
   /**
    * Check if this is a valid file for this IOServiceProvider.
@@ -243,4 +243,28 @@ public interface IOServiceProvider {
    */
   String getFileTypeDescription();
 
+  /**
+   * Used to determine the ordering for dynamically loaded IOServiceProviders.
+   */
+  enum SortGroup {
+    GROUP_1, LAST_GROUP,
+  }
+
+  /**
+   * Get the SortGroup for this IOServiceProvider. This determines the order in which the dynamically loaded
+   * IOServiceProviders are checked to see if they can open a file with isValidFile().
+   *
+   * @return SortGroup, by default the SortGroup.LAST_GROUP will be used.
+   */
+  default SortGroup getSortGroup() {
+    return SortGroup.LAST_GROUP;
+  }
+
+  /**
+   * Use the SortGroup to determine the ordering for dynamically loaded IOServiceProviders.
+   */
+  @Override
+  default int compareTo(IOServiceProvider other) {
+    return getSortGroup().compareTo(other.getSortGroup());
+  }
 }

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrIosp.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrIosp.java
@@ -38,6 +38,16 @@ public class ZarrIosp extends AbstractIOServiceProvider {
     return raf.isDirectory();
   }
 
+  /**
+   * Set the SortGroup to GROUP_1 so this IOSP will be checked first, since `isValidFile()` is a quick check
+   *
+   * @return SortGroup.GROUP_1
+   */
+  @Override
+  public SortGroup getSortGroup() {
+    return SortGroup.GROUP_1;
+  }
+
   @Override
   public String getFileTypeId() {
     return fileTypeId;


### PR DESCRIPTION
## Description of Changes

There is no way to control the order of the IOSP classes loaded by the `ServiceLoader`. This can result in very slow performance for S3 Zarr files, since many IOSPs will want to read the data to check if it is a valid file of their type. The `ZarrIosp` check is super fast since it only needs to check whether its Raf is a directory type.

I propose to add a new method to the `IOServiceProvider` interface that will sort the IOSPs into two (or later more) groups so that the fast/common IOSPs can be checked first and the rest checked later.


