### PR TITLE
Fix remove deleted files from cache

### DIFF
--- a/cdm/core/src/test/java/ucar/nc2/util/cache/TestRandomAccessFileCacheCleanup.java
+++ b/cdm/core/src/test/java/ucar/nc2/util/cache/TestRandomAccessFileCacheCleanup.java
@@ -21,7 +21,7 @@ public class TestRandomAccessFileCacheCleanup {
   @BeforeClass
   public static void enableCache() {
     RandomAccessFile.shutdown();
-    cache = new FileCache("RandomAccessFile", 0, 1, 1, 0);
+    cache = new FileCache("RandomAccessFile", 0, 1, 1, 0, true);
     RandomAccessFile.setGlobalFileCache(cache);
     assertThat(cache.showCache().size()).isEqualTo(0);
   }


### PR DESCRIPTION
This addresses a possible problem with the fix from https://github.com/Unidata/netcdf-java/pull/1268. The goal there was to cleanup deleted files from the cache, since some users had issues deleting files that were locked by the RandomAccessFile cache. However, that change affected both that and the NetcdfFile cache, where a `location` can be a file path or a url path (say for an aggregation). Since the url path doesn't point to an existing file it will always remove that from the cache. Here I propose fixing this by having a flag that can be turned on for the RandomAccessFile cache but off for other caches. Update to TDS in https://github.com/Unidata/tds/pull/463.