### PR TITLE
Fix grib collection NaNs bug

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxisBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxisBuilder.java
@@ -133,6 +133,10 @@ public class CoverageCoordAxisBuilder {
   // for point: values are the points, values[npts]
   // for intervals: values are the edges, values[2*npts]: low0, high0, low1, high1
 
+  public void setMissingTolerance(double tolerance) {
+    missingTolerance = tolerance;
+  }
+
   public void setSpacingFromValues(boolean isInterval) {
     if (isInterval) {
       setSpacingFromIntervalValues();
@@ -227,7 +231,7 @@ public class CoverageCoordAxisBuilder {
     }
   }
 
-  private static final double missingTolerance = .05;
+  private double missingTolerance = .05;
 
   private boolean isRegular(Counters.Counter resol) {
     if (resol.getUnique() == 1) {

--- a/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
+++ b/grib/src/main/java/ucar/nc2/grib/coverage/GribCoverageDataset.java
@@ -852,6 +852,7 @@ public class GribCoverageDataset implements CoverageReader, CoordAxisReader {
     CoverageCoordAxisBuilder builder =
         new CoverageCoordAxisBuilder(refName, master.getUnit(), Grib.GRIB_RUNTIME, DataType.DOUBLE, AxisType.RunTime,
             atts, CoverageCoordAxis.DependenceType.dependent, time.getName(), null, length, 0, 0, 0, data, this);
+    builder.setMissingTolerance(0.0);
     builder.setSpacingFromValues(false);
 
     return new CoverageCoordAxis1D(builder);


### PR DESCRIPTION
Fix issue that a variable missing from one grib partition would result in all values of the variable after that time returning NaN for the "best" dataset. This was due to the runtime axis being marked regular if the number of missing values is less than 5%. With a regular runtime axis, the variable is assumed to have values for all runtimes which messes up the lookup for which partition contains which runtime.

The proposed fix is to not allow a tolerance of 5% in the case of the grib coverage runtime axis. The runtime axis with missing values will then be marked irregular instead of regular, so it will keep track of which exact values it has.

Related to previous issue: https://github.com/Unidata/netcdf-java/pull/1063
Integration test added to the TDS for this fix: https://github.com/Unidata/tds/pull/473
Jenkins tests passing on this branch: https://jenkins-aws.unidata.ucar.edu/job/tara-netcdf-java/51/


