### PR TITLE
Update jdom2 2.0.6 -> 2.0.6.1

### DIFF
--- a/netcdf-java-platform/build.gradle
+++ b/netcdf-java-platform/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api "com.google.protobuf:protoc:${depVersion.protobuf}"
     api 'com.google.guava:guava:32.0.1-jre'
     api 'com.google.re2j:re2j:1.3'
-    api 'org.jdom:jdom2:2.0.6'
+    api 'org.jdom:jdom2:2.0.6.1'
     api 'joda-time:joda-time:2.10.3' // replace by javax.time
 
     // netcdf4, dap4

--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -12,14 +12,6 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-       file name: jdom2-2.0.6.jar
-       reason: mitigated by https://github.com/Unidata/netcdf-java/pull/801
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.jdom/jdom2@.*$</packageUrl>
-    <cve>CVE-2021-33813</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
       file name: screenshot_sync
       reason: False positive.  We do not use the fredsmith utils.
     ]]></notes>


### PR DESCRIPTION
jdom 2.0.6 contains vulnerability
https://avd.aquasec.com/nvd/2021/cve-2021-33813/

version 2.0.6.1 has been released to address this.

## Description of Changes

_Erase this and add a general description of changes, heads-up on any tricky parts, etc., here._

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
