### PR TITLE
Fix performance issue that aggregation cache not used for coverages

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageDatasetFactory.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageDatasetFactory.java
@@ -126,8 +126,21 @@ public class CoverageDatasetFactory {
 
   }
 
+  /**
+   * @deprecated Use openNcmlString(String, String)
+   */
+  @Deprecated
   public static Optional<FeatureDatasetCoverage> openNcmlString(String ncml) throws IOException {
-    NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), null, null);
+    return openNcmlString(ncml, null);
+  }
+
+  /**
+   * @param ncml the NcML as a String
+   * @param location the URL location string of the NcML document,
+   *        or may be just a unique name for caching purposes (if null, aggregation cache will not be used).
+   */
+  public static Optional<FeatureDatasetCoverage> openNcmlString(String ncml, String location) throws IOException {
+    NetcdfDataset ncd = NetcdfDatasets.openNcmlDataset(new StringReader(ncml), location, null);
 
     DtCoverageDataset gds = new DtCoverageDataset(ncd);
     if (!gds.getGrids().isEmpty()) {

--- a/cdm/s3/src/test/java/ucar/nc2/internal/ncml/s3/S3AggScanFeatureType.java
+++ b/cdm/s3/src/test/java/ucar/nc2/internal/ncml/s3/S3AggScanFeatureType.java
@@ -96,7 +96,7 @@ public class S3AggScanFeatureType {
       ncml = ncmlStream.collect(Collectors.joining());
     }
     assertThat(ncml).isNotNull();
-    Optional<FeatureDatasetCoverage> fdc = CoverageDatasetFactory.openNcmlString(ncml);
+    Optional<FeatureDatasetCoverage> fdc = CoverageDatasetFactory.openNcmlString(ncml, null);
     assertThat(fdc.isPresent()).isTrue();
     List<CoverageCollection> cc = fdc.get().getCoverageCollections();
     checkCoverages(cc);


### PR DESCRIPTION
The aggregation cache for join existing aggregations stores coordinate information so that all files don't need to be opened on every request. For this cache to be used, `NetcdfFile.location` must be a non null value. This PR ensures the `location` is not null when an ncml dataset is opened as a coverage (for instance with NCSS).

Use this change in the TDS: https://github.com/Unidata/tds/pull/475