### PR TITLE
Convert missing values before scale and offset

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
@@ -13,6 +13,8 @@ import ucar.nc2.dataset.NetcdfDataset.Enhance;
 import ucar.nc2.filter.*;
 import ucar.nc2.internal.dataset.CoordinatesHelper;
 import ucar.nc2.util.CancelTask;
+import ucar.nc2.util.Misc;
+
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -719,7 +721,7 @@ public class VariableDS extends Variable implements VariableEnhanced, EnhanceSca
 
   @Override
   public boolean isFillValue(double val) {
-    return hasFillValue && fillValue == val;
+    return hasFillValue && Misc.nearlyEquals(val, fillValue, Misc.defaultMaxRelativeDiffFloat);
   }
 
   @Override

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingUnsigned.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestScaleOffsetMissingUnsigned.java
@@ -286,8 +286,7 @@ public class TestScaleOffsetMissingUnsigned {
 
   // This test demonstrated the bug in https://github.com/Unidata/netcdf-java/issues/572, but for unsigned variables.
   @Test
-  public void testNegativeScaleOffsetValidRangeUnsigned()
-      throws URISyntaxException, IOException, InvalidRangeException {
+  public void testNegativeScaleOffsetValidRangeUnsigned() throws URISyntaxException, IOException {
     File testResource = new File(getClass().getResource("testScaleOffsetMissingUnsigned.ncml").toURI());
     float fpTol = 1e-6f;
 

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestStandardVar.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestStandardVar.java
@@ -330,7 +330,7 @@ public class TestStandardVar {
     Array A = v.read();
     Index ima = A.getIndex();
 
-    double val = A.getFloat(ima.set(1, 1));
+    double val = A.getDouble(ima.set(1, 1));
     assert Double.isNaN(val);
     assert v.isMissing(val);
 
@@ -340,7 +340,7 @@ public class TestStandardVar {
     A = v.read();
     ima = A.getIndex();
 
-    val = A.getFloat(ima.set(1, 1));
+    val = A.getDouble(ima.set(1, 1));
     Assert2.assertNearlyEquals(val, -999.99, 0.001);
     assert v.isMissing(val);
   }

--- a/cdm/core/src/test/java/ucar/nc2/filter/TestEnhancements.java
+++ b/cdm/core/src/test/java/ucar/nc2/filter/TestEnhancements.java
@@ -78,10 +78,8 @@ public class TestEnhancements {
 
     // short data with small scale and offsets
     Array smallVals = Array.factory(DataType.FLOAT, new int[] {dataLen}, missingData);
-
     builder.addVariable("smallVals", DataType.FLOAT, "dim").addAttribute(new Attribute(CDM.SCALE_FACTOR, 1e-12))
-        .addAttribute(new Attribute(CDM.ADD_OFFSET, 1e-12)).addAttribute(new Attribute(CDM.FILL_VALUE, 110));
-
+        .addAttribute(new Attribute(CDM.ADD_OFFSET, 1e-12)).addAttribute(new Attribute(CDM.FILL_VALUE, FILL_VALUE));
 
     // write data
     NetcdfFormatWriter writer = builder.build();
@@ -166,7 +164,7 @@ public class TestEnhancements {
   public void testConvertMissingWithSmallScaleAndOffset() throws IOException {
     Variable v = ncd.findVariable("smallVals");
     Array data = v.read();
-    assertThat(Double.isNaN(data.getDouble(2))).isTrue();
+    assertThat(Double.isNaN(data.getDouble(6))).isTrue();
     assertThat(Double.isNaN(data.getDouble(1))).isFalse();
   }
 }

--- a/cdm/core/src/test/resources/ucar/nc2/dataset/testScaleOffsetMissingUnsigned.ncml
+++ b/cdm/core/src/test/resources/ucar/nc2/dataset/testScaleOffsetMissingUnsigned.ncml
@@ -49,13 +49,6 @@
         <values>980 990 1000 1010 1020</values>
     </variable>
     
-    <variable name="unpackedValidRange" shape="5" type="ushort">
-        <attribute name="scale_factor" type="float" value="0.01" />
-        <attribute name="valid_range" type="float" value="9.9 10.1" />  <!-- already unpacked -->
-        
-        <values>980 990 1000 1010 1020</values>
-    </variable>
-    
     <variable name="unsignedOffsetAttribute" shape="1" type="byte">
         <attribute name="add_offset" type="byte" isUnsigned="true" value="-100" />  <!-- 156 -->
         <values>-50</values>


### PR DESCRIPTION
Swap the order that `ConvertMissing` and `ScaleOffset` are applied so that `ConvertMissing` uses packed values to check for missing values.


