### PR TITLE
set default projection units to km

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/geoloc/ProjectionImpl.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/ProjectionImpl.java
@@ -76,7 +76,7 @@ public abstract class ProjectionImpl implements Projection, java.io.Serializable
   /**
    * name of the default units for this projection
    */
-  protected String defaultUnits;
+  protected String defaultUnits = "kilometers";
 
   /**
    * flag for latlon

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
@@ -73,12 +73,4 @@ public class TestNetcdfDataset {
       assertThat((Object) datasetVariable).isInstanceOf(VariableDS.class);
     }
   }
-
-  @Test
-  public void testUserIssue() throws IOException {
-    String filePath = TestDir.cdmLocalTestDataDir + "era5.nc";
-    NetcdfDataset ncDataset = NetcdfDataset.openDataset(filePath);
-    System.out.println(ncDataset);
-    ncDataset.close();
-  }
 }

--- a/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
+++ b/cdm/core/src/test/java/ucar/nc2/dataset/TestNetcdfDataset.java
@@ -73,4 +73,12 @@ public class TestNetcdfDataset {
       assertThat((Object) datasetVariable).isInstanceOf(VariableDS.class);
     }
   }
+
+  @Test
+  public void testUserIssue() throws IOException {
+    String filePath = TestDir.cdmLocalTestDataDir + "era5.nc";
+    NetcdfDataset ncDataset = NetcdfDataset.openDataset(filePath);
+    System.out.println(ncDataset);
+    ncDataset.close();
+  }
 }


### PR DESCRIPTION
fixes https://github.com/Unidata/tds/issues/482 which occurs because the coordinate system is not converting meters to kilometers.