### PR TITLE
Use _ARRAY_DIMENSIONS to create shared, named dimensions in ZarrHeader

### DIFF
--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -286,8 +286,7 @@ public class ZarrHeader {
     int[] shape = zarray.getShape();
 
     if (hasNamedDimensions && shape.length != dimNames.length) {
-      throw new IllegalArgumentException(
-          "Var " + vname + " has dimensions attribute count that does not match its rank.");
+      throw new ZarrFormatException("Array " + vname + " has dimensions attribute count that does not match its rank.");
     }
 
     final List<Dimension> dims = new ArrayList<>();
@@ -311,7 +310,7 @@ public class ZarrHeader {
           final Dimension prevd = optd.get();
 
           if (dd.getLength() != prevd.getLength()) {
-            throw new IllegalArgumentException("Named dimension " + dname + " seen with inconsistent lengths.");
+            throw new ZarrFormatException("Named dimension " + dname + " seen with inconsistent lengths.");
           }
         } else {
           logger.trace("adding {} to group as a shared dimension", dname);
@@ -331,6 +330,18 @@ public class ZarrHeader {
     VInfo vinfo = new VInfo(chunks, zarray.getFillValue(), zarray.getCompressor(), zarray.getByteOrder(),
         zarray.getOrder(), zarray.getSeparator(), zarray.getFilters(), dataOffset, initializedChunks);
     var.setSPobject(vinfo);
+
+    // Include some info from .zarray file in attributes for display when showing variable detail.
+    // Possibly add to this fill_value if in .zarray but not .zattrs?
+    if (attrs == null) {
+      attrs = new ArrayList<Attribute>();
+    }
+    final Filter compressor = zarray.getCompressor();
+    if (compressor == null) {
+      attrs.add(new Attribute("_Compressor", "none"));
+    } else {
+      attrs.add(new Attribute("_Compressor", zarray.getCompressor().getName()));
+    }
 
     // add current attributes, if any exist
     if (attrs != null) {

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -239,35 +239,39 @@ public class ZarrHeader {
     String[] dimNames = null;
     boolean hasNamedDimensions = false;
 
-    for (Attribute attr : attrs) {
-      final String attrName = attr.getName();
-      if ("_ARRAY_DIMENSIONS".equals(attrName)) {
-        try {
-          final ArrayObject.D1 aod1 = (ArrayObject.D1) attr.getValues();
+    if (attrs != null) {
 
-          // getSize returns a long
-          final int aodSize = (int) aod1.getSize();
-          dimNames = new String[aodSize];
+      for (Attribute attr : attrs) {
+        final String attrName = attr.getName();
+        if ("_ARRAY_DIMENSIONS".equals(attrName)) {
+          try {
+            final ArrayObject.D1 aod1 = (ArrayObject.D1) attr.getValues();
 
-          for (int i = 0; i < aodSize; ++i) {
-            dimNames[i] = (String) aod1.get(i);
+            // getSize returns a long
+            final int aodSize = (int) aod1.getSize();
+            dimNames = new String[aodSize];
+
+            for (int i = 0; i < aodSize; ++i) {
+              dimNames[i] = (String) aod1.get(i);
+            }
+            hasNamedDimensions = true;
+            // logger.trace(" found _ARRAY_DIMENSIONS array {}", aod1);
+          } catch (final Exception exc) {
+            logger.debug("  Could not extract _ARRAY_DIMENSIONS for {}, {}", vname, exc.getMessage());
           }
-          hasNamedDimensions = true;
-          // logger.trace(" found _ARRAY_DIMENSIONS array {}", aod1);
-        } catch (final Exception exc) {
-          logger.debug("  Could not extract _ARRAY_DIMENSIONS for {}, {}", vname, exc.getMessage());
+
+          //// Informational logging
+          // } else if ("coordinates".equals(attrName) || "standard_name".equals(attrName) || "units".equals(attrName))
+          //// {
+          // try {
+          // ArrayObject.D1 aod1 = (ArrayObject.D1) attr.getValues();
+          // String coordsStr = (String) aod1.get(0);
+          // logger.trace(" var {} has {} attr '{}'", vname, attrName, coordsStr);
+          // } catch (final Exception exc) {
+          // logger.debug(" Exception extracting {} attr value, {}", attrName, exc.getMessage());
+          // }
+
         }
-
-        //// Informational logging
-        // } else if ("coordinates".equals(attrName) || "standard_name".equals(attrName) || "units".equals(attrName)) {
-        // try {
-        // ArrayObject.D1 aod1 = (ArrayObject.D1) attr.getValues();
-        // String coordsStr = (String) aod1.get(0);
-        // logger.trace(" var {} has {} attr '{}'", vname, attrName, coordsStr);
-        // } catch (final Exception exc) {
-        // logger.debug(" Exception extracting {} attr value, {}", attrName, exc.getMessage());
-        // }
-
       }
     }
 

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrKeys.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrKeys.java
@@ -14,6 +14,7 @@ public final class ZarrKeys {
   public static final String ZARRAY = ".zarray";
   public static final String ZATTRS = ".zattrs";
   public static final String ZGROUP = ".zgroup";
+  public static final String ZMETADATA = ".zmetadata";
 
   // key names
   public static final String SHAPE = "shape";

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -52,6 +52,8 @@ dependencies {
   netcdfAll project(':cdm:cdm-image')
   netcdfAll project(':cdm:cdm-radial')
   netcdfAll project(':cdm:cdm-misc')
+  netcdfAll project(':cdm:cdm-s3')
+  netcdfAll project(':cdm:cdm-zarr')
   netcdfAll project(':bufr')
   netcdfAll project(':grib')
   netcdfAll project(':netcdf4')

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -52,8 +52,6 @@ dependencies {
   netcdfAll project(':cdm:cdm-image')
   netcdfAll project(':cdm:cdm-radial')
   netcdfAll project(':cdm:cdm-misc')
-  netcdfAll project(':cdm:cdm-s3')
-  netcdfAll project(':cdm:cdm-zarr')
   netcdfAll project(':bufr')
   netcdfAll project(':grib')
   netcdfAll project(':netcdf4')


### PR DESCRIPTION
## Description of Changes

This PR adds code to the ZarrHeader class to look for the xarray/geozarr _ARRAY_DIMENSIONS attribute and, if present, use it to name a variable's dimensions and to create shared dimensions with the variable's group.

This is a first effort to see how much code/effort was necessary and may not consider cases where this info should be explicitly be ignored, or if there are additional Exceptions that one needs to watch for.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
