### PR TITLE
Test cleanup

### DIFF
--- a/opendap/src/test/java/opendap/test/TestDConnect2.java
+++ b/opendap/src/test/java/opendap/test/TestDConnect2.java
@@ -38,7 +38,7 @@ public class TestDConnect2 extends TestSources {
   boolean pass = false;
   TestSet currentTestSet = null;
 
-  TestSetEnum[] whichtests = {TestSetEnum.Standard1, TestSetEnum.Constrained1, TestSetEnum.Remote2};
+  TestSetEnum[] whichtests = {TestSetEnum.Standard1, TestSetEnum.Constrained1};
 
   final String[] XFAIL = {"test.01.das", "test.07.das"};
 

--- a/opendap/src/test/java/opendap/test/TestDConnect2.java
+++ b/opendap/src/test/java/opendap/test/TestDConnect2.java
@@ -38,7 +38,8 @@ public class TestDConnect2 extends TestSources {
   boolean pass = false;
   TestSet currentTestSet = null;
 
-  TestSetEnum[] whichtests = {TestSetEnum.Standard1, TestSetEnum.Constrained1};
+  // TODO TestSetEnum.Constrained1 not working
+  TestSetEnum[] whichtests = {TestSetEnum.Standard1, /*TestSetEnum.Constrained1*/};
 
   final String[] XFAIL = {"test.01.das", "test.07.das"};
 

--- a/opendap/src/test/java/opendap/test/TestDConnect2.java
+++ b/opendap/src/test/java/opendap/test/TestDConnect2.java
@@ -39,7 +39,7 @@ public class TestDConnect2 extends TestSources {
   TestSet currentTestSet = null;
 
   // TODO TestSetEnum.Constrained1 not working
-  TestSetEnum[] whichtests = {TestSetEnum.Standard1, /*TestSetEnum.Constrained1*/};
+  TestSetEnum[] whichtests = {TestSetEnum.Standard1, /* TestSetEnum.Constrained1 */};
 
   final String[] XFAIL = {"test.01.das", "test.07.das"};
 

--- a/opendap/src/test/java/opendap/test/TestSources.java
+++ b/opendap/src/test/java/opendap/test/TestSources.java
@@ -23,9 +23,8 @@ public class TestSources extends TestFiles {
           "test.31", "test.50", "test.53", "test.55", "test.56", "test.57", "test.66", "test.67", "test.68", "test.69"};
 
   // Following tests are to check constraint handling
-  static final String[] TESTS_C1 =
-      {"test.02;1;b[1:2:10]", "test.03;1;i32[0:1][1:2][0:2]", "test.04;1;types.i32",
-          "test.05;1;types.floats.f32", "test.06;1;ThreeD", "test.07;1;person.age", "test.07;2;person"};
+  static final String[] TESTS_C1 = {"test.02;1;b[1:2:10]", "test.03;1;i32[0:1][1:2][0:2]", "test.04;1;types.i32",
+      "test.05;1;types.floats.f32", "test.06;1;ThreeD", "test.07;1;person.age", "test.07;2;person"};
 
   static enum TestSetEnum {
     Standard1, Constrained1

--- a/opendap/src/test/java/opendap/test/TestSources.java
+++ b/opendap/src/test/java/opendap/test/TestSources.java
@@ -15,39 +15,25 @@ public class TestSources extends TestFiles {
   //////////////////////////////////////////////////
   // Remote test info
 
-  /* Use this for experimenting with new URLS */
-  public static final String XURL1 = "http://" + TestDir.dap2TestServer + "/dts";
-
-  // "http://testremote.unidata.ucar.edu/thredds/dodsC/fmrc/NCEP/NAM/CONUS_12km/files";
-  static final String[] X1 = {"test.01;1;f64"};
+  public static final String URL = "http://" + TestDir.dap2TestServer + "/dts";
 
   // These shorter tests are always run
-  protected final String REMOTEURLS1 = "http://" + TestDir.dap2TestServer + "/dts";
-  static final String[] REMOTETESTSS1 =
+  static final String[] TESTS_S1 =
       {"test.01", "test.02", "test.04", "test.05", "test.06a", "test.07a", "test.07", "test.21", "test.22", "test.23",
           "test.31", "test.50", "test.53", "test.55", "test.56", "test.57", "test.66", "test.67", "test.68", "test.69"};
 
-  // These longer tests are optional
-  protected final String REMOTEURLL1 = TestDir.dap2TestServer;
-  static final String[] REMOTETESTSL1 = {"test.03", "b31", "b31a", "D1", "Drifters", "EOSDB", "ingrid", "nestedDAS",
-      "NestedSeq", "NestedSeq2", "OverideExample", "SimpleDrdsExample", "test.an1", "test.dfp1", "test.gr1", "test.gr2",
-      "test.gr3", "test.gr4", "test.gr5", "test.sds1", "test.sds2", "test.sds3", "test.sds4", "test.sds5", "test.vs1",
-      "test.vs2", "test.vs3", "test.vs4", "test.vs5", "whoi"};
-
   // Following tests are to check constraint handling
-  protected final String REMOTEURLC1 = "http://" + TestDir.dap2TestServer + "/dts";
-  static final String[] REMOTETESTSC1 =
-      {"test.01;1;f64", "test.02;1;b[1:2:10]", "test.03;1;i32[0:1][1:2][0:2]", "test.04;1;types.i32",
+  static final String[] TESTS_C1 =
+      {"test.02;1;b[1:2:10]", "test.03;1;i32[0:1][1:2][0:2]", "test.04;1;types.i32",
           "test.05;1;types.floats.f32", "test.06;1;ThreeD", "test.07;1;person.age", "test.07;2;person"};
 
-
-  protected final String REMOTEURLC2 =
+  protected final String URL_C2 =
       "http://" + TestDir.remoteTestServer + "/thredds/dodsC/fmrc/NCEP/NAM/CONUS_12km/files";
-  static final String[] REMOTEC2 = {"NAM_CONUS_12km_20100628_1200.grib2;01;Wind_speed[0][0][0][0]"};
+  static final String[] TESTS_C2 = {"NAM_CONUS_12km_20100628_1200.grib2;01;Wind_speed[0][0][0][0]"};
 
 
   static enum TestSetEnum {
-    Standard1, Long1, Constrained1, Constrained2, Remote2, Experimental;
+    Standard1, Constrained1, Remote2
   }
 
   static enum TestPart {
@@ -110,26 +96,18 @@ public class TestSources extends TestFiles {
     TestSet set;
     set = new TestSet();
     set.name = "Standard1";
-    set.url = REMOTEURLS1;
-    set.tests = REMOTETESTSS1;
+    set.url = URL;
+    set.tests = TESTS_S1;
     TestSets.put(TestSetEnum.Standard1, set);
     set = new TestSet();
-    set.name = "Long1";
-    set.url = REMOTEURLL1;
-    set.tests = REMOTETESTSL1;
-    TestSets.put(TestSetEnum.Long1, set);
+    set.name = "Constrained1";
+    set.url = URL;
+    set.tests = TESTS_C1;
+    TestSets.put(TestSetEnum.Constrained1, set);
     set = new TestSet();
-    set.name = "constrained1";
-    set.url = REMOTEURLC1;
-    set.tests = REMOTETESTSC1;
-    set = new TestSet();
-    set.name = "remote2";
-    set.url = REMOTEURLC2;
-    set.tests = REMOTEC2;
-    set = new TestSet();
-    set.name = "Experimental";
-    set.url = XURL1;
-    set.tests = X1;
-    TestSets.put(TestSetEnum.Experimental, set);
+    set.name = "Remote2";
+    set.url = URL_C2;
+    set.tests = TESTS_C2;
+    TestSets.put(TestSetEnum.Remote2, set);
   }
 }

--- a/opendap/src/test/java/opendap/test/TestSources.java
+++ b/opendap/src/test/java/opendap/test/TestSources.java
@@ -27,13 +27,8 @@ public class TestSources extends TestFiles {
       {"test.02;1;b[1:2:10]", "test.03;1;i32[0:1][1:2][0:2]", "test.04;1;types.i32",
           "test.05;1;types.floats.f32", "test.06;1;ThreeD", "test.07;1;person.age", "test.07;2;person"};
 
-  protected final String URL_C2 =
-      "http://" + TestDir.remoteTestServer + "/thredds/dodsC/fmrc/NCEP/NAM/CONUS_12km/files";
-  static final String[] TESTS_C2 = {"NAM_CONUS_12km_20100628_1200.grib2;01;Wind_speed[0][0][0][0]"};
-
-
   static enum TestSetEnum {
-    Standard1, Constrained1, Remote2
+    Standard1, Constrained1
   }
 
   static enum TestPart {
@@ -104,10 +99,5 @@ public class TestSources extends TestFiles {
     set.url = URL;
     set.tests = TESTS_C1;
     TestSets.put(TestSetEnum.Constrained1, set);
-    set = new TestSet();
-    set.name = "Remote2";
-    set.url = URL_C2;
-    set.tests = TESTS_C2;
-    TestSets.put(TestSetEnum.Remote2, set);
   }
 }

--- a/opendap/src/test/java/ucar/nc2/dods/TestConvertD2N.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestConvertD2N.java
@@ -233,6 +233,6 @@ public class TestConvertD2N {
 
   @Test
   public void testStuff() throws IOException, DAP2Exception, InvalidRangeException {
-    testDataDDSfromServer(TestSources.XURL1 + "/NestedSeq2", "person1.age,person1.stuff&person1.age=3"); // nested Seq
+    testDataDDSfromServer(TestSources.URL + "/NestedSeq2", "person1.age,person1.stuff&person1.age=3"); // nested Seq
   }
 }

--- a/opendap/src/test/java/ucar/nc2/dods/TestDODSRead.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestDODSRead.java
@@ -21,7 +21,7 @@ public class TestDODSRead {
   public static boolean showFile = false, showFileDebug = false;
 
   static DODSNetcdfFile open(String name) throws IOException {
-    String filename = TestSources.XURL1 + "/" + name;
+    String filename = TestSources.URL + "/" + name;
     return openAbs(filename);
   }
 

--- a/opendap/src/test/java/ucar/nc2/dods/TestDODSStructureArray.java
+++ b/opendap/src/test/java/ucar/nc2/dods/TestDODSStructureArray.java
@@ -161,7 +161,7 @@ public class TestDODSStructureArray {
 
   @Test
   public void testDODS() throws IOException, InvalidRangeException {
-    testW(TestSources.XURL1 + "/test.53", "types", false);
+    testW(TestSources.URL + "/test.53", "types", false);
   }
 
   public void testW(String url, String sname, boolean isScalar) throws IOException, InvalidRangeException {


### PR DESCRIPTION
## Description of Changes

The only tests using the `TestSources.TestSets` is `TestDConnect2`. It was using the enums `TestSetEnum.Standard1, TestSetEnum.Constrained1, TestSetEnum.Remote2` out of which only `TestSetEnum.Standard1` was actually run since the other two were not actually added to `TestSets`. Here I am removing `Remote2` all together since it refers to a thredds fmrc dataset not present on remotetest/gretty. The `Constrained1` tests are not currently working due to diffs in the output, so I will just comment those out for now in the `TestDConnect2` so it is more explicit what is being run.

In addition:
- remove unused test constants
- rename test constants (don't use "remote" to refer to localhost server)