### PR TITLE
Fix renaming a dimension in aggregations

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -810,9 +810,11 @@ public class NcmlReader {
 
     String nameInFile = dimElem.getAttributeValue("orgName") != null ? dimElem.getAttributeValue("orgName") : name;
 
-    // LOOK this is wrong, groupBuilder may already have the dimension.
     // see if it already exists
-    Dimension dim = (refGroup == null) ? null : refGroup.findDimension(nameInFile);
+    Optional<Dimension> dimFromAgg = groupBuilder.findDimension(nameInFile);
+    Dimension dim =
+        (refGroup == null || dimFromAgg.isPresent()) ? dimFromAgg.orElse(null) : refGroup.findDimension(nameInFile);
+
     if (dim == null) { // nope - create it
       String lengthS = dimElem.getAttributeValue("length");
       if (lengthS == null) {

--- a/cdm/core/src/test/data/ncml/aggregationRenameDim.xml
+++ b/cdm/core/src/test/data/ncml/aggregationRenameDim.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+
+  <dimension name="newTime" orgName="time"/>
+  <variable name="newTime" orgName="time" />
+  <variable name="newTime" shape="newTime" />
+  <variable name="P" shape="newTime lat lon" />
+  <variable name="T" shape="newTime lat lon" />
+
+  <aggregation dimName="time" type="joinExisting">
+    <netcdf location="nc/jan.nc"/>
+    <netcdf location="nc/feb.nc"/>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/data/ncml/aggregationScanRenameDim.xml
+++ b/cdm/core/src/test/data/ncml/aggregationScanRenameDim.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+
+  <dimension name="newTime" orgName="time"/>
+  <variable name="newTime" orgName="time" />
+  <variable name="newTime" shape="newTime" />
+  <variable name="P" shape="newTime lat lon" />
+  <variable name="T" shape="newTime lat lon" />
+
+  <aggregation dimName="time" type="joinExisting">
+    <scan location="nc/" regExp="^(jan.nc|feb.nc)$"/>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyDim.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyDim.java
@@ -3,8 +3,6 @@ package ucar.nc2.internal.ncml;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import ucar.ma2.Array;
 import ucar.ma2.IndexIterator;
@@ -14,44 +12,35 @@ import ucar.nc2.Variable;
 import ucar.nc2.ncml.TestNcmlRead;
 
 public class TestNcmlModifyDim {
-  private static final String filename = "file:./" + TestNcmlRead.topDir + "modifyDim.xml";
-  private static NetcdfFile ncfile = null;
-
-  @BeforeClass
-  public static void setUp() throws IOException {
-    ncfile = NcmlReader.readNcml(filename, null, null).build();
-  }
-
-  @AfterClass
-  public static void tearDown() throws IOException {
-    ncfile.close();
-  }
-
   @Test
   public void shouldRenameDim() throws IOException {
-    assertThat(ncfile.getRootGroup().getDimensions().size()).isEqualTo(3);
+    final String filename = "file:./" + TestNcmlRead.topDir + "modifyDim.xml";
 
-    Dimension newDim = ncfile.findDimension("newTime");
-    assertThat(newDim).isNotNull();
-    assertThat(newDim.isVariableLength()).isFalse();
-    assertThat(newDim.isShared()).isTrue();
-    assertThat(newDim.isUnlimited()).isTrue();
+    try (NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build()) {
+      assertThat(ncfile.getRootGroup().getDimensions().size()).isEqualTo(3);
 
-    Dimension oldDim = ncfile.findDimension("time");
-    assertThat(oldDim).isNull();
+      Dimension newDim = ncfile.findDimension("newTime");
+      assertThat(newDim).isNotNull();
+      assertThat(newDim.isVariableLength()).isFalse();
+      assertThat(newDim.isShared()).isTrue();
+      assertThat(newDim.isUnlimited()).isTrue();
 
-    Variable time = ncfile.findVariable("time");
-    assertThat((Object) time).isNotNull();
-    assertThat(time.getDimensionsString()).isEqualTo("newTime");
+      Dimension oldDim = ncfile.findDimension("time");
+      assertThat(oldDim).isNull();
 
-    Array data = time.read();
-    assertThat(data.getRank()).isEqualTo(1);
-    assertThat(data.getSize()).isEqualTo(4);
-    assertThat(data.getShape()[0]).isEqualTo(4);
-    assertThat(data.getElementType()).isEqualTo(int.class);
+      Variable time = ncfile.findVariable("time");
+      assertThat((Object) time).isNotNull();
+      assertThat(time.getDimensionsString()).isEqualTo("newTime");
 
-    IndexIterator dataIter = data.getIndexIterator();
-    assertThat(dataIter.getIntNext()).isEqualTo(6);
-    assertThat(dataIter.getIntNext()).isEqualTo(18);
+      Array data = time.read();
+      assertThat(data.getRank()).isEqualTo(1);
+      assertThat(data.getSize()).isEqualTo(4);
+      assertThat(data.getShape()[0]).isEqualTo(4);
+      assertThat(data.getElementType()).isEqualTo(int.class);
+
+      IndexIterator dataIter = data.getIndexIterator();
+      assertThat(dataIter.getIntNext()).isEqualTo(6);
+      assertThat(dataIter.getIntNext()).isEqualTo(18);
+    }
   }
 }

--- a/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyDim.java
+++ b/cdm/core/src/test/java/ucar/nc2/internal/ncml/TestNcmlModifyDim.java
@@ -43,4 +43,34 @@ public class TestNcmlModifyDim {
       assertThat(dataIter.getIntNext()).isEqualTo(18);
     }
   }
+
+  @Test
+  public void shouldRenameDimInAggregation() throws IOException {
+    final String filename = "file:./" + TestNcmlRead.topDir + "aggregationRenameDim.xml";
+    checkDimIsRenamed(filename);
+  }
+
+  @Test
+  public void shouldRenameDimInAggregationScan() throws IOException {
+    final String filename = "file:./" + TestNcmlRead.topDir + "aggregationScanRenameDim.xml";
+    checkDimIsRenamed(filename);
+  }
+
+  private void checkDimIsRenamed(String filename) throws IOException {
+    try (NetcdfFile ncfile = NcmlReader.readNcml(filename, null, null).build()) {
+      Dimension newDim = ncfile.findDimension("newTime");
+      assertThat(newDim).isNotNull();
+
+      Dimension oldDim = ncfile.findDimension("time");
+      assertThat(oldDim).isNull();
+
+      Variable newTime = ncfile.findVariable("newTime");
+      assertThat((Object) newTime).isNotNull();
+      Array data = newTime.read();
+      assertThat(data.getSize()).isEqualTo(59);
+
+      Variable time = ncfile.findVariable("time");
+      assertThat((Object) time).isNull();
+    }
+  }
 }


### PR DESCRIPTION
## Description of Changes

Renaming an aggregation dimension using NcML does not work-- it will throw an exception in the case of an aggregation with a scan element (see https://github.com/Unidata/tds/issues/490) and have the wrong size in the case of an aggregation with locations. The aggregation dimension is already part of the `groupBuilder`, so we need to use that instead of the `refGroup` (which is the dimension from a single file, or null in the case of a scan), in order to treat it as an existing dimension instead of a new one.