### PR TITLE
Update d4ts version

### DIFF
--- a/cdm-test-utils/src/main/resources/ucar/unidata/util/test/Dockerfile
+++ b/cdm-test-utils/src/main/resources/ucar/unidata/util/test/Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 # TODO use release version of d4ts
 #ENV D4TS_WAR_URL https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/d4ts/5.4/d4ts-5.4.war
-ENV D4TS_WAR_URL https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/edu/ucar/d4ts/5.5-SNAPSHOT/d4ts-5.5-20240410.110406-179.war
+ENV D4TS_WAR_URL https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/edu/ucar/d4ts/5.5-SNAPSHOT/d4ts-5.5-20240507.221412-201.war
 ENV DTS_WAR_URL https://artifacts.unidata.ucar.edu/repository/unidata-releases/edu/ucar/dtswar/5.4/dtswar-5.4.war
 
 # Install necessary packages


### PR DESCRIPTION
## Description of Changes

Update dockerfile to use latest snapshot for d4ts (previous snapshot no longer present on nexus). After the next release we should use the release version here, but the 5.4 release did not work correctly.
