### PR TITLE
MFileZip fixes

### DIFF
--- a/cdm/core/src/main/java/thredds/inventory/MFile.java
+++ b/cdm/core/src/main/java/thredds/inventory/MFile.java
@@ -35,6 +35,15 @@ public interface MFile extends Comparable<MFile> {
 
   boolean isDirectory();
 
+  /**
+   * Check if this MFile is a zip file
+   * 
+   * @return true if the MFile is a zip file
+   */
+  default boolean isZipFile() {
+    return false;
+  }
+
   default boolean isReadable() {
     return true;
   }

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -115,6 +115,11 @@ public class MFileZip implements MFile {
   }
 
   @Override
+  public boolean isZipFile() {
+    return true;
+  }
+
+  @Override
   public boolean isReadable() {
     // readable if root is readable
     return Files.isReadable(rootPath);

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -22,6 +22,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import ucar.nc2.util.IO;
+import ucar.unidata.io.RandomAccessFile;
 
 /**
  * Implements thredds.inventory.MFile for ZipFiles and ZipEntries
@@ -167,16 +168,14 @@ public class MFileZip implements MFile {
 
   @Override
   public void writeToStream(OutputStream outputStream) throws IOException {
-    for (ZipEntry entry : leafEntries) {
-      final File file = new File(entry.getName());
-      IO.copyFile(file, outputStream);
-    }
+    IO.copyFile(rootPath.toFile(), outputStream);
   }
 
   @Override
   public void writeToStream(OutputStream outputStream, long offset, long maxBytes) throws IOException {
-    throw new UnsupportedOperationException(
-        "Writing MFileZip with a byte range to stream not implemented. Filename: " + getName());
+    try (RandomAccessFile randomAccessFile = RandomAccessFile.acquire(rootPath.toString())) {
+      IO.copyRafB(randomAccessFile, offset, maxBytes, outputStream);
+    }
   }
 
   @Override

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -101,12 +101,12 @@ public class MFileZip implements MFile {
 
   @Override
   public long getLastModified() {
-    return this.entry == null ? 0 : this.entry.getLastModifiedTime().toMillis();
+    return this.entry == null ? rootPath.toFile().lastModified() : this.entry.getLastModifiedTime().toMillis();
   }
 
   @Override
   public long getLength() {
-    return this.entry == null ? 0 : this.entry.getSize();
+    return this.entry == null ? rootPath.toFile().length() : this.entry.getSize();
   }
 
   @Override

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -7,6 +7,7 @@ package thredds.inventory.zarr;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import thredds.filesystem.MFileOS;
 import thredds.inventory.MFile;
@@ -206,7 +207,7 @@ public class MFileZip implements MFile {
 
     @Override
     public boolean canProvide(String location) {
-      return location != null && location.contains(ext);
+      return location != null && location.toLowerCase(Locale.ROOT).contains(ext);
     }
 
     @Nonnull

--- a/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
+++ b/cdm/zarr/src/main/java/thredds/inventory/zarr/MFileZip.java
@@ -117,7 +117,7 @@ public class MFileZip implements MFile {
   @Override
   public boolean isReadable() {
     // readable if root is readable
-    return Files.isReadable(Paths.get(root.getName()));
+    return Files.isReadable(rootPath);
   }
 
   @Override

--- a/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
+++ b/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
@@ -81,6 +81,15 @@ public class TestMFileZip {
         assertThat(mFile.getLength()).isEqualTo(new File(zipFile.getName()).length());
       }
     }
+
+    @Test
+    public void shouldProvideForZipExtensions() {
+      MFileZip.Provider provider = new MFileZip.Provider();
+      assertThat(provider.canProvide("foo.zip")).isTrue();
+      assertThat(provider.canProvide("foo.ZIP")).isTrue();
+      assertThat(provider.canProvide("foo.zip2")).isTrue();
+      assertThat(provider.canProvide("foo.txt")).isFalse();
+    }
   }
 
   private static ZipFile createTemporaryZipFile(int size, int numberOfFiles) throws IOException {

--- a/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
+++ b/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
@@ -52,7 +52,7 @@ public class TestMFileZip {
 
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         mFile.writeToStream(outputStream);
-        assertThat(outputStream.size()).isEqualTo(expectedSize * expectedNumberOfFiles);
+        assertThat(outputStream.size()).isEqualTo(mFile.getLength());
       }
     }
   }

--- a/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
+++ b/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
@@ -47,21 +47,23 @@ public class TestMFileZip {
 
     @Test
     public void shouldWriteZipToStream() throws IOException {
-      final ZipFile zipFile = createTemporaryZipFile(expectedSize, expectedNumberOfFiles);
-      final MFileZip mFile = new MFileZip(zipFile.getName());
+      try (ZipFile zipFile = createTemporaryZipFile(expectedSize, expectedNumberOfFiles)) {
+        final MFileZip mFile = new MFileZip(zipFile.getName());
 
-      final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-      mFile.writeToStream(outputStream);
-      assertThat(outputStream.size()).isEqualTo(expectedSize * expectedNumberOfFiles);
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        mFile.writeToStream(outputStream);
+        assertThat(outputStream.size()).isEqualTo(expectedSize * expectedNumberOfFiles);
+      }
     }
   }
 
   public static class TestMFileZipNonParameterized {
     @Test
     public void shouldReturnTrueForExistingFile() throws IOException {
-      final ZipFile zipFile = createTemporaryZipFile(2, 0);
-      final MFileZip mFile = new MFileZip(zipFile.getName());
-      assertThat(mFile.exists()).isEqualTo(true);
+      try (ZipFile zipFile = createTemporaryZipFile(2, 0)) {
+        final MFileZip mFile = new MFileZip(zipFile.getName());
+        assertThat(mFile.exists()).isEqualTo(true);
+      }
     }
 
     @Test

--- a/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
+++ b/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
@@ -40,14 +40,14 @@ public class TestMFileZip {
     }
 
     @Parameterized.Parameter(0)
-    public int expectedSize;
+    public int entrySize;
 
     @Parameterized.Parameter(1)
-    public int expectedNumberOfFiles;
+    public int numberOfEntries;
 
     @Test
     public void shouldWriteZipToStream() throws IOException {
-      try (ZipFile zipFile = createTemporaryZipFile(expectedSize, expectedNumberOfFiles)) {
+      try (ZipFile zipFile = createTemporaryZipFile("TestWriteZip", entrySize, numberOfEntries)) {
         final MFileZip mFile = new MFileZip(zipFile.getName());
 
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -60,7 +60,7 @@ public class TestMFileZip {
   public static class TestMFileZipNonParameterized {
     @Test
     public void shouldReturnTrueForExistingFile() throws IOException {
-      try (ZipFile zipFile = createTemporaryZipFile(2, 0)) {
+      try (ZipFile zipFile = createTemporaryZipFile("TestExists", 2, 0)) {
         final MFileZip mFile = new MFileZip(zipFile.getName());
         assertThat(mFile.exists()).isEqualTo(true);
       }
@@ -68,7 +68,7 @@ public class TestMFileZip {
 
     @Test
     public void shouldGetLastModified() throws IOException {
-      try (ZipFile zipFile = createTemporaryZipFile(20, 1)) {
+      try (ZipFile zipFile = createTemporaryZipFile("TestLastModified", 20, 1)) {
         final MFileZip mFile = new MFileZip(zipFile.getName());
         assertThat(mFile.getLastModified()).isGreaterThan(0);
         assertThat(mFile.getLastModified()).isEqualTo(new File(zipFile.getName()).lastModified());
@@ -77,7 +77,7 @@ public class TestMFileZip {
 
     @Test
     public void shouldGetLengthForZipFile() throws IOException {
-      try (ZipFile zipFile = createTemporaryZipFile(30, 1)) {
+      try (ZipFile zipFile = createTemporaryZipFile("TestLength", 30, 1)) {
         final MFileZip mFile = new MFileZip(zipFile.getName());
         assertThat(mFile.getLength()).isGreaterThan(30);
         assertThat(mFile.getLength()).isEqualTo(new File(zipFile.getName()).length());
@@ -94,8 +94,8 @@ public class TestMFileZip {
     }
   }
 
-  private static ZipFile createTemporaryZipFile(int size, int numberOfFiles) throws IOException {
-    final File zipFile = tempFolder.newFile("TestMFileZip" + size + "-" + numberOfFiles + ".zip");
+  private static ZipFile createTemporaryZipFile(String name, int size, int numberOfFiles) throws IOException {
+    final File zipFile = tempFolder.newFile(name + "-" + size + "-" + numberOfFiles + ".zip");
 
     try (FileOutputStream fos = new FileOutputStream(zipFile.getPath());
         ZipOutputStream zipOS = new ZipOutputStream(fos)) {

--- a/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
+++ b/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
@@ -55,6 +55,25 @@ public class TestMFileZip {
         assertThat(outputStream.size()).isEqualTo(mFile.getLength());
       }
     }
+
+    @Test
+    public void shouldWritePartialZipToStream() throws IOException {
+      try (ZipFile zipFile = createTemporaryZipFile("TestWritePartialZip", entrySize, numberOfEntries)) {
+        final MFileZip mFile = new MFileZip(zipFile.getName());
+        final int length = (int) mFile.getLength();
+
+        final int offset = 1;
+        final int maxBytes = 100;
+
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        final int startPosition = Math.min(offset, length);
+        final int endPosition = Math.min(offset + maxBytes, length);
+
+        mFile.writeToStream(outputStream, offset, maxBytes);
+        assertThat(outputStream.size()).isEqualTo(Math.max(0, endPosition - startPosition));
+      }
+    }
   }
 
   public static class TestMFileZipNonParameterized {

--- a/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
+++ b/cdm/zarr/src/test/java/thredds/inventory/zarr/TestMFileZip.java
@@ -63,6 +63,24 @@ public class TestMFileZip {
       final MFileZip mFile = new MFileZip(zipFile.getName());
       assertThat(mFile.exists()).isEqualTo(true);
     }
+
+    @Test
+    public void shouldGetLastModified() throws IOException {
+      try (ZipFile zipFile = createTemporaryZipFile(20, 1)) {
+        final MFileZip mFile = new MFileZip(zipFile.getName());
+        assertThat(mFile.getLastModified()).isGreaterThan(0);
+        assertThat(mFile.getLastModified()).isEqualTo(new File(zipFile.getName()).lastModified());
+      }
+    }
+
+    @Test
+    public void shouldGetLengthForZipFile() throws IOException {
+      try (ZipFile zipFile = createTemporaryZipFile(30, 1)) {
+        final MFileZip mFile = new MFileZip(zipFile.getName());
+        assertThat(mFile.getLength()).isGreaterThan(30);
+        assertThat(mFile.getLength()).isEqualTo(new File(zipFile.getName()).length());
+      }
+    }
   }
 
   private static ZipFile createTemporaryZipFile(int size, int numberOfFiles) throws IOException {


### PR DESCRIPTION
## Description of Changes

Several issues with `MFileZip` have come to light since it has been incorporated in the TDS as part of the zarr code. This PR fixes these and adds some unit tests.

- Fix `getLastModified` and `getLength` for the root zip file to not return 0
- Fix `writeToStream` to work the same as it would for a `MFileOS`
- Allow the zip extension to be case insensitive
- Add `isZipFile` to `MFile` interface. In the TDS, the fileServer should allow downloading zips but disallow downloading directories. `MFileZip`s can be considered directories. So we need a way to distinguish between directories and zip files. This is what I came up with but we could also consider changing `isDirectory` or doing something else. See https://github.com/Unidata/tds/pull/501 for proposed TDS change.
