### PR TITLE
NetcdfFiles should use its own logger

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -49,7 +49,7 @@ import ucar.unidata.util.StringUtil2;
  * @since 10/3/2019.
  */
 public class NetcdfFiles {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NetcdfFile.class);
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NetcdfFiles.class);
   private static final List<IOServiceProvider> registeredProviders = new ArrayList<>();
   private static final List<RandomAccessFileProvider> registeredRandomAccessFileProviders = new ArrayList<>();
   private static final int default_buffersize = 8092;


### PR DESCRIPTION
Trying to figure out why I was not getting log messages from NetcdfFiles and found it was using a different class's logger.


## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
