### PR TITLE
Optimize Shuffle.decode method

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/filter/Shuffle.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Shuffle.java
@@ -61,24 +61,24 @@ public class Shuffle extends Filter {
 
   @Override
   public byte[] decode(byte[] dataIn) {
-    if (dataIn.length % elemSize != 0 || elemSize <= 1) {
+    if (dataIn.length % this.elemSize == 0 && this.elemSize > 1) {
+      int nElems = dataIn.length / this.elemSize;
+      byte[] result = new byte[dataIn.length];
+
+      for (int j = 0; j < this.elemSize; ++j) {
+        int sourceIndex = j * nElems;
+        int destIndex = j;
+        for (int i = 0; i < nElems; ++i) {
+          result[destIndex] = dataIn[sourceIndex];
+          sourceIndex++;
+          destIndex += this.elemSize;
+        }
+      }
+
+      return result;
+    } else {
       return dataIn;
     }
-
-    int nElems = dataIn.length / elemSize;
-    int[] start = new int[elemSize];
-    for (int k = 0; k < elemSize; k++) {
-      start[k] = k * nElems;
-    }
-
-    byte[] result = new byte[dataIn.length];
-    for (int i = 0; i < nElems; i++) {
-      for (int j = 0; j < elemSize; j++) {
-        result[(i * elemSize) + j] = dataIn[i + start[j]];
-      }
-    }
-
-    return result;
   }
 
   public static class Provider implements FilterProvider {


### PR DESCRIPTION
## Description of Changes

While doing a profiling session I've noticed this method popping up over and over. Noticed there were some simple and obvious optimizations, like not allocating an extra array, and avoiding repeated multiplications in index computation, and thought to share the results with the wider community. 

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
