### PR TITLE
Add logger to N3headerNew that CDF5 is not supported

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/iosp/netcdf3/N3headerNew.java
@@ -38,6 +38,9 @@ public class N3headerNew {
       case NETCDF3:
       case NETCDF3_64BIT_OFFSET:
         return true;
+      case NETCDF3_64BIT_DATA:
+        log.debug("NETCDF3_64BIT_DATA (CDF5) not supported");
+        return false;
       default:
         return false;
     }


### PR DESCRIPTION
## Description of Changes

Added a logger.debug statement to N3headerNew to indicate that CDF5/Pnetcdf is not supported yet\ even though the magic number is recognized.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
