### PR TITLE
Zarr unit tests and minor cleanups

### DIFF
--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -255,22 +255,9 @@ public class ZarrHeader {
               dimNames[i] = (String) aod1.get(i);
             }
             hasNamedDimensions = true;
-            // logger.trace(" found _ARRAY_DIMENSIONS array {}", aod1);
           } catch (final Exception exc) {
             logger.debug("  Could not extract _ARRAY_DIMENSIONS for {}, {}", vname, exc.getMessage());
           }
-
-          //// Informational logging
-          // } else if ("coordinates".equals(attrName) || "standard_name".equals(attrName) || "units".equals(attrName))
-          //// {
-          // try {
-          // ArrayObject.D1 aod1 = (ArrayObject.D1) attr.getValues();
-          // String coordsStr = (String) aod1.get(0);
-          // logger.trace(" var {} has {} attr '{}'", vname, attrName, coordsStr);
-          // } catch (final Exception exc) {
-          // logger.debug(" Exception extracting {} attr value, {}", attrName, exc.getMessage());
-          // }
-
         }
       }
     }

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -297,7 +297,7 @@ public class ZarrHeader {
     // Include some info from .zarray file in attributes for display when showing variable detail.
     // Possibly add to this fill_value if in .zarray but not .zattrs?
     if (attrs == null) {
-      attrs = new ArrayList<Attribute>();
+      attrs = new ArrayList<>();
     }
     final Filter compressor = zarray.getCompressor();
     if (compressor == null) {

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -223,7 +223,7 @@ public class ZarrHeader {
   private void makeVariable(RandomAccessDirectoryItem item, long dataOffset, ZArray zarray,
       Map<Integer, Long> initializedChunks, List<Attribute> attrs) throws ZarrFormatException {
     // make new Variable
-    Variable.Builder var = Variable.builder();
+    Variable.Builder<?> var = Variable.builder();
     String location = ZarrUtils.trimLocation(item.getLocation());
 
     // set var name

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -34,7 +34,7 @@ public class ZarrHeader {
   private final RandomAccessDirectory rootRaf;
   private final Group.Builder rootGroup;
   private final String rootLocation;
-  private static ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   public ZarrHeader(RandomAccessDirectory raf, Group.Builder rootGroup) {
     this.rootRaf = raf;

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -39,9 +39,6 @@ public class ZarrHeader {
   private final String rootLocation;
   private static ObjectMapper objectMapper = new ObjectMapper();
 
-  /*
-   *
-   */
   public ZarrHeader(RandomAccessDirectory raf, Group.Builder rootGroup) {
     this.rootRaf = raf;
     this.rootGroup = rootGroup;
@@ -60,16 +57,10 @@ public class ZarrHeader {
     private List<Attribute> attrs; // list of variable attributes
     private long dataOffset; // byte position where data starts
 
-    /*
-     *
-     */
     void setAttrs(List<Attribute> attrs) {
       this.attrs = attrs;
     }
 
-    /*
-     *
-     */
     void setVar(RandomAccessDirectoryItem var) {
       this.var = var;
       this.attrs = null;
@@ -102,9 +93,6 @@ public class ZarrHeader {
       return ZarrUtils.getObjectNameFromPath(attrPath).equals(ZarrUtils.getObjectNameFromPath(varPath));
     }
 
-    /*
-     *
-     */
     void processItem(RandomAccessDirectoryItem item) {
       if (var == null) {
         return;
@@ -122,9 +110,6 @@ public class ZarrHeader {
       }
     }
 
-    /*
-     *
-     */
     void makeVar() {
       if (var == null) {
         return; // do nothing if no variable is in progress
@@ -187,9 +172,6 @@ public class ZarrHeader {
     delayedVarMaker.makeVar();
   }
 
-  /*
-   *
-   */
   private void makeGroup(RandomAccessDirectoryItem item, List<Attribute> attrs) {
     // make new Group
     Group.Builder group = Group.builder();
@@ -217,9 +199,6 @@ public class ZarrHeader {
     }
   }
 
-  /*
-   *
-   */
   private void makeVariable(RandomAccessDirectoryItem item, long dataOffset, ZArray zarray,
       Map<Integer, Long> initializedChunks, List<Attribute> attrs) throws ZarrFormatException {
     // make new Variable
@@ -337,9 +316,6 @@ public class ZarrHeader {
     parentGroup.addVariable(var);
   }
 
-  /*
-   *
-   */
   private List<Attribute> makeAttributes(RandomAccessDirectoryItem item) {
     // get RandomAccessFile for JSON parsing
     try {

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -7,13 +7,10 @@ package ucar.nc2.iosp.zarr;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import ucar.ma2.Array;
 import ucar.ma2.ArrayObject;
-import ucar.ma2.ArrayString;
 import ucar.nc2.Attribute;
 import ucar.nc2.Dimension;
 import ucar.nc2.Group;
-import ucar.ma2.Index;
 import ucar.nc2.Variable;
 import ucar.nc2.filter.Filter;
 import ucar.unidata.io.RandomAccessFile;

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrHeader.java
@@ -331,9 +331,7 @@ public class ZarrHeader {
     }
 
     // add current attributes, if any exist
-    if (attrs != null) {
-      var.addAttributes(attrs);
-    }
+    var.addAttributes(attrs);
 
     // Add var to parent.
     parentGroup.addVariable(var);

--- a/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrLayoutBB.java
+++ b/cdm/zarr/src/main/java/ucar/nc2/iosp/zarr/ZarrLayoutBB.java
@@ -14,7 +14,6 @@ import java.nio.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A tiled layout for Zarr formats that accommodates uncompressing and filtering data before returning

--- a/cdm/zarr/src/main/java/ucar/unidata/io/zarr/VirtualRandomAccessFile.java
+++ b/cdm/zarr/src/main/java/ucar/unidata/io/zarr/VirtualRandomAccessFile.java
@@ -9,9 +9,6 @@ import ucar.nc2.NetcdfFiles;
 import ucar.unidata.io.RandomAccessFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.OptionalLong;
 
 /**
  * A wrapper for a RandomAccessFile that allows lazy loading

--- a/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZArray.java
+++ b/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZArray.java
@@ -1,0 +1,96 @@
+package ucar.nc2.iosp.zarr;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.ByteOrder;
+import org.junit.Test;
+import ucar.ma2.DataType;
+import ucar.nc2.iosp.zarr.ZArray.Order;
+
+public class TestZArray {
+  private static final String DTYPE = ">f8";
+  private static final String ORDER = "C";
+  private static final String DELIMITER = ".";
+
+  @Test
+  public void shouldParseDataType() throws ZarrFormatException {
+    final String dtype = ">f8";
+    final ZArray zArray = new ZArray(null, null, null, dtype, null, ORDER, null, DELIMITER);
+    assertThat(zArray.getDataType()).isEqualTo(DataType.DOUBLE);
+    assertThat(zArray.getDtype()).isEqualTo(dtype);
+  }
+
+  @Test
+  public void shouldRefuseInvalidDataType() {
+    final String dtype = ">a5";
+    assertThrows(ZarrFormatException.class, () -> new ZArray(null, null, null, dtype, null, ORDER, null, DELIMITER));
+  }
+
+  @Test
+  public void shouldParseBigEndianByteOrder() throws ZarrFormatException {
+    final String dtype = ">f4";
+    final ZArray zArray = new ZArray(null, null, null, dtype, null, ORDER, null, DELIMITER);
+    assertThat(zArray.getByteOrder()).isEqualTo(ByteOrder.BIG_ENDIAN);
+  }
+
+  @Test
+  public void shouldParseLittleEndianByteOrder() throws ZarrFormatException {
+    final String dtype = "<f4";
+    final ZArray zArray = new ZArray(null, null, null, dtype, null, ORDER, null, DELIMITER);
+    assertThat(zArray.getByteOrder()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  @Test
+  public void shouldParseNativeByteOrder() throws ZarrFormatException {
+    final String dtype = "|f4";
+    final ZArray zArray = new ZArray(null, null, null, dtype, null, ORDER, null, DELIMITER);
+    assertThat(zArray.getByteOrder()).isEqualTo(ByteOrder.nativeOrder());
+  }
+
+  @Test
+  public void shouldRefuseInvalidByteOrder() {
+    final String dtype = "f4";
+    assertThrows(ZarrFormatException.class, () -> new ZArray(null, null, null, dtype, null, ORDER, null, DELIMITER));
+  }
+
+  @Test
+  public void shouldParseRowMajorOrder() throws ZarrFormatException {
+    final String order = "C";
+    final ZArray zArray = new ZArray(null, null, null, DTYPE, null, order, null, DELIMITER);
+    assertThat(zArray.getOrder()).isEqualTo(Order.C);
+  }
+
+  @Test
+  public void shouldParseColumnMajorOrder() throws ZarrFormatException {
+    final String order = "F";
+    final ZArray zArray = new ZArray(null, null, null, DTYPE, null, order, null, DELIMITER);
+    assertThat(zArray.getOrder()).isEqualTo(Order.F);
+  }
+
+  @Test
+  public void shouldRefuseInvalidOrder() {
+    final String order = "A";
+    assertThrows(ZarrFormatException.class, () -> new ZArray(null, null, null, DTYPE, null, order, null, DELIMITER));
+  }
+
+  @Test
+  public void shouldParseDotSeparator() throws ZarrFormatException {
+    final String separator = ".";
+    final ZArray zArray = new ZArray(null, null, null, DTYPE, null, ORDER, null, separator);
+    assertThat(zArray.getSeparator()).isEqualTo(separator);
+  }
+
+  @Test
+  public void shouldParseSlashSeparator() throws ZarrFormatException {
+    final String separator = "/";
+    final ZArray zArray = new ZArray(null, null, null, DTYPE, null, ORDER, null, separator);
+    assertThat(zArray.getSeparator()).isEqualTo(separator);
+  }
+
+  @Test
+  public void shouldRefuseInvalidSeparator() {
+    final String separator = "-";
+    assertThrows(ZarrFormatException.class, () -> new ZArray(null, null, null, DTYPE, null, ORDER, null, separator));
+  }
+}

--- a/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrDataTypes.java
+++ b/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrDataTypes.java
@@ -10,7 +10,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ucar.ma2.Array;
 import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
 import ucar.nc2.NetcdfFile;

--- a/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrIosp.java
+++ b/cdm/zarr/src/test/java/ucar/nc2/iosp/zarr/TestZarrIosp.java
@@ -18,7 +18,6 @@ import ucar.nc2.Group;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
 import ucar.nc2.Variable;
-import ucar.nc2.filter.Filters;
 
 import java.io.IOException;
 import java.nio.ByteOrder;


### PR DESCRIPTION
## Description of Changes

- Add unit tests for `ZArray` class
- Fix test in `TestZarrIosp` that was unzipping a non-zarr file and not cleaning it up after tests. This is fixed by first copying the zip file to a temporary folder before using it in the tests.
- A few minor cleanups such as: remove unused imports, remove commented out code, remove unneeded null check