### PR TITLE
Fix nullptr exception

### DIFF
--- a/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
+++ b/cdm/core/src/main/java/thredds/filesystem/MFileOS.java
@@ -88,9 +88,11 @@ public class MFileOS implements MFile {
     return file.getName();
   }
 
+  @Nullable
   @Override
   public MFile getParent() {
-    return new MFileOS(file.getParentFile());
+    File parent = file.getParentFile();
+    return parent == null ? null : new MFileOS(parent);
   }
 
   @Override

--- a/cdm/core/src/test/java/ucar/nc2/util/TestURLnaming.java
+++ b/cdm/core/src/test/java/ucar/nc2/util/TestURLnaming.java
@@ -5,6 +5,8 @@
 
 package ucar.nc2.util;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import java.lang.invoke.MethodHandles;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -30,6 +32,14 @@ public class TestURLnaming {
     testResolve("file://test/me/", "file:/wanna", "file:/wanna");
     testResolve("file://test/me/", "C:/wanna", "C:/wanna");
     testResolve("http://test/me/", "file:wanna", "file:wanna");
+
+    testResolve("urlWithoutSlash", "file:///path/with/slash", "file:///path/with/slash");
+  }
+
+  @Test
+  public void testResolveFile() {
+    assertThat(URLnaming.resolveFile("urlWithoutSlash", "file:///path/with/slash"))
+        .isEqualTo("file:///path/with/slash");
   }
 
   private void testResolve(String base, String rel, String result) {


### PR DESCRIPTION
## Description of Changes

NcML aggregations are calling `UrlNaming.resolveFile` with the dataset URL as the `baseDir` and the netcdf location as the `filepath`. This is causing a nullptr exception in the `MFileOS::getParent` call when the dataset URL does not have any slashes so the parent is null. Maybe this function should not be called at all in this case (the URL is not a baseDir so it is a bit weird), but in any case this nullptr exception should be fixed. This PR fixes the nullptr exception in `MFileOS` and adds unit tests.
