### PR TITLE
revert axis name changes and add work done to use coordVars to set co…

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
@@ -27,6 +27,7 @@ public class CDM {
   public static final String ABBREV = "abbreviation";
   public static final String ADD_OFFSET = "add_offset";
   public static final String CONVENTIONS = "Conventions";
+  public static final String CF_VERSION = "CF-1.9";
   public static final String DESCRIPTION = "description";
   public static final String FILL_VALUE = "_FillValue";
   public static final String HISTORY = "history";

--- a/cdm/core/src/main/java/ucar/nc2/ft/DsgFeatureCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/DsgFeatureCollection.java
@@ -7,6 +7,7 @@ package ucar.nc2.ft;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import ucar.nc2.Variable;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.time.CalendarDateUnit;
 import java.util.List;
@@ -36,20 +37,20 @@ public interface DsgFeatureCollection {
   ucar.nc2.constants.FeatureType getCollectionFeatureType();
 
   /**
-   * The name of time unit.
+   * The name of time unit, if there is a time axis.
    *
-   * @return name of time unit string, may not be null
+   * @return name of time unit string, may be null
    */
-  @Nonnull
+  @Nullable
   String getTimeName();
 
 
   /**
-   * The time unit.
+   * The time unit, if there is a time axis.
    * 
-   * @return time unit, may not be null
+   * @return time unit, may be null
    */
-  @Nonnull
+  @Nullable
   CalendarDateUnit getTimeUnit();
 
   /**
@@ -67,6 +68,14 @@ public interface DsgFeatureCollection {
    */
   @Nullable
   String getAltUnits();
+
+  /**
+   * The list of coordinate variables in the collection
+   *
+   * @return the list of coordinate variables, may be empty but not null;
+   */
+  @Nonnull
+  List<CoordinateAxis> getCoordinateVariables();
 
   /*
    * Other variables needed for completeness, eg joined coordinate variables

--- a/cdm/core/src/main/java/ucar/nc2/ft/FeatureDatasetFactoryManager.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/FeatureDatasetFactoryManager.java
@@ -330,17 +330,6 @@ public class FeatureDatasetFactoryManager {
     if (ft != null)
       return wrap(ft, ncd, task, errlog);
 
-    /*
-     * grids dont usually have a FeatureType attribute, so check these fist
-     * if (isGrid(ncd.getCoordinateSystems())) {
-     * ucar.nc2.dt.grid.GridDataset gds = new ucar.nc2.dt.grid.GridDataset(ncd); // LOOK
-     * if (gds.getGrids().size() > 0) {
-     * if (debug) System.out.println(" wrapUnknown found grids ");
-     * return gds;
-     * }
-     * }
-     */
-
     // find a Factory that claims this dataset
     Object analysis = null;
     FeatureDatasetFactory useFactory = null;
@@ -355,16 +344,6 @@ public class FeatureDatasetFactoryManager {
       }
     }
 
-    /*
-     * try again as a Grid
-     * if (null == useFactory) {
-     * // if no datatype was requested, give em a GridDataset only if some Grids are found.
-     * ucar.nc2.dt.grid.GridDataset gds = new ucar.nc2.dt.grid.GridDataset(ncd);
-     * if (gds.getGrids().size() > 0)
-     * return gds;
-     * }
-     */
-
     // Fail
     if (null == useFactory) {
       errlog.format("Failed (wrapUnknown) to find Datatype Factory for= %s%n", ncd.getLocation());
@@ -374,26 +353,6 @@ public class FeatureDatasetFactoryManager {
     // this call must be thread safe - done by implementation
     return useFactory.open(null, ncd, analysis, task, errlog);
   }
-
-  /*
-   * static private boolean isGrid(java.util.List<CoordinateSystem> csysList) {
-   * CoordinateSystem use = null;
-   * for (CoordinateSystem csys : csysList) {
-   * if (use == null) use = csys;
-   * else if (csys.getCoordinateAxes().size() > use.getCoordinateAxes().size())
-   * use = csys;
-   * }
-   * 
-   * if (use == null) return false;
-   * CoordinateAxis lat = use.getLatAxis();
-   * CoordinateAxis lon = use.getLonAxis();
-   * if ((lat != null) && (lat.getSize() <= 1)) return false; // COARDS singletons
-   * if ((lon != null) && (lon.getSize() <= 1)) return false;
-   * 
-   * // hueristics - cant say i like this, multidim point features could easily violate
-   * return (use.getRankDomain() > 2) && (use.getRankDomain() <= use.getRankRange());
-   * }
-   */
 
   /**
    * Determine if factory type matches wanted feature type.

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/DsgCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/DsgCollectionImpl.java
@@ -5,6 +5,7 @@
 package ucar.nc2.ft.point;
 
 import ucar.nc2.Variable;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.DsgFeatureCollection;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.time.CalendarDateUnit;
@@ -27,6 +28,7 @@ public abstract class DsgCollectionImpl implements DsgFeatureCollection {
   protected String altName = "altitude";
   protected String altUnits;
   protected CollectionInfo info;
+  protected List<CoordinateAxis> coordVars;
   protected List<Variable> extras; // variables needed to make CF/DSG writing work
 
   protected DsgCollectionImpl(String name, CalendarDateUnit timeUnit, String altUnits) {
@@ -35,13 +37,19 @@ public abstract class DsgCollectionImpl implements DsgFeatureCollection {
     this.altUnits = altUnits;
   }
 
-  protected DsgCollectionImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits) {
+  protected DsgCollectionImpl(String name, List<CoordinateAxis> coordVars) {
     this.name = name;
-    this.timeName = timeName;
-    this.timeUnit = timeUnit;
-    this.altName = altName;
-    this.altUnits = altUnits;
+    this.coordVars = coordVars;
+
+    for (CoordinateAxis coord : coordVars) {
+      if (coord.getAxisType().isTime()) {
+        this.timeUnit = CalendarDateUnit.of(null, coord.getUnitsString());
+        this.timeName = coord.getShortName();
+      } else if (coord.getAxisType().isVert()) {
+        this.altUnits = coord.getUnitsString();
+        this.altName = coord.getShortName();
+      }
+    }
   }
 
   @Nonnull
@@ -50,13 +58,13 @@ public abstract class DsgCollectionImpl implements DsgFeatureCollection {
     return name;
   }
 
-  @Nonnull
+  @Nullable
   @Override
   public String getTimeName() {
     return timeName;
   }
 
-  @Nonnull
+  @Nullable
   @Override
   public CalendarDateUnit getTimeUnit() {
     return timeUnit;
@@ -72,6 +80,12 @@ public abstract class DsgCollectionImpl implements DsgFeatureCollection {
   @Override
   public String getAltUnits() {
     return altUnits;
+  }
+
+  @Nonnull
+  @Override
+  public List<CoordinateAxis> getCoordinateVariables() {
+    return this.coordVars;
   }
 
   @Nonnull

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/PointCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/PointCollectionImpl.java
@@ -6,8 +6,10 @@ package ucar.nc2.ft.point;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.ft.PointFeatureIterator;
@@ -28,9 +30,8 @@ public abstract class PointCollectionImpl extends DsgCollectionImpl implements P
     super(name, timeUnit, altUnits);
   }
 
-  protected PointCollectionImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits) {
-    super(name, timeName, timeUnit, altName, altUnits);
+  protected PointCollectionImpl(String name, List<CoordinateAxis> coordVars) {
+    super(name, coordVars);
   }
 
   @Nonnull
@@ -61,7 +62,7 @@ public abstract class PointCollectionImpl extends DsgCollectionImpl implements P
     protected CalendarDateRange filter_date;
 
     public PointCollectionSubset(PointCollectionImpl from, LatLonRect filter_bb, CalendarDateRange filter_date) {
-      super(from.name, from.getTimeName(), from.getTimeUnit(), from.getAltName(), from.getAltUnits());
+      super(from.name, from.timeUnit, from.altUnits);
       this.from = from;
       this.filter_bb = filter_bb;
       this.filter_date = filter_date;

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/PointFeatureCCCImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/PointFeatureCCCImpl.java
@@ -4,10 +4,12 @@
  */
 package ucar.nc2.ft.point;
 
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.*;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.nc2.constants.FeatureType;
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Abstract superclass for multiply nested NestedPointFeatureCollection
@@ -25,9 +27,8 @@ public abstract class PointFeatureCCCImpl extends DsgCollectionImpl implements P
     this.collectionFeatureType = collectionFeatureType;
   }
 
-  protected PointFeatureCCCImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits, FeatureType collectionFeatureType) {
-    super(name, timeName, timeUnit, altName, altUnits);
+  protected PointFeatureCCCImpl(String name, List<CoordinateAxis> coords, FeatureType collectionFeatureType) {
+    super(name, coords);
     this.collectionFeatureType = collectionFeatureType;
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/PointFeatureCCImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/PointFeatureCCImpl.java
@@ -5,8 +5,10 @@
 package ucar.nc2.ft.point;
 
 import java.io.IOException;
+import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureCC;
 import ucar.nc2.ft.PointFeatureIterator;
 import ucar.nc2.time.CalendarDateRange;
@@ -29,9 +31,9 @@ public abstract class PointFeatureCCImpl extends DsgCollectionImpl implements Po
     this.collectionFeatureType = collectionFeatureType;
   }
 
-  protected PointFeatureCCImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName, String altUnits,
-      FeatureType collectionFeatureType) {
-    super(name, timeName, timeUnit, altName, altUnits);
+
+  protected PointFeatureCCImpl(String name, List<CoordinateAxis> coords, FeatureType collectionFeatureType) {
+    super(name, coords);
     this.collectionFeatureType = collectionFeatureType;
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/ProfileFeatureImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/ProfileFeatureImpl.java
@@ -6,9 +6,12 @@ package ucar.nc2.ft.point;
 
 import javax.annotation.Nonnull;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.ProfileFeature;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.unidata.geoloc.LatLonPoint;
+
+import java.util.List;
 
 /**
  * Abstract superclass for implementations of ProfileFeature.
@@ -31,9 +34,9 @@ public abstract class ProfileFeatureImpl extends PointCollectionImpl implements 
     }
   }
 
-  public ProfileFeatureImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName, String altUnits,
-      double lat, double lon, double time, int nfeatures) {
-    super(name, timeName, timeUnit, altName, altUnits);
+  public ProfileFeatureImpl(String name, List<CoordinateAxis> coords, double lat, double lon, double time,
+      int nfeatures) {
+    super(name, coords);
     this.latlonPoint = LatLonPoint.create(lat, lon);
     this.time = time;
     if (nfeatures >= 0) {

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/SectionCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/SectionCollectionImpl.java
@@ -5,7 +5,10 @@
 package ucar.nc2.ft.point;
 
 import java.io.IOException;
+import java.util.List;
+
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureCCIterator;
 import ucar.nc2.ft.TrajectoryProfileFeature;
 import ucar.nc2.ft.TrajectoryProfileFeatureCollection;
@@ -21,9 +24,12 @@ import ucar.nc2.time.CalendarDateUnit;
 
 public abstract class SectionCollectionImpl extends PointFeatureCCCImpl implements TrajectoryProfileFeatureCollection {
 
-  protected SectionCollectionImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits) {
-    super(name, timeName, timeUnit, altName, altUnits, FeatureType.TRAJECTORY_PROFILE);
+  protected SectionCollectionImpl(String name, CalendarDateUnit timeUnit, String altUnits) {
+    super(name, timeUnit, altUnits, FeatureType.TRAJECTORY_PROFILE);
+  }
+
+  protected SectionCollectionImpl(String name, List<CoordinateAxis> coords) {
+    super(name, coords, FeatureType.TRAJECTORY_PROFILE);
   }
 
   /////////////////////////////////////////////////////////////////////////////////////

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/SectionFeatureImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/SectionFeatureImpl.java
@@ -23,9 +23,9 @@ import ucar.nc2.time.CalendarDateUnit;
 
 public abstract class SectionFeatureImpl extends PointFeatureCCImpl implements TrajectoryProfileFeature {
 
-  protected SectionFeatureImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits) {
-    super(name, timeName, timeUnit, altName, altUnits, FeatureType.TRAJECTORY_PROFILE);
+
+  protected SectionFeatureImpl(String name, CalendarDateUnit timeUnit, String altUnits) {
+    super(name, timeUnit, altUnits, FeatureType.TRAJECTORY_PROFILE);
   }
 
   /////////////////////////////////////////////////////////////////////////////////////

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/StationProfileCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/StationProfileCollectionImpl.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureCC;
 import ucar.nc2.ft.PointFeatureCCIterator;
 import ucar.nc2.ft.StationProfileFeature;
@@ -34,9 +35,8 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl
     super(name, timeUnit, altUnits, FeatureType.STATION_PROFILE);
   }
 
-  public StationProfileCollectionImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits) {
-    super(name, timeName, timeUnit, altName, altUnits, FeatureType.STATION_PROFILE);
+  public StationProfileCollectionImpl(String name, List<CoordinateAxis> coordVars) {
+    super(name, coordVars, FeatureType.STATION_PROFILE);
   }
 
   // Double-check idiom for lazy initialization of instance fields. See Effective Java 2nd Ed, p. 283.
@@ -135,7 +135,7 @@ public abstract class StationProfileCollectionImpl extends PointFeatureCCCImpl
     private final List<StationFeature> stations;
 
     StationProfileFeatureCollectionSubset(StationProfileCollectionImpl from, List<StationFeature> stations) {
-      super(from.getName(), from.getTimeName(), from.getTimeUnit(), from.getAltName(), from.getAltUnits());
+      super(from.getName(), from.getTimeUnit(), from.getAltUnits());
       this.from = from;
       this.stations = stations;
     }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/StationProfileFeatureImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/StationProfileFeatureImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.ma2.StructureData;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.ft.PointFeatureCollectionIterator;
 import ucar.nc2.ft.ProfileFeature;
@@ -43,22 +44,14 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
     this.timeSeriesNpts = npts;
   }
 
-  public StationProfileFeatureImpl(String name, String desc, String wmoId, double lat, double lon, double alt,
-      String timeName, CalendarDateUnit timeUnit, String altName, String altUnits, int npts) {
-    super(name, timeName, timeUnit, altName, altUnits, FeatureType.STATION_PROFILE);
-    station = new StationImpl(name, desc, wmoId, lat, lon, alt, npts);
-    this.timeSeriesNpts = npts;
-  }
-
-  public StationProfileFeatureImpl(Station s, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits, int npts) {
-    super(s.getName(), timeName, timeUnit, altName, altUnits, FeatureType.STATION_PROFILE);
+  public StationProfileFeatureImpl(Station s, CalendarDateUnit timeUnit, String altUnits, int npts) {
+    super(s.getName(), timeUnit, altUnits, FeatureType.STATION_PROFILE);
     this.station = s;
     this.timeSeriesNpts = npts;
   }
 
-  public StationProfileFeatureImpl(Station s, CalendarDateUnit timeUnit, String altUnits, int npts) {
-    super(s.getName(), timeUnit, altUnits, FeatureType.STATION_PROFILE);
+  public StationProfileFeatureImpl(Station s, List<CoordinateAxis> coords, int npts) {
+    super(s.getName(), coords, FeatureType.STATION_PROFILE);
     this.station = s;
     this.timeSeriesNpts = npts;
   }
@@ -152,7 +145,7 @@ public abstract class StationProfileFeatureImpl extends PointFeatureCCImpl imple
     private final CalendarDateRange dateRange;
 
     public StationProfileFeatureSubset(StationProfileFeatureImpl from, CalendarDateRange filter_date) {
-      super(from.station, from.getTimeName(), from.getTimeUnit(), from.getAltName(), from.getAltUnits(), -1);
+      super(from.station, from.getTimeUnit(), from.getAltUnits(), -1);
       this.from = from;
       this.dateRange = filter_date;
     }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionFlattened.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionFlattened.java
@@ -19,7 +19,7 @@ public class StationTimeSeriesCollectionFlattened extends PointCollectionImpl {
   protected StationTimeSeriesCollectionImpl from;
 
   public StationTimeSeriesCollectionFlattened(StationTimeSeriesCollectionImpl from, CalendarDateRange dateRange) {
-    super(from.getName(), from.getTimeName(), from.getTimeUnit(), from.getAltName(), from.getAltUnits());
+    super(from.getName(), from.getTimeUnit(), from.getAltUnits());
     this.from = from;
     if (dateRange != null) {
       getInfo();

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/StationTimeSeriesCollectionImpl.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.ft.PointFeatureCollectionIterator;
@@ -35,9 +36,8 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
     super(name, timeUnit, altUnits, FeatureType.STATION);
   }
 
-  public StationTimeSeriesCollectionImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits) {
-    super(name, timeName, timeUnit, altName, altUnits, FeatureType.STATION);
+  public StationTimeSeriesCollectionImpl(String name, List<CoordinateAxis> coordVars) {
+    super(name, coordVars, FeatureType.STATION);
   }
 
   // Double-check idiom for lazy initialization of instance fields. See Effective Java 2nd Ed, p. 283.
@@ -135,7 +135,7 @@ public abstract class StationTimeSeriesCollectionImpl extends PointFeatureCCImpl
     private final List<StationFeature> stations;
 
     StationSubset(StationTimeSeriesCollectionImpl from, List<StationFeature> stations) {
-      super(from.getName(), from.getTimeName(), from.getTimeUnit(), from.getAltName(), from.getAltUnits());
+      super(from.getName(), from.getTimeUnit(), from.getAltUnits());
       this.stations = stations;
     }
 

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/StationTimeSeriesFeatureImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/StationTimeSeriesFeatureImpl.java
@@ -5,9 +5,11 @@
 package ucar.nc2.ft.point;
 
 import java.io.IOException;
+import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.ma2.StructureData;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureIterator;
 import ucar.nc2.ft.StationTimeSeriesFeature;
 import ucar.nc2.time.CalendarDateRange;
@@ -32,8 +34,8 @@ public abstract class StationTimeSeriesFeatureImpl extends PointCollectionImpl i
   }
 
   public StationTimeSeriesFeatureImpl(String name, String desc, String wmoId, double lat, double lon, double alt,
-      String timeName, CalendarDateUnit timeUnit, String altName, String altUnits, int npts, StructureData sdata) {
-    super(name, timeName, timeUnit, altName, altUnits);
+      List<CoordinateAxis> coords, int npts, StructureData sdata) {
+    super(name, coords);
     s = new StationFeatureImpl(name, desc, wmoId, lat, lon, alt, npts, sdata);
   }
 
@@ -46,9 +48,8 @@ public abstract class StationTimeSeriesFeatureImpl extends PointCollectionImpl i
     }
   }
 
-  public StationTimeSeriesFeatureImpl(StationFeature s, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits, int nfeatures) {
-    super(s.getName(), timeName, timeUnit, altName, altUnits);
+  public StationTimeSeriesFeatureImpl(StationFeature s, List<CoordinateAxis> coords, int nfeatures) {
+    super(s.getName(), coords);
     this.s = s;
     if (nfeatures >= 0) {
       getInfo(); // create the object

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/TrajectoryFeatureImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/TrajectoryFeatureImpl.java
@@ -4,10 +4,12 @@
  */
 package ucar.nc2.ft.point;
 
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.TrajectoryFeature;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.time.CalendarDateUnit;
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Implementation of TrajectoryFeature
@@ -17,17 +19,16 @@ import javax.annotation.Nonnull;
  */
 public abstract class TrajectoryFeatureImpl extends PointCollectionImpl implements TrajectoryFeature {
 
-  public TrajectoryFeatureImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName, String altUnits,
-      int nfeatures) {
-    super(name, timeName, timeUnit, altName, altUnits);
+  public TrajectoryFeatureImpl(String name, CalendarDateUnit timeUnit, String altUnits, int nfeatures) {
+    super(name, timeUnit, altUnits);
     if (nfeatures >= 0) {
       getInfo(); // create the object
       info.nfeatures = nfeatures;
     }
   }
 
-  public TrajectoryFeatureImpl(String name, CalendarDateUnit timeUnit, String altUnits, int nfeatures) {
-    super(name, timeUnit, altUnits);
+  public TrajectoryFeatureImpl(String name, List<CoordinateAxis> coords, int nfeatures) {
+    super(name, coords);
     if (nfeatures >= 0) {
       getInfo(); // create the object
       info.nfeatures = nfeatures;

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/remote/StationCollectionStream.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/remote/StationCollectionStream.java
@@ -161,8 +161,7 @@ public class StationCollectionStream extends StationTimeSeriesCollectionImpl {
     PointIteratorStream riter;
 
     StationFeatureStream(StationTimeSeriesFeature s, CalendarDateRange dateRange) {
-      super(s, s.getTimeName(), StationCollectionStream.this.getTimeUnit(), s.getAltName(),
-          StationCollectionStream.this.getAltUnits(), -1);
+      super(s, s.getCoordinateVariables(), -1);
       this.stnFeature = s;
       if (dateRange != null) {
         getInfo();

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/standard/PointDatasetStandardFactory.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/standard/PointDatasetStandardFactory.java
@@ -141,6 +141,10 @@ public class PointDatasetStandardFactory implements FeatureDatasetFactory {
         // create member variables
         dataVariables = new ArrayList<>(flatTable.getDataVariables());
 
+        // TODO: implement flatTable.getCoordinateVariables, use in FeatureCollection constructors
+        // once this is implemented, feature collections will have a full set of coordinate axes
+        // to use in the CFPointWriter implementations in place of default axis info
+
         featureType = flatTable.getFeatureType(); // hope they're all the same
         if (flatTable.getFeatureType() == FeatureType.POINT)
           featureCollections.add(new StandardPointCollectionImpl(flatTable, timeUnit, altUnits));

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardPointCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardPointCollectionImpl.java
@@ -6,6 +6,9 @@
 package ucar.nc2.ft.point.standard;
 
 import java.io.IOException;
+import java.util.List;
+
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureIterator;
 import ucar.nc2.ft.point.PointCollectionImpl;
 import ucar.nc2.time.CalendarDateUnit;
@@ -20,7 +23,13 @@ public class StandardPointCollectionImpl extends PointCollectionImpl {
   private NestedTable ft;
 
   StandardPointCollectionImpl(NestedTable ft, CalendarDateUnit timeUnit, String altUnits) {
-    super(ft.getName(), ft.getTimeName(), timeUnit, ft.getAltName(), altUnits);
+    super(ft.getName(), timeUnit, altUnits);
+    this.ft = ft;
+    this.extras = ft.getExtras();
+  }
+
+  StandardPointCollectionImpl(NestedTable ft, List<CoordinateAxis> coordVars) {
+    super(ft.getName(), coordVars);
     this.ft = ft;
     this.extras = ft.getExtras();
   }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardProfileCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardProfileCollectionImpl.java
@@ -7,10 +7,12 @@ package ucar.nc2.ft.point.standard;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureDataIterator;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.ft.PointFeatureCollectionIterator;
@@ -37,13 +39,23 @@ import ucar.unidata.geoloc.LatLonRect;
 public class StandardProfileCollectionImpl extends PointFeatureCCImpl implements ProfileFeatureCollection {
   private NestedTable ft;
 
-  protected StandardProfileCollectionImpl(String name, String timeName, CalendarDateUnit timeUnit, String altName,
-      String altUnits) {
-    super(name, timeName, timeUnit, altName, altUnits, FeatureType.PROFILE);
+  protected StandardProfileCollectionImpl(String name, CalendarDateUnit timeUnit, String altUnits) {
+    super(name, timeUnit, altUnits, FeatureType.PROFILE);
+  }
+
+
+  StandardProfileCollectionImpl(String name, List<CoordinateAxis> coordVars) {
+    super(name, coordVars, FeatureType.PROFILE);
   }
 
   StandardProfileCollectionImpl(NestedTable ft, CalendarDateUnit timeUnit, String altUnits) {
-    super(ft.getName(), ft.getTimeName(), timeUnit, ft.getAltName(), altUnits, FeatureType.PROFILE);
+    super(ft.getName(), timeUnit, altUnits, FeatureType.PROFILE);
+    this.ft = ft;
+    this.extras = ft.getExtras();
+  }
+
+  StandardProfileCollectionImpl(NestedTable ft, List<CoordinateAxis> coordVars) {
+    super(ft.getName(), coordVars, FeatureType.PROFILE);
     this.ft = ft;
     this.extras = ft.getExtras();
   }
@@ -63,9 +75,8 @@ public class StandardProfileCollectionImpl extends PointFeatureCCImpl implements
     StructureData profileData;
 
     StandardProfileFeature(Cursor cursor, double time, StructureData profileData) {
-      super(ft.getFeatureName(cursor), ft.getTimeName(), StandardProfileCollectionImpl.this.getTimeUnit(),
-          ft.getAltName(), StandardProfileCollectionImpl.this.getAltUnits(), ft.getLatitude(cursor),
-          ft.getLongitude(cursor), time, -1);
+      super(ft.getFeatureName(cursor), StandardProfileCollectionImpl.this.getTimeUnit(),
+          StandardProfileCollectionImpl.this.getAltUnits(), ft.getLatitude(cursor), ft.getLongitude(cursor), time, -1);
 
       this.cursor = cursor;
       this.profileData = profileData;
@@ -135,7 +146,7 @@ public class StandardProfileCollectionImpl extends PointFeatureCCImpl implements
     LatLonRect boundingBox;
 
     StandardProfileCollectionSubset(StandardProfileCollectionImpl from, LatLonRect boundingBox) {
-      super(from.getName() + "-subset", from.getTimeName(), from.getTimeUnit(), from.getAltName(), from.getAltUnits());
+      super(from.getName() + "-subset", from.getTimeUnit(), from.getAltUnits());
       this.from = from;
       this.boundingBox = boundingBox;
     }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardSectionCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardSectionCollectionImpl.java
@@ -7,9 +7,11 @@ package ucar.nc2.ft.point.standard;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureDataIterator;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.PointFeatureCC;
 import ucar.nc2.ft.PointFeatureCCIterator;
@@ -40,7 +42,13 @@ public class StandardSectionCollectionImpl extends SectionCollectionImpl {
   private NestedTable ft;
 
   StandardSectionCollectionImpl(NestedTable ft, CalendarDateUnit timeUnit, String altUnits) {
-    super(ft.getName(), ft.getTimeName(), timeUnit, ft.getAltName(), altUnits);
+    super(ft.getName(), timeUnit, altUnits);
+    this.ft = ft;
+    this.extras = ft.getExtras();
+  }
+
+  StandardSectionCollectionImpl(NestedTable ft, List<CoordinateAxis> coords) {
+    super(ft.getName(), coords);
     this.ft = ft;
     this.extras = ft.getExtras();
   }
@@ -122,8 +130,8 @@ public class StandardSectionCollectionImpl extends SectionCollectionImpl {
     StructureData sectionData;
 
     StandardSectionFeature(Cursor cursor, StructureData sectionData) {
-      super(ft.getFeatureName(cursor), ft.getTimeName(), StandardSectionCollectionImpl.this.getTimeUnit(),
-          ft.getAltName(), StandardSectionCollectionImpl.this.getAltUnits());
+      super(ft.getFeatureName(cursor), StandardSectionCollectionImpl.this.getTimeUnit(),
+          StandardSectionCollectionImpl.this.getAltUnits());
       this.cursor = cursor;
       this.sectionData = sectionData;
     }
@@ -201,8 +209,8 @@ public class StandardSectionCollectionImpl extends SectionCollectionImpl {
     StructureData profileData;
 
     StandardSectionProfileFeature(Cursor cursor, double time, StructureData profileData) {
-      super(ft.getFeatureName(cursor), ft.getTimeName(), ft.getTimeUnit(), ft.getAltName(), ft.getAltUnits(),
-          ft.getLatitude(cursor), ft.getLongitude(cursor), time, -1);
+      super(ft.getFeatureName(cursor), ft.getTimeUnit(), ft.getAltUnits(), ft.getLatitude(cursor),
+          ft.getLongitude(cursor), time, -1);
 
       this.cursor = cursor;
       this.profileData = profileData;

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardStationCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardStationCollectionImpl.java
@@ -6,9 +6,11 @@
 package ucar.nc2.ft.point.standard;
 
 import java.io.IOException;
+import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureDataIterator;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureIterator;
 import ucar.nc2.ft.StationTimeSeriesFeature;
 import ucar.nc2.ft.point.StationFeature;
@@ -32,7 +34,13 @@ public class StandardStationCollectionImpl extends StationTimeSeriesCollectionIm
   private NestedTable ft;
 
   StandardStationCollectionImpl(NestedTable ft, CalendarDateUnit timeUnit, String altUnits) {
-    super(ft.getName(), ft.getTimeName(), timeUnit, ft.getAltName(), altUnits);
+    super(ft.getName(), timeUnit, altUnits);
+    this.ft = ft;
+    this.extras = ft.getExtras();
+  }
+
+  StandardStationCollectionImpl(NestedTable ft, List<CoordinateAxis> coordVars) {
+    super(ft.getName(), coordVars);
     this.ft = ft;
     this.extras = ft.getExtras();
   }
@@ -73,7 +81,7 @@ public class StandardStationCollectionImpl extends StationTimeSeriesCollectionIm
     StructureData stationData;
 
     StandardStationFeatureImpl(StationFeature s, CalendarDateUnit dateUnit, StructureData stationData, int recnum) {
-      super(s, ft.getTimeName(), dateUnit, ft.getAltName(), ft.getAltUnits(), -1);
+      super(s, dateUnit, ft.getAltUnits(), -1);
       this.recnum = recnum;
       this.stationData = stationData;
     }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardStationProfileCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardStationProfileCollectionImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureDataIterator;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.PointFeatureCC;
 import ucar.nc2.ft.PointFeatureCCIterator;
@@ -47,7 +48,13 @@ public class StandardStationProfileCollectionImpl extends StationProfileCollecti
   private NestedTable ft;
 
   StandardStationProfileCollectionImpl(NestedTable ft, CalendarDateUnit timeUnit, String altUnits) {
-    super(ft.getName(), ft.getTimeName(), timeUnit, ft.getAltName(), altUnits);
+    super(ft.getName(), timeUnit, altUnits);
+    this.ft = ft;
+  }
+
+
+  StandardStationProfileCollectionImpl(NestedTable ft, List<CoordinateAxis> coordVars) {
+    super(ft.getName(), coordVars);
     this.ft = ft;
   }
 
@@ -135,9 +142,7 @@ public class StandardStationProfileCollectionImpl extends StationProfileCollecti
     Cursor cursor;
 
     StandardStationProfileFeature(Station s, Cursor cursor, StructureData stationProfileData, int recnum) {
-      super(s, StandardStationProfileCollectionImpl.this.getTimeName(),
-          StandardStationProfileCollectionImpl.this.getTimeUnit(),
-          StandardStationProfileCollectionImpl.this.getAltName(),
+      super(s, StandardStationProfileCollectionImpl.this.getTimeUnit(),
           StandardStationProfileCollectionImpl.this.getAltUnits(), -1);
       this.cursor = cursor;
       // this.recnum = recnum;
@@ -249,8 +254,8 @@ public class StandardStationProfileCollectionImpl extends StationProfileCollecti
 
     StandardProfileFeature(Station s, String timeName, CalendarDateUnit timeUnit, String altName, String altUnits,
         double time, Cursor cursor, StructureData profileData) {
-      super(timeUnit.makeCalendarDate(time).toString(), timeName, timeUnit, altName, altUnits, s.getLatitude(),
-          s.getLongitude(), time, -1);
+      super(timeUnit.makeCalendarDate(time).toString(), timeUnit, altUnits, s.getLatitude(), s.getLongitude(), time,
+          -1);
       this.cursor = cursor;
       this.profileData = profileData;
 

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardTrajectoryCollectionImpl.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/standard/StandardTrajectoryCollectionImpl.java
@@ -7,10 +7,12 @@ package ucar.nc2.ft.point.standard;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import javax.annotation.Nonnull;
 import ucar.ma2.StructureData;
 import ucar.ma2.StructureDataIterator;
 import ucar.nc2.constants.FeatureType;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.PointFeatureCollection;
 import ucar.nc2.ft.PointFeatureCollectionIterator;
 import ucar.nc2.ft.PointFeatureIterator;
@@ -39,8 +41,18 @@ public class StandardTrajectoryCollectionImpl extends PointFeatureCCImpl impleme
     super(name, timeUnit, altUnits, FeatureType.TRAJECTORY);
   }
 
+  protected StandardTrajectoryCollectionImpl(String name, List<CoordinateAxis> coords) {
+    super(name, coords, FeatureType.TRAJECTORY);
+  }
+
   StandardTrajectoryCollectionImpl(NestedTable ft, CalendarDateUnit timeUnit, String altUnits) {
-    super(ft.getName(), ft.getTimeName(), timeUnit, ft.getAltName(), altUnits, FeatureType.TRAJECTORY);
+    super(ft.getName(), timeUnit, altUnits, FeatureType.TRAJECTORY);
+    this.ft = ft;
+    this.extras = ft.getExtras();
+  }
+
+  StandardTrajectoryCollectionImpl(NestedTable ft, List<CoordinateAxis> coords) {
+    super(ft.getName(), coords, FeatureType.TRAJECTORY);
     this.ft = ft;
     this.extras = ft.getExtras();
   }
@@ -57,8 +69,8 @@ public class StandardTrajectoryCollectionImpl extends PointFeatureCCImpl impleme
     StructureData trajData;
 
     StandardTrajectoryFeature(Cursor cursor, StructureData trajData) {
-      super(ft.getFeatureName(cursor), ft.getTimeName(), StandardTrajectoryCollectionImpl.this.getTimeUnit(),
-          ft.getAltName(), StandardTrajectoryCollectionImpl.this.getAltUnits(), -1);
+      super(ft.getFeatureName(cursor), StandardTrajectoryCollectionImpl.this.getTimeUnit(),
+          StandardTrajectoryCollectionImpl.this.getAltUnits(), -1);
       this.cursor = cursor;
       this.trajData = trajData;
     }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
@@ -41,7 +41,6 @@ import java.util.*;
  */
 public abstract class CFPointWriter implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(CFPointWriter.class);
-  private static final String CF_VERSION = "CF-1.9";
 
   public static final String recordName = "obs";
   public static final String recordDimName = "obs";
@@ -448,7 +447,7 @@ public abstract class CFPointWriter implements Closeable {
   }
 
   private void addGlobalAtts(List<Attribute> atts) {
-    writer.addGroupAttribute(null, new Attribute(CDM.CONVENTIONS, isExtendedModel ? CDM.CF_EXTENDED : CF_VERSION));
+    writer.addGroupAttribute(null, new Attribute(CDM.CONVENTIONS, isExtendedModel ? CDM.CF_EXTENDED : CDM.CF_VERSION));
     writer.addGroupAttribute(null, new Attribute(CDM.HISTORY, "Written by CFPointWriter"));
     for (Attribute att : atts) {
       if (!reservedGlobalAtts.contains(att.getShortName()))

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriter.java
@@ -39,7 +39,6 @@ import java.util.*;
  * <li>netcdf3: use indexed ragged array representation</li>
  * </ul>
  */
-@Deprecated
 public abstract class CFPointWriter implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(CFPointWriter.class);
   private static final String CF_VERSION = "CF-1.9";
@@ -861,6 +860,12 @@ public abstract class CFPointWriter implements Closeable {
       writer.updateAttribute(null, new Attribute(ACDD.LON_MIN, llbb.getLowerLeftPoint().getLongitude()));
       writer.updateAttribute(null, new Attribute(ACDD.LON_MAX, llbb.getUpperRightPoint().getLongitude()));
     }
+    if (minDate == null)
+      minDate = CalendarDate.present();
+    if (maxDate == null)
+      maxDate = CalendarDate.present();
+    writer.updateAttribute(null, new Attribute(ACDD.TIME_START, CalendarDateFormatter.toDateTimeStringISO(minDate)));
+    writer.updateAttribute(null, new Attribute(ACDD.TIME_END, CalendarDateFormatter.toDateTimeStringISO(maxDate)));
 
     writer.close();
   }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriterConfig.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/CFPointWriterConfig.java
@@ -18,9 +18,6 @@ import ucar.nc2.write.Nc4ChunkingDefault;
 public class CFPointWriterConfig {
   public NetcdfFileWriter.Version version; // netcdf file version
   public Nc4Chunking chunking; // for netcdf-4
-  public boolean noTimeCoverage; // does not have a time dimension
-  public int recDimensionLength = -1; // do use unlimited dimension (for netcdf3), use fixed dimension of this length
-                                      // NOT USED
 
   public CFPointWriterConfig(NetcdfFileWriter.Version version) {
     this(version, new Nc4ChunkingDefault()); // The default chunker used in Nc4Iosp.
@@ -29,10 +26,5 @@ public class CFPointWriterConfig {
   public CFPointWriterConfig(NetcdfFileWriter.Version version, Nc4Chunking chunking) {
     this.version = version;
     this.chunking = chunking;
-  }
-
-  public CFPointWriterConfig setNoTimeCoverage(boolean noTimeCoverage) {
-    this.noTimeCoverage = noTimeCoverage;
-    return this;
   }
 }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFPointCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFPointCollection.java
@@ -8,6 +8,7 @@ package ucar.nc2.ft.point.writer;
 import com.google.common.collect.ImmutableList;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.conv.CF1Convention;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateUnit;
@@ -32,11 +33,15 @@ import java.io.IOException;
  * @since Nov 23, 2010
  */
 public class WriterCFPointCollection extends CFPointWriter {
-  // private Map<String, Variable> varMap = new HashMap<>();
 
   public WriterCFPointCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
       CalendarDateUnit timeUnit, String altUnits, CFPointWriterConfig config) throws IOException {
     super(fileOut, globalAtts, dataVars, timeUnit, altUnits, config);
+  }
+
+  public WriterCFPointCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
+      List<CoordinateAxis> coordVars, CFPointWriterConfig config) throws IOException {
+    super(fileOut, globalAtts, dataVars, config, coordVars);
     writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.point.name()));
     writer.addGroupAttribute(null, new Attribute(CF.DSG_REPRESENTATION, "Point Data, H.1"));
   }

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFPointCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFPointCollection.java
@@ -37,6 +37,8 @@ public class WriterCFPointCollection extends CFPointWriter {
   public WriterCFPointCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
       CalendarDateUnit timeUnit, String altUnits, CFPointWriterConfig config) throws IOException {
     super(fileOut, globalAtts, dataVars, timeUnit, altUnits, config);
+    writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.point.name()));
+    writer.addGroupAttribute(null, new Attribute(CF.DSG_REPRESENTATION, "Point Data, H.1"));
   }
 
   public WriterCFPointCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFProfileCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFProfileCollection.java
@@ -12,6 +12,7 @@ import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.conv.CF1Convention;
 import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft.ProfileFeature;
@@ -43,6 +44,14 @@ public class WriterCFProfileCollection extends CFPointWriter {
   public WriterCFProfileCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
       CalendarDateUnit timeUnit, String altUnits, CFPointWriterConfig config) throws IOException {
     super(fileOut, globalAtts, dataVars, timeUnit, altUnits, config);
+    writer.addGroupAttribute(null,
+        new Attribute(CF.DSG_REPRESENTATION, "Contiguous ragged array representation of profiles, H.3.4"));
+    writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.profile.name()));
+  }
+
+  public WriterCFProfileCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
+      List<CoordinateAxis> coordVars, CFPointWriterConfig config) throws IOException {
+    super(fileOut, globalAtts, dataVars, config, coordVars);
     writer.addGroupAttribute(null,
         new Attribute(CF.DSG_REPRESENTATION, "Contiguous ragged array representation of profiles, H.3.4"));
     writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.profile.name()));

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationCollection.java
@@ -10,6 +10,7 @@ import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.ft.*;
 import ucar.nc2.ft.point.StationFeature;
 import ucar.nc2.ft.point.StationPointFeature;
@@ -53,9 +54,17 @@ public class WriterCFStationCollection extends CFPointWriter {
   private int desc_strlen = 1, wmo_strlen = 1;
   private Map<String, Variable> featureVarMap = new HashMap<>();
 
-  public WriterCFStationCollection(String fileOut, List<Attribute> atts, List<VariableSimpleIF> dataVars,
+  public WriterCFStationCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
       CalendarDateUnit timeUnit, String altUnits, CFPointWriterConfig config) throws IOException {
-    super(fileOut, atts, dataVars, timeUnit, altUnits, config);
+    super(fileOut, globalAtts, dataVars, timeUnit, altUnits, config);
+    writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.timeSeries.name()));
+    writer.addGroupAttribute(null, new Attribute(CF.DSG_REPRESENTATION,
+        "Timeseries of station data in the indexed ragged array representation, H.2.5"));
+  }
+
+  public WriterCFStationCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
+      List<CoordinateAxis> coordVars, CFPointWriterConfig config) throws IOException {
+    super(fileOut, globalAtts, dataVars, config, coordVars);
     writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.timeSeries.name()));
     writer.addGroupAttribute(null, new Attribute(CF.DSG_REPRESENTATION,
         "Timeseries of station data in the indexed ragged array representation, H.2.5"));

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationProfileCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFStationProfileCollection.java
@@ -13,6 +13,7 @@ import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.conv.CF1Convention;
 import ucar.nc2.ft.*;
 import ucar.nc2.ft.point.StationFeature;
@@ -52,6 +53,14 @@ public class WriterCFStationProfileCollection extends CFPointWriter {
   public WriterCFStationProfileCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
       CalendarDateUnit timeUnit, String altUnits, CFPointWriterConfig config) throws IOException {
     super(fileOut, globalAtts, dataVars, timeUnit, altUnits, config);
+    writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.timeSeriesProfile.name()));
+    writer.addGroupAttribute(null,
+        new Attribute(CF.DSG_REPRESENTATION, "Ragged array representation of time series profiles, H.5.3"));
+  }
+
+  public WriterCFStationProfileCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
+      List<CoordinateAxis> coordVars, CFPointWriterConfig config) throws IOException {
+    super(fileOut, globalAtts, dataVars, config, coordVars);
     writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.timeSeriesProfile.name()));
     writer.addGroupAttribute(null,
         new Attribute(CF.DSG_REPRESENTATION, "Ragged array representation of time series profiles, H.5.3"));

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryCollection.java
@@ -10,6 +10,7 @@ import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.conv.CF1Convention;
 import ucar.nc2.ft.*;
 import ucar.nc2.time.CalendarDateUnit;
@@ -33,6 +34,14 @@ public class WriterCFTrajectoryCollection extends CFPointWriter {
   public WriterCFTrajectoryCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
       CalendarDateUnit timeUnit, String altUnits, CFPointWriterConfig config) throws IOException {
     super(fileOut, globalAtts, dataVars, timeUnit, altUnits, config);
+    writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.trajectory.name()));
+    writer.addGroupAttribute(null,
+        new Attribute(CF.DSG_REPRESENTATION, "Contiguous ragged array representation of trajectories, H.4.3"));
+  }
+
+  public WriterCFTrajectoryCollection(String fileOut, List<Attribute> globalAtts, List<VariableSimpleIF> dataVars,
+      List<CoordinateAxis> coordVars, CFPointWriterConfig config) throws IOException {
+    super(fileOut, globalAtts, dataVars, config, coordVars);
     writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.trajectory.name()));
     writer.addGroupAttribute(null,
         new Attribute(CF.DSG_REPRESENTATION, "Contiguous ragged array representation of trajectories, H.4.3"));

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryProfileCollection.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer/WriterCFTrajectoryProfileCollection.java
@@ -10,6 +10,7 @@ import ucar.ma2.*;
 import ucar.nc2.*;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
+import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.conv.CF1Convention;
 import ucar.nc2.ft.*;
 import ucar.nc2.time.CalendarDateUnit;
@@ -46,6 +47,15 @@ public class WriterCFTrajectoryProfileCollection extends CFPointWriter {
     writer.addGroupAttribute(null,
         new Attribute(CF.DSG_REPRESENTATION, "Contiguous ragged array representation of trajectory profile, H.6.3"));
   }
+
+  public WriterCFTrajectoryProfileCollection(String fileOut, List<Attribute> globalAtts,
+      List<VariableSimpleIF> dataVars, List<CoordinateAxis> coordVars, CFPointWriterConfig config) throws IOException {
+    super(fileOut, globalAtts, dataVars, config, coordVars);
+    writer.addGroupAttribute(null, new Attribute(CF.FEATURE_TYPE, CF.FeatureType.trajectoryProfile.name()));
+    writer.addGroupAttribute(null,
+        new Attribute(CF.DSG_REPRESENTATION, "Contiguous ragged array representation of trajectory profile, H.6.3"));
+  }
+
 
   public void setFeatureAuxInfo2(int ntraj, int traj_strlen) {
     this.ntraj = ntraj;

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer2/WriterCFPointAbstract.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer2/WriterCFPointAbstract.java
@@ -40,6 +40,8 @@ import ucar.unidata.geoloc.LatLonRect;
 abstract class WriterCFPointAbstract implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(WriterCFPointAbstract.class);
 
+  private static final String CF_VERSION = "CF-1.9";
+
   static final String recordName = "obs";
   static final String recordDimName = "obs";
   static final String latName = "latitude";
@@ -126,7 +128,7 @@ abstract class WriterCFPointAbstract implements Closeable {
   }
 
   private void addGlobalAtts(AttributeContainer atts) {
-    writerb.addAttribute(new Attribute(CDM.CONVENTIONS, isExtendedModel ? CDM.CF_EXTENDED : "CF-1.6"));
+    writerb.addAttribute(new Attribute(CDM.CONVENTIONS, isExtendedModel ? CDM.CF_EXTENDED : CF_VERSION));
     writerb.addAttribute(new Attribute(CDM.HISTORY, "Written by CFPointWriter"));
     for (Attribute att : atts) {
       if (!reservedGlobalAtts.contains(att.getShortName()))

--- a/cdm/core/src/main/java/ucar/nc2/ft/point/writer2/WriterCFPointAbstract.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft/point/writer2/WriterCFPointAbstract.java
@@ -40,8 +40,6 @@ import ucar.unidata.geoloc.LatLonRect;
 abstract class WriterCFPointAbstract implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(WriterCFPointAbstract.class);
 
-  private static final String CF_VERSION = "CF-1.9";
-
   static final String recordName = "obs";
   static final String recordDimName = "obs";
   static final String latName = "latitude";
@@ -128,7 +126,7 @@ abstract class WriterCFPointAbstract implements Closeable {
   }
 
   private void addGlobalAtts(AttributeContainer atts) {
-    writerb.addAttribute(new Attribute(CDM.CONVENTIONS, isExtendedModel ? CDM.CF_EXTENDED : CF_VERSION));
+    writerb.addAttribute(new Attribute(CDM.CONVENTIONS, isExtendedModel ? CDM.CF_EXTENDED : CDM.CF_VERSION));
     writerb.addAttribute(new Attribute(CDM.HISTORY, "Written by CFPointWriter"));
     for (Attribute att : atts) {
       if (!reservedGlobalAtts.contains(att.getShortName()))

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
@@ -189,8 +189,7 @@ public class CoverageAsPoint {
     private StationFeature createStationFeature(String name) {
       double stationZ = varGroup.zAxis != null ? varGroup.zAxis.getCoordEdgeFirst() : 0.0;
       return new CoverageAsStationProfile(name, name, null, nearestLatLonPoint.getLatitude(),
-          nearestLatLonPoint.getLongitude(), stationZ, this.timeName, this.timeUnit, this.altName, this.altUnits, -1,
-          varGroup);
+          nearestLatLonPoint.getLongitude(), stationZ, this.timeUnit, this.altUnits, -1, varGroup);
     }
   }
 
@@ -220,8 +219,7 @@ public class CoverageAsPoint {
     private StationFeature createStationFeature(String name) {
       double stationZ = varGroup.zAxis != null ? varGroup.zAxis.getCoordMidpoint(0) : 0.0;
       return new CoverageAsStationFeature(name, name, null, nearestLatLonPoint.getLatitude(),
-          nearestLatLonPoint.getLongitude(), stationZ, this.timeName, this.timeUnit, this.altName, this.altUnits, -1,
-          varGroup);
+          nearestLatLonPoint.getLongitude(), stationZ, this.timeUnit, this.altUnits, -1, varGroup);
     }
   }
 
@@ -232,8 +230,8 @@ public class CoverageAsPoint {
     private VarGroup varGroup;
 
     private CoverageAsStationProfile(String name, String desc, String wmoId, double lat, double lon, double alt,
-        String timeName, CalendarDateUnit timeUnit, String altName, String altUnits, int npts, VarGroup varGroup) {
-      super(name, desc, wmoId, lat, lon, alt, timeName, timeUnit, altName, altUnits, npts);
+        CalendarDateUnit timeUnit, String altUnits, int npts, VarGroup varGroup) {
+      super(name, desc, wmoId, lat, lon, alt, timeUnit, altUnits, npts);
       this.varGroup = varGroup;
     }
 
@@ -309,10 +307,9 @@ public class CoverageAsPoint {
       @Override
       public PointFeatureCollection next() throws IOException {
         double obsTime = this.timeAxis != null ? this.timeAxis.getCoordMidpoint(curr) : 0.0;
-        String timeName = this.timeAxis != null ? this.timeAxis.getName() : "time";
         curr++;
-        return new CoverageAsProfileFeature(obsTime, timeName, varGroup.dateUnit, varGroup.zAxis.getName(),
-            varGroup.zUnit, getLatitude(), getLongitude(), this.varIters);
+        return new CoverageAsProfileFeature(obsTime, varGroup.dateUnit, varGroup.zUnit, getLatitude(), getLongitude(),
+            this.varIters);
       }
     }
 
@@ -320,9 +317,9 @@ public class CoverageAsPoint {
 
       List<VarIter> varIters;
 
-      CoverageAsProfileFeature(double obsTime, String timeName, CalendarDateUnit timeUnit, String altName,
-          String altUnits, double lat, double lon, List<VarIter> varIters) {
-        super("", timeName, timeUnit, altName, altUnits, lat, lon, obsTime, -1);
+      CoverageAsProfileFeature(double obsTime, CalendarDateUnit timeUnit, String altUnits, double lat, double lon,
+          List<VarIter> varIters) {
+        super("", timeUnit, altUnits, lat, lon, obsTime, -1);
         this.varIters = varIters;
       }
 
@@ -466,8 +463,8 @@ public class CoverageAsPoint {
     private VarGroup varGroup;
 
     private CoverageAsStationFeature(String name, String desc, String wmoId, double lat, double lon, double alt,
-        String timeName, CalendarDateUnit timeUnit, String altName, String altUnits, int npts, VarGroup varGroup) {
-      super(name, desc, wmoId, lat, lon, alt, timeName, timeUnit, altName, altUnits, npts, StructureData.EMPTY);
+        CalendarDateUnit timeUnit, String altUnits, int npts, VarGroup varGroup) {
+      super(name, desc, wmoId, lat, lon, alt, timeUnit, altUnits, npts, StructureData.EMPTY);
       this.varGroup = varGroup;
     }
 

--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/writer/CoverageAsPoint.java
@@ -27,7 +27,7 @@ import ucar.unidata.geoloc.LatLonPoints;
 import ucar.unidata.util.StringUtil2;
 
 /**
- * Write DSG CF-1.6 file from a Coverage Dataset
+ * Write DSG CF-1.9 file from a Coverage Dataset
  *
  * @author caron
  * @since 7/8/2015

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/writer/TestCoverageAsPoint.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/writer/TestCoverageAsPoint.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import ucar.ma2.Array;
 import ucar.nc2.constants.FeatureType;
@@ -100,6 +101,26 @@ public class TestCoverageAsPoint {
     varNames.add("T1noZ");
     vals = Arrays.copyOfRange(expected, 0, 2);
     params.setVariables(varNames);
+    readCoverageAsPoint(varNames, params, alts[0], times, vals);
+  }
+
+  @Ignore("Enable when custom axis names are working")
+  @Test
+  public void testCoverageAsPointWithAxisName() throws IOException {
+
+    double[] vals = Arrays.copyOfRange(expected, 0, 1);
+    // test single point (no time)
+    List<String> varNames = new ArrayList<>();
+    varNames.add("2D");
+    SubsetParams params = new SubsetParams();
+    params.setVariables(varNames);
+    params.setLatLonPoint(latlon);
+    readCoverageAsPoint(varNames, params, alts[0], times, vals);
+    // test time series
+    varNames = new ArrayList<>();
+    varNames.add("T1noZ");
+    vals = Arrays.copyOfRange(expected, 0, 2);
+    params.setVariables(varNames);
     readCoverageAsPoint(varNames, params, alts[0], times, vals, 0, "time1");
 
     // test multiple time axes
@@ -143,12 +164,17 @@ public class TestCoverageAsPoint {
     varNames.add("4D");
     params.setVariables(varNames);
     readCoverageAsProfile(varNames, params, alts, times, expected);
+  }
+
+  @Ignore("Enable when custom axis names are working")
+  @Test
+  public void testCoverageAsProfileWithAxisNames() throws IOException {
+    List<String> varNames = new ArrayList<>();
+    SubsetParams params = new SubsetParams();
 
     // test two different time axes
-    varNames = new ArrayList<>();
     varNames.add("full4");
     varNames.add("withT1");
-    params = new SubsetParams();
     params.setVariables(varNames);
     params.setLatLonPoint(latlon);
     readCoverageAsProfile(varNames, params, alts, times, expected);

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/writer/TestCoverageAsPoint.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/writer/TestCoverageAsPoint.java
@@ -252,7 +252,7 @@ public class TestCoverageAsPoint {
 
   private void readCoverageAsProfile(List<String> varNames, SubsetParams params, double[] alt, double[] time,
       double[] expected) throws IOException {
-    readCoverageAsProfile(varNames, params, alt, time, expected, 0, "time", "z");
+    readCoverageAsProfile(varNames, params, alt, time, expected, 0, "time", "altitude");
   }
 
   private void readCoverageAsProfile(List<String> varNames, SubsetParams params, double[] alt, double[] time,


### PR DESCRIPTION
- reverts time and alt axis names changes from #1275 to fix DSGSubsetWriter for NCSS
- adds constructors that contain a list of coordinate variables to point feature implementations and point writers
- future work to make the CF Point writers more accurately represent the dataset they're writing should use coordinate axis info taken from the list of coordinate variables