### PR TITLE
Update test container

### DIFF
--- a/cdm-test-utils/src/main/resources/ucar/unidata/util/test/Dockerfile
+++ b/cdm-test-utils/src/main/resources/ucar/unidata/util/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM unidata/tomcat-docker:8.5-jdk11 AS base
+FROM unidata/tomcat-docker:9.0-jdk11 AS base
 
 MAINTAINER Unidata
 


### PR DESCRIPTION
## Description of Changes

Use tomcat docker 9.0 for dap tests since 8.5 was removed
