### PR TITLE
Fix invalid checksum error

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/filter/Shuffle.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Shuffle.java
@@ -39,7 +39,7 @@ public class Shuffle extends Filter {
 
   @Override
   public byte[] encode(byte[] dataIn) {
-    if (dataIn.length % elemSize != 0 || elemSize <= 1) {
+    if (elemSize <= 1) {
       return dataIn;
     }
 
@@ -56,29 +56,35 @@ public class Shuffle extends Filter {
       }
     }
 
+    int leftoverBytes = dataIn.length % this.elemSize;
+    System.arraycopy(dataIn, dataIn.length - leftoverBytes, result, result.length - leftoverBytes, leftoverBytes);
+
     return result;
   }
 
   @Override
   public byte[] decode(byte[] dataIn) {
-    if (dataIn.length % this.elemSize == 0 && this.elemSize > 1) {
-      int nElems = dataIn.length / this.elemSize;
-      byte[] result = new byte[dataIn.length];
-
-      for (int j = 0; j < this.elemSize; ++j) {
-        int sourceIndex = j * nElems;
-        int destIndex = j;
-        for (int i = 0; i < nElems; ++i) {
-          result[destIndex] = dataIn[sourceIndex];
-          sourceIndex++;
-          destIndex += this.elemSize;
-        }
-      }
-
-      return result;
-    } else {
+    if (elemSize <= 1) {
       return dataIn;
     }
+
+    int nElems = dataIn.length / this.elemSize;
+    byte[] result = new byte[dataIn.length];
+
+    for (int j = 0; j < this.elemSize; ++j) {
+      int sourceIndex = j * nElems;
+      int destIndex = j;
+      for (int i = 0; i < nElems; ++i) {
+        result[destIndex] = dataIn[sourceIndex];
+        sourceIndex++;
+        destIndex += this.elemSize;
+      }
+    }
+
+    int leftoverBytes = dataIn.length % this.elemSize;
+    System.arraycopy(dataIn, dataIn.length - leftoverBytes, result, result.length - leftoverBytes, leftoverBytes);
+
+    return result;
   }
 
   public static class Provider implements FilterProvider {


### PR DESCRIPTION
## Description of Changes

Should fix https://github.com/Unidata/netcdf-java/issues/1199.

When a double variable has multiple filters like Deflate, Shuffle, and Checksum, the Checksum was throwing an "invalid checksum" error on reading. This was because the Shuffle algorithm had a condition that it wasn't applied unless the chunk of data had a size that was a multiple of the element size. This condition was false for the case of 8 byte doubles with a checksum, which is represented as 4 bytes at the end of the chunk.

This PR allows the Shuffle encoding and decoding to apply to chunks of any size, and ensures the leftover bytes that aren't affected by the shuffle remain the same. This is in line with the netcdf-c library behavior.


