### PR TITLE
Improve support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ For information about how to subscribe, see the "Subscribe" link on this page
 For more general netCDF discussion, see the netcdfgroup@unidata.ucar.edu email list.
 
 We appreciate feedback from users of this package.
-Please send comments and suggestions to <support-netcdf-java@unidata.ucar.edu>.
-For bug reports, feel free to open an issue on this repository, or contact us at the address above.
+Open a GitHub issue or discussion if you have comments,
+suggestions, or bug reports.
 Please identify the version of the package as well as the version/vendor of Java you are using.
 For potential security issues, please contact security@unidata.ucar.edu directly.
 

--- a/docs/src/site/_config.yml
+++ b/docs/src/site/_config.yml
@@ -30,19 +30,8 @@ port: 4005
 #exclude:
 #  - Gemfile.lock
 
-
-# used as a contact email and subject line for the Feedback link in the top navigation bar
-feedback_email: support-netcdf-java@unidata.ucar.edu
-feedback_subject_line: Documentation Feedback
-
-# if you uncomment the next line, the Feedback link gets removed
-# feedback_disable: true
-
-# if you uncomment the next line, it changes the Feedback text
-# feedback_text: "Need help?"
-
-# if you uncomment the next line, it changes where the feedback link points to
-# feedback_link: "http://helpy.io/"
+# used for the Feedback link in the top navigation bar
+feedback_link: "https://github.com/Unidata/netcdf-java/issues/new?title=Documentation%20feedback"
 
 # library used for syntax highlighting
 highlighter: rouge

--- a/docs/src/site/pages/netcdfJava/developer/FileTypes.md
+++ b/docs/src/site/pages/netcdfJava/developer/FileTypes.md
@@ -19,7 +19,7 @@ To support this functionality, `getFileTypeId()`, `getFileTypeVersion()`, and `g
 You will need to add these methods to your IOServiceProvider implementations. To use an IOSP implementation, you must include its module in your netCDF-java build.
 For more information on including modules in your build, see [here](using_netcdf_java_artifacts.html).
 
-To register your format/IOServiceProvider, or to send corrections and additions to this table, please send email to <support-netcdf-java@unidata.ucar.edu>.
+To register your format/IOServiceProvider, or to send corrections and additions to this table, please open a [GitHub issue](https://github.com/Unidata/netcdf-java/issues/new?title=Documentation%20feedback).
 
 | Id | Description | Module | Reference URL
 | BUFR | WMO Binary Universal Form | `bufr` | <http://www.wmo.int/pages/prog/www/WMOCodes/OperationalCodes.html/> |


### PR DESCRIPTION
Emphasize GitHub as primary avenue of support, while eSupport can still be used for security issues.