### PR TITLE
Fix subsetting axis with single value

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis1D.java
+++ b/cdm/core/src/main/java/ucar/nc2/ft2/coverage/CoverageCoordAxis1D.java
@@ -100,7 +100,7 @@ public class CoverageCoordAxis1D extends CoverageCoordAxis { // implements Itera
     switch (spacing) {
       case regularInterval:
       case regularPoint:
-        return getResolution() > 0;
+        return getResolution() >= 0;
 
       case irregularPoint:
         return values[0] <= values[ncoords - 1];

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
@@ -14,6 +14,7 @@ import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Range;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.ft2.coverage.CoverageCoordAxis.Spacing;
+import ucar.nc2.util.Optional;
 
 @RunWith(Enclosed.class)
 public class TestCoordAxisHelper {
@@ -70,5 +71,21 @@ public class TestCoordAxisHelper {
 
   public static class TestCoordAxisHelperNonParameterized {
 
+    @Test
+    public void shouldSubsetSingleValuedAxis() {
+      final double[] values = new double[] {42.0};
+      final double resolution = 0.0;
+
+      final CoverageCoordAxisBuilder coverageCoordAxisBuilder = new CoverageCoordAxisBuilder("name", "unit",
+          "description", DataType.DOUBLE, AxisType.Time, null, CoverageCoordAxis.DependenceType.independent, null,
+          Spacing.regularPoint, values.length, values[0], values[values.length - 1], resolution, values, null);
+      final CoverageCoordAxis1D coverageCoordAxis = new CoverageCoordAxis1D(coverageCoordAxisBuilder);
+      final CoordAxisHelper coordAxisHelper = new CoordAxisHelper(coverageCoordAxis);
+
+      final Optional<CoverageCoordAxisBuilder> subsetBuilder = coordAxisHelper.subset(0.0, 100.0, 1);
+      assertThat(subsetBuilder.isPresent()).isTrue();
+      assertThat(subsetBuilder.get().startValue).isEqualTo(values[0]);
+      assertThat(subsetBuilder.get().endValue).isEqualTo(values[0]);
+    }
   }
 }

--- a/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
+++ b/cdm/core/src/test/java/ucar/nc2/ft2/coverage/TestCoordAxisHelper.java
@@ -4,7 +4,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import ucar.ma2.DataType;
@@ -13,52 +15,60 @@ import ucar.ma2.Range;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.ft2.coverage.CoverageCoordAxis.Spacing;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class TestCoordAxisHelper {
 
-  @Parameterized.Parameters(name = "{0}, {1}")
-  public static List<Object[]> getTestParameters() {
-    return Arrays.asList(
+  @RunWith(Parameterized.class)
+  public static class TestCoordAxisHelperParametrized {
 
-        new Object[] {Spacing.regularPoint, new double[] {0.0, 10.0, 20.0, 30.0, 40.0}},
-        new Object[] {Spacing.irregularPoint, new double[] {0.0, 5.0, 20.0, 30.0, 40.0}},
-        new Object[] {Spacing.regularInterval, new double[] {0.0, 10.0, 20.0, 30.0, 40.0}},
-        new Object[] {Spacing.contiguousInterval, new double[] {0.0, 5.0, 20.0, 30.0, 40.0}},
-        new Object[] {Spacing.discontiguousInterval, new double[] {0.0, 0.0, 20.0, 30.0, 40.0, 40.0, 50.0, 50.0}}
+    @Parameterized.Parameters(name = "{0}, {1}")
+    public static List<Object[]> getTestParameters() {
+      return Arrays.asList(
 
-    );
-  }
+          new Object[] {Spacing.regularPoint, new double[] {0.0, 10.0, 20.0, 30.0, 40.0}},
+          new Object[] {Spacing.irregularPoint, new double[] {0.0, 5.0, 20.0, 30.0, 40.0}},
+          new Object[] {Spacing.regularInterval, new double[] {0.0, 10.0, 20.0, 30.0, 40.0}},
+          new Object[] {Spacing.contiguousInterval, new double[] {0.0, 5.0, 20.0, 30.0, 40.0}},
+          new Object[] {Spacing.discontiguousInterval, new double[] {0.0, 0.0, 20.0, 30.0, 40.0, 40.0, 50.0, 50.0}}
 
-  private final Spacing spacing;
-  private final double[] values;
-
-  public TestCoordAxisHelper(Spacing spacing, double[] values) {
-    this.spacing = spacing;
-    this.values = values;
-  }
-
-  @Test
-  public void shouldSubsetAxisByRange() throws InvalidRangeException {
-    final AxisType axisType = AxisType.Time;
-    final double resolution = values[1] - values[0];
-
-    final CoverageCoordAxisBuilder coverageCoordAxisBuilder = new CoverageCoordAxisBuilder("name", "unit",
-        "description", DataType.DOUBLE, axisType, null, CoverageCoordAxis.DependenceType.independent, null, spacing,
-        values.length, values[0], values[values.length - 1], resolution, values, null);
-    final CoverageCoordAxis1D coverageCoordAxis = new CoverageCoordAxis1D(coverageCoordAxisBuilder);
-    final CoordAxisHelper coordAxisHelper = new CoordAxisHelper(coverageCoordAxis);
-
-    final Range subsetRange = new Range(1, 3);
-    final CoverageCoordAxisBuilder subsetBuilder = coordAxisHelper.subsetByIndex(subsetRange);
-    assertThat(subsetBuilder).isNotNull();
-    assertThat(subsetBuilder.axisType).isEqualTo(axisType);
-    assertThat(subsetBuilder.startValue).isEqualTo(values[subsetRange.first()]);
-    assertThat(subsetBuilder.endValue).isEqualTo(values[subsetRange.last()]);
-
-    if (spacing == Spacing.regularPoint || spacing == Spacing.regularInterval) {
-      assertThat(subsetBuilder.values).isNull();
-    } else {
-      assertThat(subsetBuilder.values).isNotNull();
+      );
     }
+
+    private final Spacing spacing;
+    private final double[] values;
+
+    public TestCoordAxisHelperParametrized(Spacing spacing, double[] values) {
+      this.spacing = spacing;
+      this.values = values;
+    }
+
+    @Test
+    public void shouldSubsetAxisByRange() throws InvalidRangeException {
+      final AxisType axisType = AxisType.Time;
+      final double resolution = values[1] - values[0];
+
+      final CoverageCoordAxisBuilder coverageCoordAxisBuilder = new CoverageCoordAxisBuilder("name", "unit",
+          "description", DataType.DOUBLE, axisType, null, CoverageCoordAxis.DependenceType.independent, null, spacing,
+          values.length, values[0], values[values.length - 1], resolution, values, null);
+      final CoverageCoordAxis1D coverageCoordAxis = new CoverageCoordAxis1D(coverageCoordAxisBuilder);
+      final CoordAxisHelper coordAxisHelper = new CoordAxisHelper(coverageCoordAxis);
+
+      final Range subsetRange = new Range(1, 3);
+      final CoverageCoordAxisBuilder subsetBuilder = coordAxisHelper.subsetByIndex(subsetRange);
+      assertThat(subsetBuilder).isNotNull();
+      assertThat(subsetBuilder.axisType).isEqualTo(axisType);
+      assertThat(subsetBuilder.startValue).isEqualTo(values[subsetRange.first()]);
+      assertThat(subsetBuilder.endValue).isEqualTo(values[subsetRange.last()]);
+
+      if (spacing == Spacing.regularPoint || spacing == Spacing.regularInterval) {
+        assertThat(subsetBuilder.values).isNull();
+      } else {
+        assertThat(subsetBuilder.values).isNotNull();
+      }
+    }
+  }
+
+  public static class TestCoordAxisHelperNonParameterized {
+
   }
 }


### PR DESCRIPTION
## Description of Changes

Fixes https://github.com/Unidata/tds/issues/532.

- `isAscending` should return true for any positive `resolution`, including 0 (which is the resolution of an axis with a single value). This condition is used to determine whether min/max indexes should get flipped when a subset is requested, which currently results in an error for the case of an axis with a single value.
- Add a test and a small refactor of existing test class (easiest to view diff without whitespace changes).