### PR TITLE
Make methods public

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -921,7 +921,7 @@ public class NetcdfFiles {
    * @param vname the name
    * @return escaped version of it
    */
-  private static String makeValidPathName(String vname) {
+  public static String makeValidPathName(String vname) {
     return EscapeStrings.backslashEscape(vname, reservedFullName);
   }
 
@@ -932,7 +932,7 @@ public class NetcdfFiles {
    * @param vname the name
    * @return escaped version of it
    */
-  static String makeValidSectionSpecName(String vname) {
+  public static String makeValidSectionSpecName(String vname) {
     return EscapeStrings.backslashEscape(vname, reservedSectionSpec);
   }
 


### PR DESCRIPTION
Make methods public that replace deprecate functionality (and used to be in the public api). Fixes https://github.com/Unidata/netcdf-java/issues/1386.
