### PR TITLE
refactor some of the enhancement SPI lgoic and provider interface

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
+++ b/cdm/core/src/main/java/ucar/nc2/constants/CDM.java
@@ -57,9 +57,6 @@ public class CDM {
   public static final String TIME_OFFSET = "time offset from runtime";
   public static final String TIME_OFFSET_HOUR = "hoursFrom0z";
   public static final String RUNTIME_COORDINATE = "runtimeCoordinate";
-  public static final String STANDARDIZE = "standardize";
-  public static final String NORMALIZE = "normalize";
-  public static final String CLASSIFY = "classify";
 
   // Special attributes
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
@@ -130,11 +130,17 @@ public class NetcdfDataset extends ucar.nc2.NetcdfFile {
      * x<0 --> 0 x>0 --> 1
      */
     ApplyClassifier,
+    /**
+     * All other Enhancement implementations that are loaded by service provider
+     * This includes third party implementations found on the classpath and loaded at runtime.
+     */
+    ApplyRuntimeLoadedEnhancements,
   }
 
-  private static Set<Enhance> EnhanceAll = Collections.unmodifiableSet(
-      EnumSet.of(Enhance.ConvertEnums, Enhance.ConvertUnsigned, Enhance.ApplyScaleOffset, Enhance.ConvertMissing,
-          Enhance.CoordSystems, Enhance.ApplyStandardizer, Enhance.ApplyNormalizer, Enhance.ApplyClassifier));
+  private static Set<Enhance> EnhanceAll =
+      Collections.unmodifiableSet(EnumSet.of(Enhance.ConvertEnums, Enhance.ConvertUnsigned, Enhance.ApplyScaleOffset,
+          Enhance.ConvertMissing, Enhance.CoordSystems, Enhance.ApplyStandardizer, Enhance.ApplyNormalizer,
+          Enhance.ApplyClassifier, Enhance.ApplyRuntimeLoadedEnhancements));
   private static Set<Enhance> EnhanceNone = Collections.unmodifiableSet(EnumSet.noneOf(Enhance.class));
   private static Set<Enhance> defaultEnhanceMode = EnhanceAll;
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/NetcdfDataset.java
@@ -116,21 +116,6 @@ public class NetcdfDataset extends ucar.nc2.NetcdfFile {
      */
     IncompleteCoordSystems,
     /**
-     * Calculate mean and standard deviation and apply to data: (z-mean)/standard_deviation.
-     * If the enhanced data type is not {@code FLOAT} or {@code DOUBLE}, this has no effect.
-     */
-    ApplyStandardizer,
-    /**
-     * Calculate minimum value and range (maximum - minimum) and apply to data: (z - min)/range.
-     * If the enhanced data type is not {@code FLOAT} or {@code DOUBLE}, this has no effect.
-     */
-    ApplyNormalizer,
-    /**
-     * Classify doubles or floats based on positive/negative into 1 or 0 {@code}
-     * x<0 --> 0 x>0 --> 1
-     */
-    ApplyClassifier,
-    /**
      * All other Enhancement implementations that are loaded by service provider
      * This includes third party implementations found on the classpath and loaded at runtime.
      */
@@ -139,8 +124,7 @@ public class NetcdfDataset extends ucar.nc2.NetcdfFile {
 
   private static Set<Enhance> EnhanceAll =
       Collections.unmodifiableSet(EnumSet.of(Enhance.ConvertEnums, Enhance.ConvertUnsigned, Enhance.ApplyScaleOffset,
-          Enhance.ConvertMissing, Enhance.CoordSystems, Enhance.ApplyStandardizer, Enhance.ApplyNormalizer,
-          Enhance.ApplyClassifier, Enhance.ApplyRuntimeLoadedEnhancements));
+          Enhance.ConvertMissing, Enhance.CoordSystems, Enhance.ApplyRuntimeLoadedEnhancements));
   private static Set<Enhance> EnhanceNone = Collections.unmodifiableSet(EnumSet.noneOf(Enhance.class));
   private static Set<Enhance> defaultEnhanceMode = EnhanceAll;
 

--- a/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
@@ -921,7 +921,7 @@ public class VariableDS extends Variable implements VariableEnhanced, EnhanceSca
 
     if (this.enhanceMode.contains(Enhance.ConvertUnsigned)) {
       this.unsignedConversion = UnsignedConversion.createFromVar(this);
-      this.dataType = unsignedConversion != null ? unsignedConversion.getOutType() : dataType;
+      this.dataType = unsignedConversion.getOutType();
     }
     if (this.enhanceMode.contains(Enhance.ConvertMissing)) {
       this.convertMissing = ConvertMissing.createFromVariable(this);
@@ -932,9 +932,11 @@ public class VariableDS extends Variable implements VariableEnhanced, EnhanceSca
       }
       this.dataType = scaleOffset != null ? scaleOffset.getScaledOffsetType() : this.dataType;
     }
-    for (Enhance enhance : this.enhanceMode) {
+
+    if (this.enhanceMode.contains(Enhance.ApplyRuntimeLoadedEnhancements)) {
       for (EnhancementProvider service : ENHANCEMENT_PROVIDERS) {
-        if (service.appliesTo(enhance, this.attributes(), dataType)) {
+        if (this.attributes().findAttribute(service.getAttributeName()) != null
+            && service.appliesTo(this.enhanceMode, dataType)) {
           loadedEnhancements.add(service.create(this));
         }
       }

--- a/cdm/core/src/main/java/ucar/nc2/filter/Classifier.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Classifier.java
@@ -128,7 +128,7 @@ public class Classifier implements Enhancement {
 
     @Override
     public boolean appliesTo(Set<Enhance> enhance, DataType dt) {
-      return enhance.contains(Enhance.ApplyClassifier) && dt.isNumeric();
+      return dt.isNumeric();
     }
 
     @Override

--- a/cdm/core/src/main/java/ucar/nc2/filter/Classifier.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Classifier.java
@@ -9,6 +9,8 @@ import ucar.nc2.dataset.VariableDS;
 import ucar.nc2.util.Misc;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+
 import ucar.ma2.*;
 import ucar.nc2.*;
 
@@ -20,8 +22,7 @@ public class Classifier implements Enhancement {
   private List<int[]> rules = new ArrayList<>();
 
   private static String name = "Classifier";
-
-
+  private static final String ATTRIBUTE_NAME = "classify";
 
   public Classifier() {
     this.AttCat = new String[0];
@@ -41,7 +42,7 @@ public class Classifier implements Enhancement {
 
     for (Attribute attribute : attributes) {
       // check like this, or something else?
-      if (attribute == var.attributes().findAttribute(CDM.CLASSIFY)) {
+      if (attribute == var.attributes().findAttribute(ATTRIBUTE_NAME)) {
         String[] sets = attribute.getStringValue().split(";");
         for (int i = 0; i < sets.length; i++) {
           // trim and clean so it's ready
@@ -126,9 +127,15 @@ public class Classifier implements Enhancement {
   }
 
   public static class Provider implements EnhancementProvider {
+
     @Override
-    public boolean appliesTo(Enhance enhance, AttributeContainer attributes, DataType dt) {
-      return enhance == Enhance.ApplyClassifier && attributes.findAttribute(CDM.CLASSIFY) != null && dt.isNumeric();
+    public String getAttributeName() {
+      return ATTRIBUTE_NAME;
+    }
+
+    @Override
+    public boolean appliesTo(Set<Enhance> enhance, DataType dt) {
+      return enhance.contains(Enhance.ApplyClassifier) && dt.isNumeric();
     }
 
     @Override

--- a/cdm/core/src/main/java/ucar/nc2/filter/Classifier.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Classifier.java
@@ -17,7 +17,6 @@ import ucar.nc2.*;
 
 public class Classifier implements Enhancement {
 
-
   private String[] AttCat;
   private List<int[]> rules = new ArrayList<>();
 
@@ -36,7 +35,6 @@ public class Classifier implements Enhancement {
   }
 
   // Factory method to create a Classifier from a Variable
-
   public static Classifier createFromVariable(VariableDS var) {
     List<Attribute> attributes = var.attributes().getAttributes();
 
@@ -53,10 +51,7 @@ public class Classifier implements Enhancement {
     }
 
     return new Classifier();
-
   }
-
-
 
   public int[] classifyWithAttributes(Array arr) {
     int[] classifiedArray = new int[(int) arr.getSize()];
@@ -73,8 +68,6 @@ public class Classifier implements Enhancement {
     }
     return classifiedArray;
   }
-
-
 
   public int classifyArrayAttribute(double val) {
     for (int[] rule : rules) {

--- a/cdm/core/src/main/java/ucar/nc2/filter/EnhancementProvider.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/EnhancementProvider.java
@@ -10,13 +10,16 @@ import ucar.nc2.*;
 import ucar.nc2.dataset.NetcdfDataset.Enhance;
 import ucar.nc2.dataset.VariableDS;
 
+import java.util.Set;
+
 
 /**
  * A Service Provider of {@link Enhancement}.
  */
 public interface EnhancementProvider {
+  String getAttributeName();
 
-  boolean appliesTo(Enhance enhance, AttributeContainer attributes, DataType dt);
+  boolean appliesTo(Set<Enhance> enhance, DataType dt);
 
   Enhancement create(VariableDS var);
 

--- a/cdm/core/src/main/java/ucar/nc2/filter/Normalizer.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Normalizer.java
@@ -88,15 +88,13 @@ public class Normalizer implements Enhancement {
 
     @Override
     public boolean appliesTo(Set<Enhance> enhance, DataType dt) {
-      return enhance.contains(Enhance.ApplyNormalizer) && dt.isFloatingPoint();
+      return dt.isFloatingPoint();
     }
 
     @Override
     public Normalizer create(VariableDS var) {
       return Normalizer.createFromVariable(var);
     }
-
-
 
   }
 

--- a/cdm/core/src/main/java/ucar/nc2/filter/Normalizer.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Normalizer.java
@@ -79,11 +79,16 @@ public class Normalizer implements Enhancement {
 
   public static class Provider implements EnhancementProvider {
 
+    private static final String ATTRIBUTE_NAME = "normalize";
 
     @Override
-    public boolean appliesTo(Enhance enhance, AttributeContainer attributes, DataType dt) {
-      return enhance == Enhance.ApplyNormalizer && attributes.findAttribute(CDM.NORMALIZE) != null
-          && dt.isFloatingPoint();
+    public String getAttributeName() {
+      return ATTRIBUTE_NAME;
+    }
+
+    @Override
+    public boolean appliesTo(Set<Enhance> enhance, DataType dt) {
+      return enhance.contains(Enhance.ApplyNormalizer) && dt.isFloatingPoint();
     }
 
     @Override

--- a/cdm/core/src/main/java/ucar/nc2/filter/Standardizer.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Standardizer.java
@@ -90,7 +90,7 @@ public class Standardizer implements Enhancement {
 
     @Override
     public boolean appliesTo(Set<Enhance> enhance, DataType dt) {
-      return enhance.contains(Enhance.ApplyStandardizer) && dt.isFloatingPoint();
+      return dt.isFloatingPoint();
     }
 
     @Override

--- a/cdm/core/src/main/java/ucar/nc2/filter/Standardizer.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Standardizer.java
@@ -81,11 +81,16 @@ public class Standardizer implements Enhancement {
 
   public static class Provider implements EnhancementProvider {
 
+    private static final String ATTRIBUTE_NAME = "standardize";
 
     @Override
-    public boolean appliesTo(Enhance enhance, AttributeContainer attributes, DataType dt) {
-      return enhance == Enhance.ApplyStandardizer && attributes.findAttribute(CDM.STANDARDIZE) != null
-          && dt.isFloatingPoint();
+    public String getAttributeName() {
+      return ATTRIBUTE_NAME;
+    }
+
+    @Override
+    public boolean appliesTo(Set<Enhance> enhance, DataType dt) {
+      return enhance.contains(Enhance.ApplyStandardizer) && dt.isFloatingPoint();
     }
 
     @Override


### PR DESCRIPTION
changed and cleaned up the logic of the EnhancementProvider a bit
- each provider now needs to know it's own attribute name
- the logic of whether to apply an enhancement is made by VariableDS
This is meant to partition things such that it's a bit safer to execute runtime-loaded Enhancements.

I'm also looking into making a Vectorize Enhancement, as mentioned in this [issue](https://github.com/Unidata/tds/issues/527), since that's something we want at CDIP as well. If/when I get it working I'll add it as an example in the docs, similar to the lighting IOSP.