### PR TITLE
Fix failing S3 test

### DIFF
--- a/cdm/s3/src/test/java/thredds/filesystem/s3/TestControllerS3.java
+++ b/cdm/s3/src/test/java/thredds/filesystem/s3/TestControllerS3.java
@@ -106,7 +106,7 @@ public class TestControllerS3 {
   public void testGetInventoryTopBucketDelimiterAws() throws URISyntaxException {
     CdmS3Uri uri = new CdmS3Uri(S3TestsCommon.TOP_LEVEL_AWS_BUCKET + DELIMITER_FRAGMENT);
     // contains a single object at "/" (/index.html)
-    checkInventoryTopCountAtMost(uri, 3);
+    checkInventoryTopCountAtMost(uri, 4);
   }
 
   @Test


### PR DESCRIPTION
A new version of the Beginners_Guide pdf was uploaded to the top level of the GOES-16 bucket, so we need to update the expected number of objects found using a delimiter of '/'.
