### PR TITLE
Upgrade github tests to thredds-test-action v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         # test against latest 8, 11, 17 of zulu and temurin java
-        java-version: [ 8, 11, 17]
-        java-vendor: [ 'zulu', 'temurin' ]
+        java-version: [8, 11, 17]
+        java-vendor: ['zulu', 'temurin', 'corretto']
     steps:
       - uses: actions/checkout@v4
       - name: Build and test with Gradle (${{ matrix.java-vendor }} ${{ matrix.java-version }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         # test against latest 8, 11 of zulu and temurin java
-        java-version: [ 8, 11]
+        java-version: [ 8, 11, 17, 21]
         java-vendor: [ 'zulu', 'temurin' ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against latest 8, 11 of zulu and temurin java
-        java-version: [ 8, 11, 17, 21]
+        # test against latest 8, 11, 17 of zulu and temurin java
+        java-version: [ 8, 11, 17]
         java-vendor: [ 'zulu', 'temurin' ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build and test with Gradle (${{ matrix.java-vendor }} ${{ matrix.java-version }})
-        uses: Unidata/thredds-test-action@v2
+        uses: Unidata/thredds-test-action@v3
         with:
           java-vendor: ${{ matrix.java-vendor }}
           java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
## Description of Changes

Use `Unidata/thredds-test-action` v3 for running the test matrix on GitHub.
