### PR TITLE
Using category list to make sure only unique categories are included

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIosp2.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIosp2.java
@@ -79,11 +79,13 @@ public class BufrIosp2 extends AbstractIOServiceProvider {
     protoMessages = new ArrayList<>();
     protoMessages.add(protoMessage);
     int category = protoMessage.ids.getCategory();
+    List<Integer> categories = new ArrayList<>();
+    categories.add(category);
     while (scanner.hasNext()) {
       Message message = scanner.next();
-      if (message.ids.getCategory() != category) {
+      if (!categories.contains(message.ids.getCategory())) {
         protoMessages.add(message);
-        category = message.ids.getCategory();
+        categories.add(message.ids.getCategory());
       }
     }
 
@@ -158,11 +160,13 @@ public class BufrIosp2 extends AbstractIOServiceProvider {
     protoMessages = new ArrayList<>();
     protoMessages.add(protoMessage);
     int category = protoMessage.ids.getCategory();
+    List<Integer> categories = new ArrayList<>();
+    categories.add(category);
     while (scanner.hasNext()) {
       Message message = scanner.next();
-      if (message.ids.getCategory() != category) {
+      if (!categories.contains(message.ids.getCategory())) {
         protoMessages.add(message);
-        category = message.ids.getCategory();
+        categories.add(message.ids.getCategory());
       }
     }
 


### PR DESCRIPTION
## Description of Changes

The commit: https://github.com/Unidata/netcdf-java/commit/c54869cd29c87c01c0e08427986c8f68b59a2f39#diff-87d57326a1634222cff4aaa832d13fd2b0c8578b6965291a81e514c100d6e11b try to read all messages when the bufr data file contains multiple message categories. But the bug exists when the messages were not arranged in file category by category. So I use category list to make sure only unique categories are included in the `protoMessages` list to solve the bug.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
Link to this issue: https://github.com/Unidata/netcdf-java/issues/1418
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
