### PR TITLE
Remove duplication of global metadata creation for BUFR

### DIFF
--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/BufrIospBuilder.java
@@ -42,26 +42,11 @@ class BufrIospBuilder {
 
     // global Attributes
     AttributeContainerMutable atts = root.getAttributeContainer();
-    atts.addAttribute(CDM.HISTORY, "Read using CDM BufrIosp2");
+    addCommonGlobalAttributes(atts, proto, location);
+
     if (bufrConfig.getFeatureType() != null) {
       atts.addAttribute(CF.FEATURE_TYPE, bufrConfig.getFeatureType().toString());
     }
-    atts.addAttribute("location", location);
-
-    atts.addAttribute("BUFR:categoryName", proto.getLookup().getCategoryName());
-    atts.addAttribute("BUFR:subCategoryName", proto.getLookup().getSubCategoryName());
-    atts.addAttribute("BUFR:centerName", proto.getLookup().getCenterName());
-    atts.addAttribute("BUFR:category", proto.ids.getCategory());
-    atts.addAttribute("BUFR:subCategory", proto.ids.getSubCategory());
-    atts.addAttribute("BUFR:localSubCategory", proto.ids.getLocalSubCategory());
-    atts.addAttribute(BufrIosp2.centerId, proto.ids.getCenterId());
-    atts.addAttribute("BUFR:subCenter", proto.ids.getSubCenterId());
-    atts.addAttribute("BUFR:table", proto.ids.getMasterTableId());
-    atts.addAttribute("BUFR:tableVersion", proto.ids.getMasterTableVersion());
-    atts.addAttribute("BUFR:localTableVersion", proto.ids.getLocalTableVersion());
-    atts.addAttribute("Conventions", "BUFR/CDM");
-    atts.addAttribute("BUFR:edition", proto.is.getBufrEdition());
-
 
     String header = proto.getHeader();
     if (header != null && !header.isEmpty()) {
@@ -80,12 +65,30 @@ class BufrIospBuilder {
 
     // global Attributes
     AttributeContainerMutable atts = root.getAttributeContainer();
+    addCommonGlobalAttributes(atts, proto, location);
+
+    for (BufrConfig bufrConfig : bufrConfigs) {
+      String varName = proto.getLookup().getCategoryName(bufrConfig.getMessage().ids.getCategory());
+      Sequence.Builder rs = Sequence.builder().setName(varName);
+      this.rootGroup.addVariable(rs);
+      makeObsRecord(bufrConfig, rs);
+      String coordS = coordinates.toString();
+      if (!coordS.isEmpty()) {
+        rs.addAttribute(new Attribute("coordinates", coordS));
+      }
+    }
+  }
+
+  private void addCommonGlobalAttributes(AttributeContainerMutable atts, Message proto, String location) {
     atts.addAttribute(CDM.HISTORY, "Read using CDM BufrIosp2");
     atts.addAttribute("location", location);
 
     atts.addAttribute("BUFR:categoryName", proto.getLookup().getCategoryName());
     atts.addAttribute("BUFR:subCategoryName", proto.getLookup().getSubCategoryName());
     atts.addAttribute("BUFR:centerName", proto.getLookup().getCenterName());
+    atts.addAttribute("BUFR:category", proto.ids.getCategory());
+    atts.addAttribute("BUFR:subCategory", proto.ids.getSubCategory());
+    atts.addAttribute("BUFR:localSubCategory", proto.ids.getLocalSubCategory());
     atts.addAttribute(BufrIosp2.centerId, proto.ids.getCenterId());
     atts.addAttribute("BUFR:subCenter", proto.ids.getSubCenterId());
     atts.addAttribute("BUFR:table", proto.ids.getMasterTableId());
@@ -97,17 +100,6 @@ class BufrIospBuilder {
     String header = proto.getHeader();
     if (header != null && !header.isEmpty()) {
       atts.addAttribute("WMO Header", header);
-    }
-
-    for (BufrConfig bufrConfig : bufrConfigs) {
-      String varName = proto.getLookup().getCategoryName(bufrConfig.getMessage().ids.getCategory());
-      Sequence.Builder rs = Sequence.builder().setName(varName);
-      this.rootGroup.addVariable(rs);
-      makeObsRecord(bufrConfig, rs);
-      String coordS = coordinates.toString();
-      if (!coordS.isEmpty()) {
-        rs.addAttribute(new Attribute("coordinates", coordS));
-      }
     }
   }
 

--- a/cdm/gcdm/src/test/java/ucar/gcdm/TestGcdmNetcdfFile.java
+++ b/cdm/gcdm/src/test/java/ucar/gcdm/TestGcdmNetcdfFile.java
@@ -36,7 +36,7 @@ public class TestGcdmNetcdfFile {
           pathname -> pathname.getName().endsWith("nc") && !pathname.getName().startsWith("test_vlen3")
               && !pathname.getName().startsWith("test_vlen4") && !pathname.getName().startsWith("test_vlen5")
               && !pathname.getName().startsWith("test_vlen9") && !pathname.getName().startsWith("test_vlen10");
-      String skipStructuresWithVlens2 = "vlen/IntTimSciSamp.nc vlen/cdm_sea_soundings.nc4";
+      String skipStructuresWithVlens2 = "vlen/IntTimSciSamp.nc vlen/cdm_sea_soundings.nc4 2024060100_GTS_sn.0001.bufr";
 
       TestDir.actOnAllParameterized("../../dap4/src/test/data/resources/nctestfiles/", skipStructuresWithVlens, result,
           false);


### PR DESCRIPTION
## Description of Changes

When reading BUFR, we should create most of the global metadata in one location in
the code to prevent differences between the two `BufrIospBuilder` constructors. Fixes Unidata/netcdf-java#1422

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
