### PR TITLE
Do not try to compress variable-sized varaibles

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/write/Nc4ChunkingStrategy.java
+++ b/cdm/core/src/main/java/ucar/nc2/write/Nc4ChunkingStrategy.java
@@ -5,7 +5,9 @@
 
 package ucar.nc2.write;
 
+import ucar.ma2.DataType;
 import ucar.nc2.Attribute;
+import ucar.nc2.Structure;
 import ucar.nc2.Variable;
 import ucar.nc2.constants.CDM;
 import javax.annotation.concurrent.Immutable;
@@ -52,7 +54,20 @@ public abstract class Nc4ChunkingStrategy implements Nc4Chunking {
 
   @Override
   public int getDeflateLevel(Variable v) {
-    return deflateLevel;
+    return isCompressible(v) ? deflateLevel : 0;
+  }
+
+  // compression should not be applied to variable-sized variables
+  // see Unidata/netcdf-java#1420
+  private boolean isCompressible(Variable v) {
+    if (v.getDataType().equals(DataType.STRING) || v.isVariableLength())
+      return false;
+
+    if (v.getDataType().equals(DataType.STRUCTURE)) {
+      Structure s = (Structure) v;
+      return s.getVariables().stream().allMatch(this::isCompressible);
+    }
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Fixes Unidata/netcdf-java#1420

## Description of Changes

Starting with netCDF-C 4.9.0, trying to apply a filter to a variable-sized variable results in an error (previous behavior was to ignore the filter). See https://github.com/Unidata/netcdf-c/pull/2716 for details. This PR does changes `Nc4ChunkingStrategy.java` to skip setting a deflate level if the variable is:

1. of data type String
2. variable length
3. a structure containing a variable that is 1. or 2.

Fixes Unidata/netcdf-java#1420

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
