### PR TITLE
Add native libaec libraries to ncIdv jar

### DIFF
--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -46,6 +46,7 @@ dependencies {
   ncIdv project(':visad:cdm-vis5d')
   ncIdv project(':httpservices')
   ncIdv project(':legacy')
+  ncIdv project(':native-compression:libaec-native')
 
   netcdfAll enforcedPlatform(project(':netcdf-java-platform'))
   netcdfAll project(':cdm:cdm-core')


### PR DESCRIPTION
## Description of Changes

Add native libaec libraries to ncIdv jar to enable the IDV to read CCSDS compressed GRIB messages.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
