### PR TITLE
Enable uduints based time coordinates on scan aggregations

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggDatasetOuter.java
@@ -1,4 +1,8 @@
-/* Copyright Unidata */
+/*
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
+ */
+
 package ucar.nc2.internal.ncml;
 
 import java.io.IOException;
@@ -11,6 +15,7 @@ import java.util.StringTokenizer;
 import javax.annotation.Nullable;
 import thredds.inventory.MFile;
 import ucar.ma2.Array;
+import ucar.ma2.DataType;
 import ucar.ma2.InvalidRangeException;
 import ucar.ma2.Range;
 import ucar.ma2.Section;
@@ -32,7 +37,8 @@ class AggDatasetOuter extends AggDataset {
   @Nullable
   final String coordValue; // if theres a coordValue on the netcdf element - may be multiple, blank separated
   final Date coordValueDate; // if its a date
-  final boolean isStringValued; // if coordinat is a String
+  final DataType coordDataType; // coordinate data type
+  final String coordUdunit; // coordinate udunit string, if numeric
 
   // not final because of deffered read
   int ncoord; // number of coordinates in outer dimension
@@ -68,18 +74,18 @@ class AggDatasetOuter extends AggDataset {
       }
     }
 
-    boolean isString = false;
+    DataType aggCoordDataType = DataType.DOUBLE;
     if ((aggregationOuter.type == Type.joinNew) || (aggregationOuter.type == Type.joinExistingOne)
         || (aggregationOuter.type == Type.forecastModelRunCollection)) {
       if (coordValueS == null) {
         coordValueS = extractCoordNameFromFilename(this.getLocation());
-        isString = true;
+        aggCoordDataType = DataType.STRING;
       } else {
         // we just need to know if its string valued
         try {
           Double.parseDouble(coordValueS);
         } catch (NumberFormatException e) {
-          isString = true;
+          aggCoordDataType = DataType.STRING;
         }
       }
     }
@@ -90,8 +96,10 @@ class AggDatasetOuter extends AggDataset {
       this.ncoord = stoker.countTokens();
     }
 
-    this.isStringValued = isString; // LOOK ??
+    coordDataType = aggCoordDataType;
     this.coordValue = coordValueS;
+    // not dealing with scan
+    this.coordUdunit = "";
     this.coordValueDate = null; // LOOK why isnt this set?
   }
 
@@ -115,13 +123,21 @@ class AggDatasetOuter extends AggDataset {
     // default is that the coordinates are just the filenames
     // this can be overriden by an explicit declaration, which will replace the variable after ther agg is processed in
     // NcMLReader
+    DataType aggCoordDataType = DataType.DOUBLE;
+    String coordUdunit = "";
     if ((aggregationOuter.type == Type.joinNew) || (aggregationOuter.type == Type.joinExistingOne)
         || (aggregationOuter.type == Type.forecastModelRunCollection)) {
       coordValueS = extractCoordNameFromFilename(this.getLocation());
-      this.isStringValued = true;
-    } else {
-      this.isStringValued = false; // LOOK ??
+      if (aggregationOuter.numericTimeSettings != null) {
+        String[] settings = aggregationOuter.numericTimeSettings.split(" ", 2);
+        aggCoordDataType = DataType.getType(settings[0]);
+        coordUdunit = settings[1];
+      } else {
+        aggCoordDataType = DataType.STRING;
+      }
     }
+    this.coordDataType = aggCoordDataType;
+    this.coordUdunit = coordUdunit;
 
     if (null != aggregationOuter.dateFormatMark) {
       String filename = cd.getName(); // LOOK operates on name, not path

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/Aggregation.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/Aggregation.java
@@ -1,6 +1,8 @@
 /*
- * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
  */
+
 package ucar.nc2.internal.ncml;
 
 import org.jdom2.Element;
@@ -95,6 +97,7 @@ public abstract class Aggregation implements ucar.nc2.ncml.AggregationIF {
 
   // experimental
   protected String dateFormatMark;
+  protected String numericTimeSettings;
   // protected EnumSet<NetcdfDataset.Enhance> enhance = null; // default no enhancement
   protected boolean isDate;
   protected DateFormatter dateFormatter = new DateFormatter();
@@ -153,13 +156,17 @@ public abstract class Aggregation implements ucar.nc2.ncml.AggregationIF {
    * @param subdirs equals "false" if should not descend into subdirectories
    * @param olderThan files must be older than this time (now - lastModified >= olderThan); must be a time unit, may ne
    *        bull
+   * @param numericTimeSettings numeric time settings (data type and udunits compatible string,
+   *        e.g. "float seconds since 1985-10-18T12:31:00", may be null)
    */
   public void addDatasetScan(Element crawlableDatasetElement, String dirName, String suffix, String regexpPatternString,
-      String dateFormatMark, Set<NetcdfDataset.Enhance> enhanceMode, String subdirs, String olderThan) {
+      String dateFormatMark, Set<NetcdfDataset.Enhance> enhanceMode, String subdirs, String olderThan,
+      String numericTimeSettings) {
 
     datasetManager.addDirectoryScan(dirName, suffix, regexpPatternString, subdirs, olderThan, enhanceMode);
 
     this.dateFormatMark = dateFormatMark;
+    this.numericTimeSettings = numericTimeSettings;
     if (dateFormatMark != null) {
       isDate = true;
       if (type == Type.joinExisting)

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationExisting.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationExisting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -76,7 +76,13 @@ class AggregationExisting extends AggregationOuter {
       }
 
     } else {
-      coordCacheVar = new CoordValueVar(dimName, DataType.STRING, "");
+      DataType coordDataType = DataType.STRING;
+      String coordUnits = "";
+      if (typicalDataset instanceof AggDatasetOuter) {
+        coordDataType = ((AggDatasetOuter) typicalDataset).coordDataType;
+        coordUnits = ((AggDatasetOuter) typicalDataset).coordUdunit;
+      }
+      coordCacheVar = new CoordValueVar(dimName, coordDataType, coordUnits);
     }
     if (coordCacheVar != null) {
       cacheList.add(coordCacheVar); // coordinate variable is always cached
@@ -134,8 +140,14 @@ class AggregationExisting extends AggregationOuter {
     if (type == Type.joinExistingOne) {
       // replace aggregation coordinate variable
       joinAggCoordOpt.ifPresent(joinAgg -> rootGroup.removeVariable(joinAgg.shortName));
+      DataType coordDataType = DataType.STRING;
+      String coordUnits = "";
+      if (typicalDataset instanceof AggDatasetOuter) {
+        coordDataType = ((AggDatasetOuter) typicalDataset).coordDataType;
+        coordUnits = ((AggDatasetOuter) typicalDataset).coordUdunit;
+      }
 
-      joinAggCoord = VariableDS.builder().setName(dimName).setDataType(DataType.STRING).setParentGroupBuilder(rootGroup)
+      joinAggCoord = VariableDS.builder().setName(dimName).setDataType(coordDataType).setParentGroupBuilder(rootGroup)
           .setDimensionsByName(dimName);
       joinAggCoord.setProxyReader(this);
       rootGroup.addVariable(joinAggCoord);
@@ -144,6 +156,9 @@ class AggregationExisting extends AggregationOuter {
       joinAggCoord.addAttribute(new Attribute(_Coordinate.AxisType, "Time"));
       joinAggCoord.addAttribute(new Attribute(CDM.LONG_NAME, "time coordinate"));
       joinAggCoord.addAttribute(new Attribute(CF.STANDARD_NAME, "time"));
+      if (coordUnits != null && !coordUnits.equals("")) {
+        joinAggCoord.addAttribute(new Attribute(CF.UNITS, coordUnits));
+      }
     }
 
     if (timeUnitsChange && joinAggCoord != null) {

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationNew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -149,7 +149,7 @@ public class AggregationNew extends AggregationOuter {
   private DataType getCoordinateType() {
     List<AggDataset> nestedDatasets = getDatasets();
     AggDatasetOuter first = (AggDatasetOuter) nestedDatasets.get(0);
-    return first.isStringValued ? DataType.STRING : DataType.DOUBLE;
+    return first.coordDataType;
   }
 
 }

--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.internal.ncml;
 
 import java.io.FileNotFoundException;
@@ -1526,6 +1527,7 @@ public class NcmlReader {
       String olderS = scanElem.getAttributeValue("olderThan");
 
       String dateFormatMark = scanElem.getAttributeValue("dateFormatMark");
+      String numericTimeSettings = scanElem.getAttributeValue("numericTimeSettings");
       Set<NetcdfDataset.Enhance> enhanceMode = NetcdfDataset.parseEnhanceMode(scanElem.getAttributeValue("enhance"));
 
       // possible relative location
@@ -1534,7 +1536,7 @@ public class NcmlReader {
       // can embed a full-blown crawlableDatasetImpl element
       Element cdElement = scanElem.getChild("crawlableDatasetImpl", ncNS); // ok if null
       agg.addDatasetScan(cdElement, dirLocation, suffix, regexpPatternString, dateFormatMark, enhanceMode, subdirs,
-          olderS);
+          olderS, numericTimeSettings);
 
       if ((cancelTask != null) && cancelTask.isCancel()) {
         return agg;

--- a/cdm/core/src/main/java/ucar/nc2/ncml/Aggregation.java
+++ b/cdm/core/src/main/java/ucar/nc2/ncml/Aggregation.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE.txt for license information.
  */
+
 package ucar.nc2.ncml;
 
 import org.jdom2.Element;
@@ -153,6 +154,7 @@ public abstract class Aggregation implements AggregationIF {
 
   // experimental
   protected String dateFormatMark;
+  protected String numericTimeSettings;
   // protected EnumSet<NetcdfDataset.Enhance> enhance = null; // default no enhancement
   protected boolean isDate;
   protected DateFormatter dateFormatter = new DateFormatter();
@@ -199,6 +201,7 @@ public abstract class Aggregation implements AggregationIF {
     explicitDatasets.add(nested);
   }
 
+
   /**
    * Add a dataset scan
    *
@@ -214,10 +217,33 @@ public abstract class Aggregation implements AggregationIF {
    */
   public void addDatasetScan(Element crawlableDatasetElement, String dirName, String suffix, String regexpPatternString,
       String dateFormatMark, Set<NetcdfDataset.Enhance> enhanceMode, String subdirs, String olderThan) {
+    addDatasetScan(crawlableDatasetElement, dirName, suffix, regexpPatternString, dateFormatMark, enhanceMode, subdirs,
+        olderThan, null);
+  }
+
+  /**
+   * Add a dataset scan
+   *
+   * @param crawlableDatasetElement defines a CrawlableDataset, or null
+   * @param dirName scan this directory
+   * @param suffix filter on this suffix (may be null)
+   * @param regexpPatternString include if full name matches this regular expression (may be null)
+   * @param dateFormatMark create dates from the filename (may be null)
+   * @param enhanceMode how should files be enhanced
+   * @param subdirs equals "false" if should not descend into subdirectories
+   * @param olderThan files must be older than this time (now - lastModified >= olderThan); must be a time unit, may ne
+   *        bull
+   * @param numericTimeSettings numeric time settings (data type and udunits compatible string,
+   *        e.g. "float seconds since 1985-10-18T12:31:00", may be null)
+   */
+  public void addDatasetScan(Element crawlableDatasetElement, String dirName, String suffix, String regexpPatternString,
+      String dateFormatMark, Set<NetcdfDataset.Enhance> enhanceMode, String subdirs, String olderThan,
+      String numericTimeSettings) {
 
     datasetManager.addDirectoryScan(dirName, suffix, regexpPatternString, subdirs, olderThan, enhanceMode);
 
     this.dateFormatMark = dateFormatMark;
+    this.numericTimeSettings = numericTimeSettings;
     if (dateFormatMark != null) {
       isDate = true;
       if (type == Type.joinExisting)

--- a/cdm/core/src/main/java/ucar/nc2/ncml/AggregationExisting.java
+++ b/cdm/core/src/main/java/ucar/nc2/ncml/AggregationExisting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -71,7 +71,13 @@ public class AggregationExisting extends AggregationOuterDimension {
       }
 
     } else {
-      coordCacheVar = new CoordValueVar(dimName, DataType.STRING, "");
+      DataType coordDataType = DataType.STRING;
+      String coordUnits = null;
+      if (typicalDataset instanceof AggregationOuterDimension.DatasetOuterDimension) {
+        coordDataType = ((AggregationOuterDimension.DatasetOuterDimension) typicalDataset).coordDataType;
+        coordUnits = ((AggregationOuterDimension.DatasetOuterDimension) typicalDataset).coordUdunit;
+      }
+      coordCacheVar = new CoordValueVar(dimName, coordDataType, coordUnits);
     }
     if (coordCacheVar != null) {
       cacheList.add(coordCacheVar); // coordinate variable is always cached
@@ -128,8 +134,14 @@ public class AggregationExisting extends AggregationOuterDimension {
         // replace aggregation coordinate variable
         ncDataset.getRootGroup().removeVariable(joinAggCoord.getShortName());
       }
-
-      joinAggCoord = new VariableDS(ncDataset, null, null, dimName, DataType.STRING, dimName, null, null);
+      DataType coordDataType = DataType.STRING;
+      String coordUnits = null;
+      if (typicalDataset instanceof AggregationOuterDimension.DatasetOuterDimension) {
+        coordDataType = ((AggregationOuterDimension.DatasetOuterDimension) typicalDataset).coordDataType;
+        coordUnits = ((AggregationOuterDimension.DatasetOuterDimension) typicalDataset).coordUdunit;
+      }
+      coordCacheVar = new CoordValueVar(dimName, coordDataType, coordUnits);
+      joinAggCoord = new VariableDS(ncDataset, null, null, dimName, coordDataType, dimName, coordUnits, null);
       joinAggCoord.setProxyReader(this);
       ncDataset.getRootGroup().addVariable(joinAggCoord);
       aggVars.add(joinAggCoord);
@@ -137,6 +149,9 @@ public class AggregationExisting extends AggregationOuterDimension {
       joinAggCoord.addAttribute(new ucar.nc2.Attribute(_Coordinate.AxisType, "Time"));
       joinAggCoord.addAttribute(new Attribute(CDM.LONG_NAME, "time coordinate"));
       joinAggCoord.addAttribute(new ucar.nc2.Attribute(CF.STANDARD_NAME, "time"));
+      if (coordUnits != null && !coordUnits.equals("")) {
+        joinAggCoord.addAttribute(new Attribute(CF.UNITS, coordUnits));
+      }
     }
 
     if (timeUnitsChange && joinAggCoord != null) {

--- a/cdm/core/src/main/java/ucar/nc2/ncml/AggregationNew.java
+++ b/cdm/core/src/main/java/ucar/nc2/ncml/AggregationNew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -134,7 +134,7 @@ public class AggregationNew extends AggregationOuterDimension {
   private DataType getCoordinateType() {
     List<Dataset> nestedDatasets = getDatasets();
     DatasetOuterDimension first = (DatasetOuterDimension) nestedDatasets.get(0);
-    return first.isStringValued ? DataType.STRING : DataType.DOUBLE;
+    return first.coordDataType;
   }
 
 }

--- a/cdm/core/src/main/java/ucar/nc2/ncml/AggregationOuterDimension.java
+++ b/cdm/core/src/main/java/ucar/nc2/ncml/AggregationOuterDimension.java
@@ -1,6 +1,8 @@
 /*
- * Copyright (c) 1998-2020 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
  */
+
 package ucar.nc2.ncml;
 
 import java.io.IOException;
@@ -554,7 +556,8 @@ public abstract class AggregationOuterDimension extends Aggregation implements P
     protected int ncoord; // number of coordinates in outer dimension for this dataset
     protected String coordValue; // if theres a coordValue on the netcdf element - may be multiple, blank separated
     protected Date coordValueDate; // if its a date
-    protected boolean isStringValued;
+    final DataType coordDataType; // coordinate data type
+    final String coordUdunit; // coordinate udunit string, if numeric
     private int aggStart, aggEnd; // index in aggregated dataset; aggStart <= i < aggEnd
 
     /**
@@ -586,19 +589,22 @@ public abstract class AggregationOuterDimension extends Aggregation implements P
         }
       }
 
+      DataType aggCoordDataType = DataType.DOUBLE;
+      String aggUdunit = null;
       if ((type == Type.joinNew) || (type == Type.joinExistingOne) || (type == Type.forecastModelRunCollection)) {
         if (coordValueS == null) {
           this.coordValue = extractCoordNameFromFilename(this.getLocation());
-          this.isStringValued = true;
+          aggCoordDataType = DataType.STRING;
         } else {
           try {
             Double.parseDouble(coordValueS);
           } catch (NumberFormatException e) {
-            this.isStringValued = true;
+            aggCoordDataType = DataType.STRING;
           }
         }
       }
-
+      this.coordDataType = aggCoordDataType;
+      this.coordUdunit = null;
       // allow coordValue attribute on JOIN_EXISTING, may be multiple values separated by blanks or commas
       if ((type == Type.joinExisting) && (coordValueS != null)) {
         StringTokenizer stoker = new StringTokenizer(coordValueS, " ,");
@@ -625,10 +631,19 @@ public abstract class AggregationOuterDimension extends Aggregation implements P
       // default is that the coordinates are just the filenames
       // this can be overriden by an explicit declaration, which will replace the variable afte ther agg is processed in
       // NcMLReader
+      DataType aggCoordDataType = DataType.DOUBLE;
+      String coordUdunit = null;
       if ((type == Type.joinNew) || (type == Type.joinExistingOne) || (type == Type.forecastModelRunCollection)) {
-        this.coordValue = extractCoordNameFromFilename(this.getLocation());
-        this.isStringValued = true;
+        if (numericTimeSettings != null) {
+          String[] settings = numericTimeSettings.split(" ", 2);
+          aggCoordDataType = DataType.getType(settings[0]);
+          coordUdunit = settings[1];
+        } else {
+          aggCoordDataType = DataType.STRING;
+        }
       }
+      this.coordDataType = aggCoordDataType;
+      this.coordUdunit = coordUdunit;
 
       if (null != dateFormatMark) {
         String filename = cd.getName(); // LOOK operates on name, not path

--- a/cdm/core/src/main/java/ucar/nc2/ncml/NcMLReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/ncml/NcMLReader.java
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.nc2.ncml;
 
 import java.io.FileNotFoundException;
@@ -1613,6 +1614,7 @@ public class NcMLReader {
       String olderS = scanElem.getAttributeValue("olderThan");
 
       String dateFormatMark = scanElem.getAttributeValue("dateFormatMark");
+      String numericTimeSettings = scanElem.getAttributeValue("numericTimeSettings");
       Set<NetcdfDataset.Enhance> enhanceMode = NetcdfDataset.parseEnhanceMode(scanElem.getAttributeValue("enhance"));
 
       // possible relative location
@@ -1621,7 +1623,7 @@ public class NcMLReader {
       // can embed a full-blown crawlableDatasetImpl element
       Element cdElement = scanElem.getChild("crawlableDatasetImpl", ncNS); // ok if null
       agg.addDatasetScan(cdElement, dirLocation, suffix, regexpPatternString, dateFormatMark, enhanceMode, subdirs,
-          olderS);
+          olderS, numericTimeSettings);
 
       if ((cancelTask != null) && cancelTask.isCancel())
         return agg;

--- a/cdm/core/src/main/resources/resources/nj22/schemas/ncml-2.2.xsd
+++ b/cdm/core/src/main/resources/resources/nj22/schemas/ncml-2.2.xsd
@@ -3,7 +3,7 @@
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
             elementFormDefault="qualified"
-            version="2.2.0">
+            version="2.2.1">
   
   <!-- XML encoding of Netcdf container object -->
   <xsd:element name="netcdf">
@@ -232,6 +232,7 @@
 
             <xsd:attribute name="dateFormatMark" type="xsd:string"/>
             <xsd:attribute name="enhance" type="xsd:boolean"/>
+            <xsd:attribute name="numericTimeSettings" type="xsd:string"/>
           </xsd:complexType>
         </xsd:element>
 

--- a/cdm/core/src/main/resources/resources/nj22/schemas/ncml-2.2.xsd
+++ b/cdm/core/src/main/resources/resources/nj22/schemas/ncml-2.2.xsd
@@ -2,7 +2,8 @@
 <xsd:schema targetNamespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
-            elementFormDefault="qualified">
+            elementFormDefault="qualified"
+            version="2.2.0">
   
   <!-- XML encoding of Netcdf container object -->
   <xsd:element name="netcdf">

--- a/cdm/core/src/test/data/ncml/aggExistingOneNumericTime.xml
+++ b/cdm/core/src/test/data/ncml/aggExistingOneNumericTime.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinExisting" recheckEvery="4 sec">
+    <scan dateFormatMark="CG#yyyyDDD_HHmmss"
+      location="nc/cg/"
+      suffix=".nc"
+      subdirs="false"
+      numericTimeSettings="int seconds since 2006-06-07T11:00:00Z"/>
+  </aggregation>
+</netcdf>

--- a/cdm/core/src/test/java/ucar/nc2/ncml/TestAggScanNumericTime.java
+++ b/cdm/core/src/test/java/ucar/nc2/ncml/TestAggScanNumericTime.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.ncml;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import ucar.ma2.Array;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.Attribute;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.time.Calendar;
+import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.CalendarDateFormatter;
+import ucar.nc2.time.CalendarDateUnit;
+
+
+public class TestAggScanNumericTime {
+
+  @Test
+  public void testNumericTime() throws IOException, InvalidRangeException, InterruptedException {
+    String aggStringTime = "file:./" + TestNcmlRead.topDir + "aggExistingOne.xml";
+    String aggNumericTime = "file:./" + TestNcmlRead.topDir + "aggExistingOneNumericTime.xml";
+
+    try (NetcdfDataset ncStr = NetcdfDataset.openDataset(aggStringTime);
+        NetcdfDataset ncNum = NetcdfDataset.openDataset(aggNumericTime)) {
+      compareTimes(ncStr, ncNum);
+    }
+  }
+
+  @Test
+  public void testNumericTimeWithBuilders() throws IOException, InvalidRangeException, InterruptedException {
+    String aggStringTime = "file:./" + TestNcmlRead.topDir + "aggExistingOne.xml";
+    String aggNumericTime = "file:./" + TestNcmlRead.topDir + "aggExistingOneNumericTime.xml";
+
+    try (NetcdfDataset ncStr = NetcdfDatasets.openDataset(aggStringTime);
+        NetcdfDataset ncNum = NetcdfDatasets.openDataset(aggNumericTime)) {
+      compareTimes(ncStr, ncNum);
+    }
+  }
+
+  void compareTimes(NetcdfDataset ncStr, NetcdfDataset ncNum) throws IOException {
+    Variable isoTimeVar = ncStr.findVariable("time");
+    assertThat(isoTimeVar != null).isTrue();
+    Variable numericTimeVar = ncNum.findVariable("time");
+    assertThat(numericTimeVar != null).isTrue();
+    Array isoTime = isoTimeVar.read();
+    Array numericTime = numericTimeVar.read();
+    Attribute numericTimeUnitAttr = numericTimeVar.findAttribute("units");
+    assertThat(numericTimeUnitAttr).isNotNull();
+    String numericTimeUnit = numericTimeUnitAttr.getStringValue();
+    assertThat(numericTimeUnit).isNotEmpty();
+    assertThat(numericTimeVar.getShape()).isEqualTo(isoTimeVar.getShape());
+    CalendarDateUnit calDateUnit = CalendarDateUnit.of(Calendar.getDefault().name(), numericTimeUnit);
+    for (int i = 0; i < numericTime.getSize(); i++) {
+      CalendarDate calDateFromIso =
+          CalendarDateFormatter.isoStringToCalendarDate(Calendar.getDefault(), isoTime.getObject(i).toString());
+      CalendarDate calDateFromNum = calDateUnit.makeCalendarDate(numericTime.getInt(i));
+      assertThat(calDateFromIso).isEqualTo(calDateFromNum);
+    }
+  }
+}

--- a/docs/src/site/pages/netcdfJava/NcmlCookbook.md
+++ b/docs/src/site/pages/netcdfJava/NcmlCookbook.md
@@ -190,7 +190,7 @@ See [Dataset URLs](dataset_urls.html) for more information on the location attri
 
 ### Assign coordinate values to unknown number of datasets.
 
-You dont have to know the number of files found in the scan, but they must be evenly spaced, and they must be in alphabetic order.
+You don't have to know the number of files found in the scan, but they must be evenly spaced, and they must be in alphabetic order.
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -207,7 +207,7 @@ You dont have to know the number of files found in the scan, but they must be ev
 </netcdf>
 ~~~
 
-### Scan directory, assign date coordinate value from filename.
+### Scan directory, assign date coordinate value (ISO time strings) from filename.
 
 The date coordinate must be derivable from the filename, using the dateFormatMark attribute.
 
@@ -217,6 +217,23 @@ The date coordinate must be derivable from the filename, using the dateFormatMar
   <aggregation dimName="time" type="joinNew">
     <variableAgg name="T"/>
     <scan location="/data/goes/" suffix=".gini" dateFormatMark="SUPER-NATIONAL_1km_SFC-T_#yyyyMMdd_HHmm" />
+  </aggregation>
+</netcdf> 
+~~~
+
+### Scan directory, assign date coordinate value (numeric, UDUNITS compatible) from filename.
+
+The date coordinate must be derivable from the filename, using the dateFormatMark attribute.
+The numericTimeSettings consists of a data type plus a UDUNITS time unit.
+These should be chosen carefully, as truncation can occur.
+
+~~~xml
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <aggregation dimName="time" type="joinNew">
+    <variableAgg name="T"/>
+    <scan location="/data/goes/" suffix=".gini" dateFormatMark="SUPER-NATIONAL_1km_SFC-T_#yyyyMMdd_HHmm"
+      numericTimeSettings="int minutes since 2015-06-07T12:00:00Z"/>
   </aggregation>
 </netcdf> 
 ~~~
@@ -254,30 +271,6 @@ Overrides existing coordinate variable, if any.
       coordValue="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30"/>
    <netcdf location="file:src/test/data/ncml/nc/feb.nc"
       coordValue="31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58"/>
- </aggregation>
-</netcdf>
-~~~
-
-### Scan directory, assign date coordinate value from filename.
-
-Each file must have exactly one time slice.
-The date coordinate must be derivable from the filename, using the `dateFormatMark` attribute.
-
-~~~xml
-<?xml version="1.0" encoding="UTF-8"?>
-<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
-  <aggregation dimName="time" type="joinExisting">
-    <scan dateFormatMark="CG#yyyyDDD_HHmmss" location="src/test/data/ncml/nc/cg/" suffix=".nc" subdirs="false" />
-  </aggregation>
-</netcdf>
-
-<?xml version="1.0" encoding="UTF-8"?>
-<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
- <aggregation dimName="time" type="joinExisting" timeUnitsChange="true"> 
-  <netcdf location="20060925_0600.nc" ncoords="2"/>
-  <netcdf location="20060925_1200.nc" ncoords="2"/>
-  <netcdf location="20060925_1800.nc" ncoords="2"/>
-  <netcdf location="20060926_0000.nc" ncoords="2"/>
  </aggregation>
 </netcdf>
 ~~~

--- a/docs/src/site/pages/netcdfJava/ncmlschema.md
+++ b/docs/src/site/pages/netcdfJava/ncmlschema.md
@@ -27,7 +27,8 @@ Aggregation specific elements are listed in <font color="darkred">red. The forec
 <xsd:schema targetNamespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
-  elementFormDefault="qualified">
+  elementFormDefault="qualified"
+  version="2.2.1">
 ~~~
 
 ### netcdf Element
@@ -446,30 +447,31 @@ The aggregation element allows multiple datasets to be combined into a single lo
 (11)   <xsd:attribute name="olderThan" type="xsd:string" />
 (12)   <xsd:attribute name="dateFormatMark" type="xsd:string" />
 (13)   <xsd:attribute name="enhance" type="xsd:string"/>
+(14)   <xsd:attribute name="numericTimeSettings" type="xsd:string"/>
       </xsd:complexType>
      </xsd:element>
 
-(14) <xsd:element name="scanFmrc" minOccurs="0" maxOccurs="unbounded">
+(15) <xsd:element name="scanFmrc" minOccurs="0" maxOccurs="unbounded">
       <xsd:complexType>
 (7)    <xsd:attribute name="location" type="xsd:string" 
 (8)    <xsd:attribute name="regExp" type="xsd:string" />use="required"/>
 (9)    <xsd:attribute name="suffix" type="xsd:string" />
 (10)   <xsd:attribute name="subdirs" type="xsd:boolean" default="true"/>
 (11)   <xsd:attribute name="olderThan" type="xsd:string" />
-(15)   <xsd:attribute name="runDateMatcher" type="xsd:string" />
+(16)   <xsd:attribute name="runDateMatcher" type="xsd:string" />
        <xsd:attribute name="forecastDateMatcher" type="xsd:string" />
        <xsd:attribute name="forecastOffsetMatcher" type="xsd:string" />
       </xsd:complexType>
      </xsd:element>
     </xsd:sequence>
     
-(16) <xsd:attribute name="type" type="AggregationType" use="required"/>
-(17) <xsd:attribute name="dimName" type="xsd:token" />
-(18) <xsd:attribute name="recheckEvery" type="xsd:string" />
-(19) <xsd:attribute name="timeUnitsChange" type="xsd:boolean"/>
+(17) <xsd:attribute name="type" type="AggregationType" use="required"/>
+(18) <xsd:attribute name="dimName" type="xsd:token" />
+(19) <xsd:attribute name="recheckEvery" type="xsd:string" />
+(20) <xsd:attribute name="timeUnitsChange" type="xsd:boolean"/>
 
       <!-- fmrc only  -->
-(20) <xsd:attribute name="fmrcDefinition" type="xsd:string" />
+(21) <xsd:attribute name="fmrcDefinition" type="xsd:string" />
 
 </xsd:complexType>
 </xsd:element>
@@ -482,7 +484,7 @@ The aggregation element allows multiple datasets to be combined into a single lo
  **promoteGlobalAttribute** element.
 4. Specify which variables should be cached (outer aggregation only) with a **cacheVariable** element.
 5. Nested **netcdf** datasets can be explicitly listed.
-6. Nested netcdf datasets can be implictly specified with a **scan** element.
+6. Nested netcdf datasets can be implicitly specified with a **scan** element.
 7. The scan directory **location**.
 8. If you specify a **regExp**, only files with whose full pathnames match the regular expression will be included.
 9. If you specify a **suffix**, only files with that ending will be included. A regExp attribute will override, that is, 
@@ -495,17 +497,18 @@ The aggregation element allows multiple datasets to be combined into a single lo
 13. You can optionally specify that the files should be opened in **enhance** mode (default is *None*).
  Generally you should do this if the ncml needs to operate on the dataset after the CoordSysBuilder has augmented it. 
  Otherwise, you should not enhance.
-14. A specialized **scanFmrc** element can be used for a forecastModelRunSingleCollection aggregation, where forecast 
+14. **numericTimeSettings** is used in conjunction with **dateFormatMark** to create a numeric, UDUNITS compatible aggregated time variable. See more below.
+15. A specialized **scanFmrc** element can be used for a forecastModelRunSingleCollection aggregation, where forecast 
  model run data is stored in multiple files, with one forecast time per file.
-15. For scanFmrc, the run date and the forecast date is extracted from the file pathname using a **runDateMatcher** and 
+16. For scanFmrc, the run date and the forecast date is extracted from the file pathname using a **runDateMatcher** and 
  either a **forecastDateMatcher** or a **forecastOffsetMatcher** attribute. See more below.
-16. You must specify an **aggregation type**.
-17. For all types except joinUnion, you must specify the **dimension name** to join.
-18. The **recheckEvery** allows you to rescan periodically to see if the set of files has changed.
-19. Only for *joinExisting* and *forecastModelRunCollection* types: if **timeUnitsChange** is set to true, the units of the 
+17. You must specify an **aggregation type**.
+18. For all types except joinUnion, you must specify the **dimension name** to join.
+19. The **recheckEvery** allows you to rescan periodically to see if the set of files has changed.
+20. Only for *joinExisting* and *forecastModelRunCollection* types: if **timeUnitsChange** is set to true, the units of the 
  joined coordinate variable may change, so examine them and do any appropriate conversion so that the aggregated 
  coordinate values have consistent units.
-20. Experimental, do not use.
+21. Experimental, do not use.
 
 ##### DateFormatMark
 A **dateFormatMark** is used on joinNew types to create date coordinate values out of the filename. It consists of a 
@@ -520,6 +523,16 @@ A **dateFormatMark** is used on joinNew types to create date coordinate values o
  A dateFormatMark can be used on a *joinExisting* type only if there is a single time in each file of the aggregation,
  in which case the coordinate values of the time can be created from the filename, instead of having to open each file
  and read it.
+
+##### numericTimeSettings
+**numericTimeSettings** can be combined with a **dateFormatMark** to produce a numeric, UDUNITS compatible time variable.
+**numericTimeSettings** consists of a data type plus a UDUNITS compatible time unit.
+Care must be taken when choosing these parameters to prevent truncation.
+ ```
+            Filename: SUPER-NATIONAL_1km_SFC-T_20051206_2300.gini 
+      DateFormatMark: SUPER-NATIONAL_1km_SFC-T_#yyyyMMdd_HHmm
+ numericTimeSettings: int minutes since 2005-12-01T00:00:00Z"
+ ```
 
 ##### ScanFmrc
 

--- a/docs/src/site/pages/netcdfJava_tutorial/ncml/NcmlAggregation.md
+++ b/docs/src/site/pages/netcdfJava_tutorial/ncml/NcmlAggregation.md
@@ -235,6 +235,7 @@ These are the ways that coordinate values may be assigned to a `joinExisting` co
   </aggregation>
   ~~~
 * If there is exactly one time slice in each file of the `joinExisting` aggregation, and you are using a scan element to dynamically scan the files in a directory, then you can use the `dateFormatMark` attribute to derive the date from the filename.
+  * You can combine `dateFormatMark` with `numericTimeSettings` to produce a time variable with numeric values and a UDUNITS compatible unit.
 * If you do not specify a coordinate variable, one must exist in each of the nested datasets, and the coordinate values will be read from it, just like any other aggregation variable.
   In this case, when the units of the aggregation coordinate change on the existing coordinate variables, you must add **timeUnitsChange=\"true\"** on the aggregation element:
   ~~~xml


### PR DESCRIPTION
## Description of Changes

Scan-based aggregations with a dateFormatMark produce a String time variable with ISO time string formatted values. This commit enables users to configure the aggregation to produce numeric, udunits based time variables. This improves compatibility with popular clients, such as xarray. Closes Unidata/netcdf-java#1327

As part of this PR, I've added a version attribute to the NcML xsd. As the xsd remains fully backwards compatiable, the namespace has not changed, but the point version of the scheme has been incremented from (previously undefined) v2.2 to v2.2.1.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
