### PR TITLE
Add windows-11-arm native compression support for libaec

### DIFF
--- a/.github/workflows/libaec.yml
+++ b/.github/workflows/libaec.yml
@@ -23,6 +23,7 @@ jobs:
           {os: ubuntu-24.04, c_compiler: gcc, lib: 'src/libaec.so', jna_id: 'linux-x86-64'},
           {os: ubuntu-24.04-arm, c_compiler: gcc, lib: 'src/libaec.so', jna_id: 'linux-aarch64'},
           {os: windows-2022, c_compiler: cl, lib: 'src\\Release\\aec.dll', jna_id: 'win32-x86-64'},
+          {os: windows-11-arm, c_compiler: cl, lib: 'src\\Release\\aec.dll', jna_id: 'win32-aarch64'},
           {os: macos-14, c_compiler: clang, lib: 'src/libaec.dylib', jna_id: 'darwin-aarch64'},
           {os: macos-13, c_compiler: clang, lib: 'src/libaec.dylib', jna_id: 'darwin-x86-64'},
         ]


### PR DESCRIPTION
## Description of Changes

Add windows-11-arm native compression support for libaec. Currently just an investigation, and this PR may not be a thing.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
