### PR TITLE
Disable root test report until move to jacoco-report-aggregation plugin

### DIFF
--- a/gradle/root/testing.gradle
+++ b/gradle/root/testing.gradle
@@ -124,6 +124,7 @@ gradle.projectsEvaluated {
     //finalizedBy jacocoRootReport
   }
 
+  /**
   task rootTestReport(type: TestReport, group: 'Reports') {
     description = 'Generates an aggregate test report'
     destinationDir = file("$buildDir/reports/allTests")
@@ -142,6 +143,8 @@ gradle.projectsEvaluated {
     // Wait until all Test tasks have run. This creates a task *ordering*, not a dependency.
     mustRunAfter subprojectTestTasks
   }
+  **/
 }
+
 
 apply plugin: 'base'  // Gives us the "clean" task for removing rootTestReport's output.


### PR DESCRIPTION
## Description of Changes

Disable root test report until move to jacoco-report-aggregation plugin

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
