### PR TITLE
Gradle fixes

### DIFF
--- a/docs/src/site/pages/netcdfJava_tutorial/overview/BuildingFromSource.md
+++ b/docs/src/site/pages/netcdfJava_tutorial/overview/BuildingFromSource.md
@@ -48,7 +48,7 @@ Next, use the Gradle wrapper to execute the assemble task:
 
 There will be various artifacts within the `<subproject>/build/libs/` subdirectories.
 For example, the `cdm-core.jar` file will be in `cdm/core/build/libs/`.
-The uber jars, such as `toolsUI.jar` and `netcdfAll.jar`, will be found in `build/libs/`.
+The uber jars, such as `toolsUI.jar` and `netcdfAll.jar`, will be found in `build/distributions/`.
 
 ## Publishing
 

--- a/gradle/any/protobuf.gradle
+++ b/gradle/any/protobuf.gradle
@@ -26,3 +26,5 @@ jacocoTestReport {
     }))
   }
 }
+
+sourceJar.dependsOn 'generateProto'

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -144,7 +144,7 @@ def createChecksumsTask = tasks.register('createChecksums') {
   group = 'publishing'
   description = 'Create .sha1, .sha256, and .md5 checksum files for the fatJars.'
   doLast {
-    String sourceDir = "${rootProject.getBuildDir()}/libs"
+    String sourceDir = "${rootProject.getBuildDir()}/distributions"
     def files = fileTree(dir: "${sourceDir}", include: '**/*.jar')
     def algorithms = ["MD5", "SHA-1", "SHA-256"]
     algorithms.each { algorithm ->
@@ -177,7 +177,7 @@ def createChecksumsTask = tasks.register('createChecksums') {
         }
         String checksum = sb.toString()
         def ext = algorithm.toLowerCase().replace("-", "")
-        String outputFilename = "${buildDir}/libs/${jarFile.getName()}.${ext}"
+        String outputFilename = "${buildDir}/distributions/${jarFile.getName()}.${ext}"
         new File(outputFilename).withWriter { writer ->
           writer.write checksum
         }


### PR DESCRIPTION
## Description of Changes

Fix artifact publishing and fatJar checksum task, and document change in the directory holding the fatJars (and their checksums) (changed from `build/libs` to `build/distributions`).

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
