### PR TITLE
#1375 Units for false_easting and false_northing (fix)

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/AbstractTransformBuilder.java
@@ -29,18 +29,6 @@ import java.util.Formatter;
 public abstract class AbstractTransformBuilder {
   private static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractTransformBuilder.class);
 
-  /*
-   * from CF: false_easting(false_northing):
-   * The value added to all abscissa(ordinate) values in the rectangular coordinates for a map projection.
-   * This value frequently is assigned to eliminate negative numbers.
-   * Expressed in the unit of the coordinate variable identified by the standard name projection_x_coordinate
-   * (projection_y_coordinate).
-   */
-  public static double getFalseEastingScaleFactor(NetcdfDataset ds, AttributeContainer ctv) {
-    String units = getGeoCoordinateUnits(ds, ctv, ds.getCoordinateAxes());
-    return getFalseEastingScaleFactor(units);
-  }
-
   public static String getGeoCoordinateUnits(NetcdfDataset ds, AttributeContainer ctv) {
     return getGeoCoordinateUnits(ds, ctv, ds.getCoordinateAxes());
   }
@@ -73,18 +61,6 @@ public abstract class AbstractTransformBuilder {
     return units;
   }
 
-  public static double getFalseEastingScaleFactor(String geoCoordinateUnits) {
-    if (geoCoordinateUnits != null) {
-      try {
-        SimpleUnit unit = SimpleUnit.factoryWithExceptions(geoCoordinateUnits);
-        return unit.convertTo(1.0, SimpleUnit.kmUnit);
-      } catch (Exception e) {
-        log.warn(geoCoordinateUnits + " not convertible to km");
-      }
-    }
-    return 1.0;
-  }
-
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   private Formatter errBuffer;
   protected double lat0, lon0, false_easting, false_northing, earth_radius;
@@ -104,12 +80,6 @@ public abstract class AbstractTransformBuilder {
     lat0 = readAttributeDouble(ctv, CF.LATITUDE_OF_PROJECTION_ORIGIN, Double.NaN);
     false_easting = readAttributeDouble(ctv, CF.FALSE_EASTING, 0.0);
     false_northing = readAttributeDouble(ctv, CF.FALSE_NORTHING, 0.0);
-
-    if ((false_easting != 0.0) || (false_northing != 0.0)) {
-      double scalef = getFalseEastingScaleFactor(units);
-      false_easting *= scalef;
-      false_northing *= scalef;
-    }
 
     double semi_major_axis = readAttributeDouble(ctv, CF.SEMI_MAJOR_AXIS, Double.NaN);
     double semi_minor_axis = readAttributeDouble(ctv, CF.SEMI_MINOR_AXIS, Double.NaN);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/LambertConformalConic.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/LambertConformalConic.java
@@ -31,12 +31,6 @@ public class LambertConformalConic extends AbstractTransformBuilder implements H
     double false_easting = readAttributeDouble(ctv, CF.FALSE_EASTING, 0.0);
     double false_northing = readAttributeDouble(ctv, CF.FALSE_NORTHING, 0.0);
 
-    if ((false_easting != 0.0) || (false_northing != 0.0)) {
-      double scalef = getFalseEastingScaleFactor(geoCoordinateUnits);
-      false_easting *= scalef;
-      false_northing *= scalef;
-    }
-
     double earth_radius = getEarthRadiusInKm(ctv);
     double semi_major_axis = readAttributeDouble(ctv, CF.SEMI_MAJOR_AXIS, Double.NaN);
     double semi_minor_axis = readAttributeDouble(ctv, CF.SEMI_MINOR_AXIS, Double.NaN);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/PolarStereographic.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/PolarStereographic.java
@@ -57,13 +57,6 @@ public class PolarStereographic extends AbstractTransformBuilder implements Hori
     }
     double false_easting = readAttributeDouble(ctv, CF.FALSE_EASTING, 0.0);
     double false_northing = readAttributeDouble(ctv, CF.FALSE_NORTHING, 0.0);
-
-    if ((false_easting != 0.0) || (false_northing != 0.0)) {
-      double scalef = getFalseEastingScaleFactor(geoCoordinateUnits);
-      false_easting *= scalef;
-      false_northing *= scalef;
-    }
-
     double earth_radius = getEarthRadiusInKm(ctv);
     double semi_major_axis = readAttributeDouble(ctv, CF.SEMI_MAJOR_AXIS, Double.NaN); // meters
     double semi_minor_axis = readAttributeDouble(ctv, CF.SEMI_MINOR_AXIS, Double.NaN);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/Sinusoidal.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/Sinusoidal.java
@@ -27,12 +27,6 @@ public class Sinusoidal extends AbstractTransformBuilder implements HorizTransfo
     double false_northing = readAttributeDouble(ctv, CF.FALSE_NORTHING, 0.0);
     double earth_radius = getEarthRadiusInKm(ctv);
 
-    if ((false_easting != 0.0) || (false_northing != 0.0)) {
-      double scalef = getFalseEastingScaleFactor(geoCoordinateUnits);
-      false_easting *= scalef;
-      false_northing *= scalef;
-    }
-
     ucar.unidata.geoloc.projection.Sinusoidal proj =
         new ucar.unidata.geoloc.projection.Sinusoidal(centralMeridian, false_easting, false_northing, earth_radius);
     return new ProjectionCT(ctv.getName(), "FGDC", proj);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/Stereographic.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/Stereographic.java
@@ -27,13 +27,6 @@ public class Stereographic extends AbstractTransformBuilder implements HorizTran
     double lat0 = readAttributeDouble(ctv, CF.LATITUDE_OF_PROJECTION_ORIGIN, 90.0);
     double false_easting = readAttributeDouble(ctv, CF.FALSE_EASTING, 0.0);
     double false_northing = readAttributeDouble(ctv, CF.FALSE_NORTHING, 0.0);
-
-    if ((false_easting != 0.0) || (false_northing != 0.0)) {
-      double scalef = getFalseEastingScaleFactor(geoCoordinateUnits); // conversion from axis-unit to km
-      false_easting *= scalef;
-      false_northing *= scalef;
-    }
-
     double earth_radius = getEarthRadiusInKm(ctv);
     double semi_major_axis = readAttributeDouble(ctv, CF.SEMI_MAJOR_AXIS, Double.NaN); // meters
     double semi_minor_axis = readAttributeDouble(ctv, CF.SEMI_MINOR_AXIS, Double.NaN);

--- a/cdm/core/src/main/java/ucar/nc2/dataset/transform/TransverseMercator.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/transform/TransverseMercator.java
@@ -32,13 +32,6 @@ public class TransverseMercator extends AbstractTransformBuilder implements Hori
     double lat0 = readAttributeDouble(ctv, CF.LATITUDE_OF_PROJECTION_ORIGIN, Double.NaN);
     double false_easting = readAttributeDouble(ctv, CF.FALSE_EASTING, 0.0);
     double false_northing = readAttributeDouble(ctv, CF.FALSE_NORTHING, 0.0);
-
-    if ((false_easting != 0.0) || (false_northing != 0.0)) {
-      double scalef = getFalseEastingScaleFactor(geoCoordinateUnits);
-      false_easting *= scalef;
-      false_northing *= scalef;
-    }
-
     double earth_radius = getEarthRadiusInKm(ctv);
     double semi_major_axis = readAttributeDouble(ctv, CF.SEMI_MAJOR_AXIS, Double.NaN);
     double semi_minor_axis = readAttributeDouble(ctv, CF.SEMI_MINOR_AXIS, Double.NaN);

--- a/cdm/core/src/main/java/ucar/nc2/dt/grid/CFGridWriter2.java
+++ b/cdm/core/src/main/java/ucar/nc2/dt/grid/CFGridWriter2.java
@@ -369,13 +369,6 @@ public class CFGridWriter2 {
     if ((null != att) && att.getStringValue().equals("Projection")) {
       Attribute east = ctv.findAttribute("false_easting");
       Attribute north = ctv.findAttribute("false_northing");
-      if ((null != east) || (null != north)) {
-        double scalef = AbstractTransformBuilder.getFalseEastingScaleFactor(ds, ctv);
-        if (scalef != 1.0) {
-          convertAttribute(ctv, east, scalef);
-          convertAttribute(ctv, north, scalef);
-        }
-      }
     }
   }
 

--- a/legacy/src/main/java/ucar/nc2/dt/grid/CFGridWriter.java
+++ b/legacy/src/main/java/ucar/nc2/dt/grid/CFGridWriter.java
@@ -486,13 +486,6 @@ public class CFGridWriter {
     if ((null != att) && att.getStringValue().equals("Projection")) {
       Attribute east = ctv.findAttribute("false_easting");
       Attribute north = ctv.findAttribute("false_northing");
-      if ((null != east) || (null != north)) {
-        double scalef = AbstractTransformBuilder.getFalseEastingScaleFactor(ds, ctv);
-        if (scalef != 1.0) {
-          convertAttribute(ctv, east, scalef);
-          convertAttribute(ctv, north, scalef);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Description of Changes

See the description of the issue #1375

I have worked with GIS systems and Geographic projections at Deltares since 1998 and I am 100% sure that:
No exceptions exist where false easting/northing units differ from the projected coordinates. These values are intrinsic to the coordinate system's design and always share the same units

So I propose to remove the scaling of these parameters completely, also for other projections where it is applied.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
