### PR TITLE
Fix sourceJar building

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -13,3 +13,5 @@ jobs:
           java-version: '11'
       - name: Build with Gradle (refresh dependencies)
         run: ./gradlew clean classes testClasses assemble --refresh-dependencies
+      - name: Build sourceJars
+        run: ./gradlew sourceJar

--- a/gradle/any/protobuf.gradle
+++ b/gradle/any/protobuf.gradle
@@ -8,14 +8,6 @@ protobuf {
   }
 }
 
-// Add generated sources to the main sourceSet, which keeps intellij happy.
-// Now, we could use the idea plugin and let gradle generate intellij project files, but it seems as though gradle is
-// considering deprecating their plugin and upstreaming it to JetBrains. Might not be a good bet to start relying on
-// the idea plugin at this point.
-// https://github.com/gradle/gradle/issues/1366#issuecomment-546928184
-sourceSets.main.java.srcDirs += ['build/generated/sources/proto/main/java',
-                                 'build/generated/sources/proto/main/grpc']
-
 jacocoTestReport {
   afterEvaluate {
     // Exclude proto generated sources and classes from the coverage reports


### PR DESCRIPTION
## Description of Changes

Currently, the sourceJar tasks of subprojects that use the proto plugin fail due to an attempt to add duplicate source files. The issue crept in when we upgraded the proto plugin. The fix is that we no longer need to manage the sourceSets to account for proto and grpc generated code.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
