### PR TITLE
Allow C library to be loaded after Nc4Iosp initialization for some cases

### DIFF
--- a/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
+++ b/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
@@ -32,7 +32,10 @@ public class NetcdfClibrary {
 
   /**
    * Set the path and name of the netcdf c library.
-   * Must be called before load() is called.
+   * <p>
+   * Must be called prior to calling {@link #isLibraryPresent() isLibraryPresent}
+   * or {@link #getForeignFunctionInterface() getForeignFunctionInterface}, as
+   * the C library can only be successfully loaded once.
    *
    * @param jna_path path to shared libraries, may be null. If null, will look for system property
    *        "jna.library.path", then environment variable "JNA_PATH". If set, will set
@@ -40,6 +43,12 @@ public class NetcdfClibrary {
    * @param lib_name library name, may be null. If null, will use "netcdf".
    */
   public static void setLibraryNameAndPath(@Nullable String jna_path, @Nullable String lib_name) {
+
+    if (nc4 != null) {
+      log.warn("netCDF-C library already set, ignoring.");
+      return;
+    }
+
     lib_name = Strings.emptyToNull(lib_name);
 
     if (lib_name == null) {
@@ -61,6 +70,11 @@ public class NetcdfClibrary {
 
     libName = lib_name;
     jnaPath = jna_path;
+
+    if ((isClibraryPresent == null || !isClibraryPresent) && jnaPath != null) {
+      // call load to retry loading, but this time with jnaPath set
+      load();
+    }
   }
 
   /**

--- a/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
+++ b/netcdf4/src/main/java/ucar/nc2/jni/netcdf/Nc4Iosp.java
@@ -74,8 +74,14 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
   private static final boolean transcodeStrings = Charset.defaultCharset() != StandardCharsets.UTF_8;
 
   /**
-   * set the path and name of the netcdf c library.
-   * must be called before load() is called.
+   * Set the path and name of the netcdf c library.
+   * <p>
+   * This method will only work if the netCDF-C library was not found on the
+   * system path. If you need to use a specific version of the C library, and
+   * you have a different version on a system path, do not use this method.
+   * Instead, call {@link NetcdfClibrary#setLibraryNameAndPath(String, String)
+   * NetcdfClibrary.setLibraryNameAndPath} prior to any uses of
+   * the Nc4Iosp class.
    *
    * @param jnaPath path to shared libraries
    * @param libName library name
@@ -83,7 +89,11 @@ public class Nc4Iosp extends AbstractIOServiceProvider implements IOServiceProvi
    */
   @Deprecated
   public static void setLibraryAndPath(String jnaPath, String libName) {
-    NetcdfClibrary.setLibraryNameAndPath(jnaPath, libName);
+    if (nc4 != null) {
+      log.warn("Library already set, ignoring.");
+    } else {
+      NetcdfClibrary.setLibraryNameAndPath(jnaPath, libName);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description of Changes

If the netCDF-C library was not found on the system library path upon initialization of the Nc4Iosp class, retry loading when calling Nc4Iosp.setLibraryAndPath.

Clarify the javadocs for the setLibraryNameAndPath methods of the Nc4Iosp and NetcdfClibrary classes.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
