### PR TITLE
Load EnhancementProviders upon VariableDS instantiation

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
+++ b/cdm/core/src/main/java/ucar/nc2/dataset/VariableDS.java
@@ -34,7 +34,14 @@ import java.util.*;
  */
 public class VariableDS extends Variable implements VariableEnhanced, EnhanceScaleMissingUnsigned {
 
-  static final ServiceLoader<EnhancementProvider> ENHANCEMENT_PROVIDERS = ServiceLoader.load(EnhancementProvider.class);
+  static final List<EnhancementProvider> ENHANCEMENT_PROVIDERS;
+
+  static {
+    ENHANCEMENT_PROVIDERS = new ArrayList<>();
+    for (EnhancementProvider enhancementProvider : ServiceLoader.load(EnhancementProvider.class)) {
+      ENHANCEMENT_PROVIDERS.add(enhancementProvider);
+    }
+  }
 
   /**
    * Constructor when there's no underlying variable.


### PR DESCRIPTION
## Description of Changes

ServiceLoader instances are not thread-safe, so rather than share a static instance, load the provides once upon instantiation of the VariableDS class. Fixes Unidata/netcdf-java#1477

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
