### PR TITLE
Set variable caching to true for defered value creation in NcML

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/NcmlReader.java
@@ -1295,6 +1295,9 @@ public class NcmlReader {
           if (v.getRank() > 0) {
             v.setDimensionsByName(v.makeDimensionsString());
           }
+          // data will get cached when build is called, but set
+          // caching to true on the variable now
+          v.setCaching(true);
         } else {
           Array data = Array.makeArray(dtype, npts, start, incr);
           v.setCachedData(data, true);


### PR DESCRIPTION
## Description of Changes

When generating values for a variable using NcML of the form `<values start="0" increment="1" />`, be sure caching is set to true on the `Variable.Builder`, as the values will be cached when they are generated during the `build()` call. 

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
