### PR TITLE
Allow hash characters in file names passed to NetcdfFiles

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
+++ b/cdm/core/src/main/java/ucar/nc2/NetcdfFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2019 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -27,6 +27,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import javax.annotation.Nullable;
+import ucar.nc2.dataset.DatasetUrl;
 import ucar.nc2.internal.iosp.netcdf3.N3headerNew;
 import ucar.nc2.internal.iosp.netcdf3.N3iospNew;
 import ucar.nc2.iosp.AbstractIOServiceProvider;
@@ -476,7 +477,9 @@ public class NetcdfFiles {
   }
 
   private static String removeFragment(String uriString) {
-    return uriString.split("#")[0];
+    List<String> protocols = DatasetUrl.getProtocols(uriString);
+    // only remove fragment from non-local files
+    return (protocols.isEmpty() || protocols.contains("file")) ? uriString : uriString.split("#")[0];
   }
 
   private static boolean looksCompressed(String filename) {

--- a/cdm/core/src/test/java/ucar/nc2/TestOpenFunkyFilePath.java
+++ b/cdm/core/src/test/java/ucar/nc2/TestOpenFunkyFilePath.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ucar.nc2.util.IO;
+import ucar.unidata.util.test.TestDir;
+
+public class TestOpenFunkyFilePath {
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void testFileWithHash() throws IOException {
+    File org = new File(TestDir.cdmLocalTestDataDir + "jan.nc");
+    NetcdfFile ncf = NetcdfFiles.open(org.getAbsolutePath());
+    assertThat(ncf).isNotNull();
+    ncf.close();
+
+    // create file to trigger error from https://github.com/Unidata/netcdf-java/issues/1492
+    File copyWithHashName = File.createTempFile("jan#", ".nc", tempFolder.getRoot());
+    IO.copyFile(org, copyWithHashName);
+
+    NetcdfFile ncf2 = NetcdfFiles.open(copyWithHashName.getAbsolutePath());
+    assertThat(ncf2).isNotNull();
+    ncf2.close();
+
+    NetcdfFile ncf3 = NetcdfFiles.open("file:" + copyWithHashName.getAbsolutePath());
+    assertThat(ncf3).isNotNull();
+    ncf3.close();
+
+    NetcdfFile ncf4 = NetcdfFiles.open("file://" + copyWithHashName.getAbsolutePath());
+    assertThat(ncf4).isNotNull();
+    ncf4.close();
+  }
+
+}

--- a/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
+++ b/cdm/s3/src/test/java/ucar/unidata/io/s3/TestS3ExternalCompressionRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2019-2025 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -19,7 +19,7 @@ import ucar.unidata.util.test.category.NeedsExternalResource;
 
 @Category(NeedsExternalResource.class)
 public class TestS3ExternalCompressionRead {
-  private static final String compressedObject = "cdms3:noaa-nexrad-level2?1991/07/20/KTLX/KTLX19910720_160529.gz";
+  private static final String compressedObject = "cdms3:unidata-nexrad-level2?1991/07/20/KTLX/KTLX19910720_160529.gz";
   private static final String fragment = "#delimiter=/";
 
   @Test


### PR DESCRIPTION
## Description of Changes

When opening a file through NetcdfFiles, any potential URI fragments are removed for certain checks. This only needs to be done for non-local files, so we skip this for local files. Fixes Unidata/netcdf-java#1492

Additionally, fix test that uses the nexrad level2 AWS S3 bucket (update bucket name).

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
