### PR TITLE
Delete the print hello when accessing grib2 Type42 data

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Drs.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Drs.java
@@ -467,7 +467,6 @@ public abstract class Grib2Drs {
       this.compressionOptionsMask = raf.read();
       this.blockSize = raf.read();
       this.referenceSampleInterval = GribNumbers.uint2(raf);
-      System.out.println("hello");
     }
 
     @Override


### PR DESCRIPTION
This PR deletes the print hello when accessing grib2 Type42 data