### PR TITLE
Dap4 null valued attributes

### DIFF
--- a/dap4/build.gradle.kts
+++ b/dap4/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
 
   testImplementation(project(":cdm-test-utils"))
 
+  testImplementation(libs.google.truth)
+
   testCompileOnly(libs.junit4)
 
   testRuntimeOnly(libs.junit5.platformLauncher)

--- a/dap4/src/main/java/dap4/core/dmr/DMRPrinter.java
+++ b/dap4/src/main/java/dap4/core/dmr/DMRPrinter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2012, UCAR/Unidata.
- * See the LICENSE file for more information.
+ * Copyright (c) 2012-2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
  */
 
 package dap4.core.dmr;
@@ -531,10 +531,14 @@ public class DMRPrinter {
         printer.marginPrintln(cs);
       }
     } else {
-      for (int i = 0; i < svec.length; i++) {
-        String s = Escape.entityEscape(svec[i], null);
-        String cs = String.format("<Value value=\"%s\"/>", s);
-        printer.marginPrintln(cs);
+      if (svec.length == 0) {
+        printer.marginPrintln("<Value/>");
+      } else {
+        for (String string : svec) {
+          String s = Escape.entityEscape(string, null);
+          String cs = String.format("<Value value=\"%s\"/>", s);
+          printer.marginPrintln(cs);
+        }
       }
     }
     printer.outdent();

--- a/dap4/src/test/java/dap4/core/dmr/TestDMRPrinterEdgeCases.java
+++ b/dap4/src/test/java/dap4/core/dmr/TestDMRPrinterEdgeCases.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package dap4.core.dmr;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import dap4.core.util.IndentWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import org.junit.Test;
+
+public class TestDMRPrinterEdgeCases {
+  @Test
+  public void testNullValueAttr() throws IOException {
+    DapAttribute attr = new DapAttribute("name", DapType.STRING);
+    attr.setValues(new String[] {});
+    DMRPrinter dmrPrinter = new DMRPrinter();
+    StringWriter sw = new StringWriter();
+    dmrPrinter.printer = new IndentWriter(sw);
+    dmrPrinter.printAttribute(attr);
+    String encodedAttribute = sw.toString();
+    assertThat(encodedAttribute).isNotEmpty();
+    assertThat(encodedAttribute).ignoringCase().contains("<value/>");
+  }
+}


### PR DESCRIPTION
## Description of Changes

Represent null-valued attributes in the DMR as `<Value/>`, which matches Hyrax behavior.

Sets the stage for fixing Unidata/tds#632

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
