### PR TITLE
Add method to close netCDF-C native library

### DIFF
--- a/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
+++ b/netcdf4/src/main/java/ucar/nc2/ffi/netcdf/NetcdfClibrary.java
@@ -6,7 +6,9 @@
 package ucar.nc2.ffi.netcdf;
 
 import com.google.common.base.Strings;
+import com.sun.jna.Library;
 import com.sun.jna.Native;
+import java.lang.reflect.Proxy;
 import javax.annotation.Nullable;
 import ucar.nc2.jni.netcdf.Nc4prototypes;
 import ucar.nc2.jni.netcdf.Nc4wrapper;
@@ -126,6 +128,21 @@ public class NetcdfClibrary {
       }
     }
     return oldlevel;
+  }
+
+  /**
+   * Closes the netCDF-C native library.
+   *
+   * <p>
+   * Call this method to ensure JNA can shut down its cleaner thread; otherwise JVM shutdown may be blocked.
+   * </p>
+   */
+  public static synchronized void shutdown() {
+    if (nc4 != null) {
+      Library.Handler lh = (Library.Handler) Proxy.getInvocationHandler(nc4);
+      lh.getNativeLibrary().close();
+      nc4 = null;
+    }
   }
 
   private static Nc4prototypes load() {

--- a/uicdm/src/main/java/ucar/nc2/ui/ToolsUI.java
+++ b/uicdm/src/main/java/ucar/nc2/ui/ToolsUI.java
@@ -16,6 +16,7 @@ import ucar.nc2.dataset.*;
 import ucar.nc2.dods.DODSNetcdfFile;
 import ucar.nc2.dt.GridDataset;
 import ucar.nc2.dt.RadialDatasetSweep;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.nc2.ft.point.PointDatasetImpl;
 import ucar.nc2.ft2.coverage.*;
 import ucar.nc2.grib.GribIndexCache;
@@ -1312,6 +1313,10 @@ public class ToolsUI extends JPanel {
 
   public static void exit() {
     doSavePrefsAndUI();
+    // close netCDF-C library, if loaded
+    if (NetcdfClibrary.isLibraryPresent()) {
+      NetcdfClibrary.shutdown();
+    }
     System.exit(0);
   }
 


### PR DESCRIPTION
## Description of Changes

Provide a method to close the netCDF-C native library, otherwise the JNA cleaner thread may get blocked.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
