### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -5,7 +5,7 @@ jobs:
     name: Check fresh compile and assemble of netCDF-Java project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/docs-tutorials.yml
+++ b/.github/workflows/docs-tutorials.yml
@@ -6,7 +6,7 @@ jobs:
     name: netCDF-Java Documentation Code Deprecation Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Java 8, 17
         uses: actions/setup-java@v5
         with:
@@ -15,7 +15,7 @@ jobs:
             8
             17
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,14 +10,14 @@ jobs:
     name: netCDF-Java Documentation Build Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew buildJekyllSite
       - if: success()
         name: Upload a preview of the rendered html
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: documentation_${{ github.sha }}
           path: docs/build/site

--- a/.github/workflows/libaec.yml
+++ b/.github/workflows/libaec.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.build_env.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'MathisRosenhauer/libaec'
           ref: 'v1.1.3'
@@ -67,7 +67,7 @@ jobs:
           cp ${{ matrix.build_env.lib }} resources/${{ matrix.build_env.jna_id }}
 
       - name: Upload ${{ matrix.build_env.jna_id }} artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: libaec-${{ matrix.build_env.jna_id }}
           path: ${{ steps.strings.outputs.build-dir }}/resources
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: libaec-*
           path: native/resources/
@@ -88,7 +88,7 @@ jobs:
         run: find native/ -type f -exec ls -lh {} \;
 
       - name: Upload merged artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: libaec-native-1.1.3-${{ github.sha }}
           path: native/

--- a/.github/workflows/libblosc2.yml
+++ b/.github/workflows/libblosc2.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo "build-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'Blosc/c-blosc2'
           ref: "v2.22.0"
@@ -58,7 +58,7 @@ jobs:
           cp -L ${{ matrix.build_env.lib }} resources/${{ matrix.build_env.jna_id }}
 
       - name: Upload ${{ matrix.build_env.jna_id }} artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: libblosc2-${{ matrix.build_env.jna_id }}
           path: ${{ steps.strings.outputs.build-dir }}/resources
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: libblosc2-*
           path: native/resources/
@@ -79,7 +79,7 @@ jobs:
         run: find native/ -type f -exec ls -lh {} \;
 
       - name: Upload merged artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: libblosc2-native-2.22.0-${{ github.sha }}
           path: native/

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -5,14 +5,14 @@ jobs:
     name: Code Style Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/test-native-compression.yml
+++ b/.github/workflows/test-native-compression.yml
@@ -22,7 +22,7 @@ jobs:
     name: netCDF-Java Native Compression Tests
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK 8, 17
         if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'macos-15-intel' }}
         uses: actions/setup-java@v5
@@ -38,7 +38,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -54,7 +54,7 @@ jobs:
       - name: Run libaec JNA tests (JDK 21 tests)
         if: ${{ matrix.os != 'ubuntu-24.04' && matrix.os != 'macos-15-intel' }}
         run: ./gradlew clean :libaec-jna:test21
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: NativeCompression_JUnit_Results_${{ github.sha }}_-${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         # test against latest 8, 11, 17, 21 of zulu and temurin java
-        java-version: [8, 11, 17, 21]
-        java-vendor: ['zulu', 'temurin', 'corretto']
+        java-version: [8, 11, 17, 21, 25]
+        java-vendor: ['temurin', 'corretto']
     steps:
       - uses: actions/checkout@v6
       - name: Build with ${{ matrix.java-vendor }} 17 and run tests with ${{ matrix.java-vendor }} 8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,15 +11,26 @@ jobs:
         java-vendor: ['zulu', 'temurin', 'corretto']
     steps:
       - uses: actions/checkout@v6
-      - name: Build with ${{ matrix.java-vendor }} 17 and run tests with ${{ matrix.java-vendor }} ${{ matrix.java-version }}
+      - name: Build with ${{ matrix.java-vendor }} 17 and run tests with ${{ matrix.java-vendor }} 8
+        if: ${{ matrix.java-version == 8 }}
         uses: Unidata/thredds-test-action@v4
         with:
           java-vendor: ${{ matrix.java-vendor }}
           java-version: 17
           build-tool: 'gradlew'
-          test-command: '-Dorg.gradle.java.installations.fromEnv=JDK8 --info --stacktrace test'
+          test-command: '-Dorg.gradle.java.installations.fromEnv=TEST_JDK --info --stacktrace test'
         env:
-          JDK8: /usr/thredds-test-environment/${{ matrix.java-vendor }}8
+          TEST_JDK: /usr/thredds-test-environment/${{ matrix.java-vendor }}8
+      - name: Build with ${{ matrix.java-vendor }} 17 and run tests with ${{ matrix.java-vendor }} ${{ matrix.java-version }}
+        if: ${{ matrix.java-version != 8 }}
+        uses: Unidata/thredds-test-action@v4
+        with:
+          java-vendor: ${{ matrix.java-vendor }}
+          java-version: 17
+          build-tool: 'gradlew'
+          test-command: '-Dorg.gradle.java.installations.fromEnv=TEST_JDK --info --stacktrace testWithJdk${{ matrix.java-version }}'
+        env:
+          TEST_JDK: /usr/thredds-test-environment/${{ matrix.java-vendor }}${{ matrix.java-version }}
       - name: Cleanup build-logic-ncj build directory
         if: failure()
         run: sudo rm -rf build-logic-ncj/build/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
         java-version: [8, 11, 17, 21]
         java-vendor: ['zulu', 'temurin', 'corretto']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build with ${{ matrix.java-vendor }} 17 and run tests with ${{ matrix.java-vendor }} ${{ matrix.java-version }}
-        uses: Unidata/thredds-test-action@v3
+        uses: Unidata/thredds-test-action@v4
         with:
           java-vendor: ${{ matrix.java-vendor }}
           java-version: 17
@@ -20,12 +20,11 @@ jobs:
           test-command: '-Dorg.gradle.java.installations.fromEnv=JDK8 --info --stacktrace test'
         env:
           JDK8: /usr/thredds-test-environment/${{ matrix.java-vendor }}8
-      - name: Prep for artifact upload
+      - name: Cleanup build-logic-ncj build directory
         if: failure()
-        run: rm -rf build-logic-ncj/build/tmp
-      - uses: actions/upload-artifact@v4
+        run: sudo rm -rf build-logic-ncj/build/
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: netCDF-Java_JUnit_Results_${{ github.sha }}_${{ matrix.java-vendor }}-${{ matrix.java-version }}
-          path: |
-            ${{ github.workspace }}/**/build/reports/tests/**/*
+          path: ${{ github.workspace }}/**/build/reports/*

--- a/bufr/src/main/java/ucar/nc2/iosp/bufr/tables/BufrTables.java
+++ b/bufr/src/main/java/ucar/nc2/iosp/bufr/tables/BufrTables.java
@@ -140,6 +140,8 @@ public class BufrTables {
     if (lookups == null)
       lookups = new ArrayList<>();
     File f = new File(filename);
+    if (f.isDirectory())
+      throw new FileNotFoundException(filename + " is a directory");
     if (!f.exists())
       throw new FileNotFoundException(filename + " not found");
     lookups.add(filename);

--- a/cdm/gcdm/build.gradle.kts
+++ b/cdm/gcdm/build.gradle.kts
@@ -5,6 +5,7 @@
 
 import com.github.psxpaul.task.JavaExecFork
 import com.google.protobuf.gradle.id
+import org.gradle.kotlin.dsl.get
 
 plugins {
   id("ncj-java-library-conventions")
@@ -83,7 +84,6 @@ val startDaemon =
     waitForPort = 16111
     waitForOutput = "Server started, listening on 16111"
     dependsOn(tasks.testClasses)
-    doLast { stopAfter = tasks.named("test") }
   }
 
-tasks.test { dependsOn(startDaemon) }
+tasks.withType<Test> { dependsOn(startDaemon) }


### PR DESCRIPTION
## Description of Changes

Update github actions:
- actions/cache@v4 -> v5
- actions/checkout@v4 -> v6
- actions/download-artifact@v4 -> v7
- actions/upload-artifact@v4 -> v6
- Unidata/thredds-test-action@v3 -> v4

Additionally:
- Address EACCESS errors related to the build-logic-ncj directory when uploading artifacts of the test results upon failure
- Remove Zulu JDK from the test matrix
- Add JDK 25
  - fix issue related to loading bufr tables as `File("").exists()` is `true` in JDK 25 (change in behavior from previous versions).

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
