### PR TITLE
Fix integer overflow for inflate

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
+++ b/cdm/core/src/main/java/ucar/nc2/filter/Deflate.java
@@ -69,7 +69,8 @@ public class Deflate extends Filter {
 
   @Override
   public byte[] decode(byte[] dataIn) throws IOException {
-    int len = Math.min(8 * dataIn.length, MAX_ARRAY_LEN);
+    long approxLen = (long) 8 * dataIn.length;
+    int len = approxLen > MAX_ARRAY_LEN ? MAX_ARRAY_LEN : (int) approxLen;
     try (ByteArrayInputStream in = new ByteArrayInputStream(dataIn);
         InflaterInputStream iis = new InflaterInputStream(in, new Inflater(), dataIn.length);
         ByteArrayOutputStream os = new ByteArrayOutputStream(len)) {

--- a/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/H5tiledLayoutBB.java
@@ -252,7 +252,8 @@ public class H5tiledLayoutBB implements LayoutBB {
 
         java.util.zip.InflaterInputStream inflatestream =
             new java.util.zip.InflaterInputStream(in, inflater, inflatebuffersize);
-        int len = Math.min(8 * compressed.length, MAX_ARRAY_LEN);
+        long approxLen = (long) 8 * compressed.length;
+        int len = approxLen > MAX_ARRAY_LEN ? MAX_ARRAY_LEN : (int) approxLen;
         ByteArrayOutputStream out = new ByteArrayOutputStream(len); // Fixes KXL-349288
         IO.copyB(inflatestream, out, len);
 


### PR DESCRIPTION
## Description of Changes

When decompressing a zlib compressed chunk, prevent an integer overflow when calculating the size of the ByteArrayOutputStream. Fixes Unidata/netcdf-java#1523

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
