### PR TITLE
Improve aec and blosc2 native loading

### DIFF
--- a/native-compression/libaec-jna/src/main/java/edu/ucar/unidata/compression/jna/libaec/LibAec.java
+++ b/native-compression/libaec-jna/src/main/java/edu/ucar/unidata/compression/jna/libaec/LibAec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2025-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -34,13 +34,21 @@ public final class LibAec {
       File library = Native.extractFromResourcePath(libName);
       Native.register(library.getAbsolutePath());
       log.debug("Using libaec library from libaec-native.jar");
-    } catch (IOException e) {
+    } catch (IOException | UnsatisfiedLinkError e) {
+      boolean unusableNativeLib = false;
+      // The native jar wasn't found on the classpath, OR the native library
+      // shipped with the jar is not compatible with the current OS toolchain.
+      // Check for the library on the system path.
+      if (e instanceof UnsatisfiedLinkError) {
+        unusableNativeLib = true;
+        log.debug("Error loading libaec from native jar: {}", e.getMessage());
+      }
       try {
         Native.register(libName);
         log.debug("Using libaec library from system");
       } catch (UnsatisfiedLinkError ule) {
-        String message =
-            "libaec C library not present. To read this data, include the libaec-native jar in your classpath "
+        String message = unusableNativeLib ? "Usable libaec C library not found. Install libaec on your system."
+            : "libaec C library not found. To read this data, include the libaec-native jar in your classpath "
                 + "(edu.ucar:libaec-native) or install libaec on your system.";
         log.error(message);
         throw new RuntimeException(message, ule);

--- a/native-compression/libblosc2-jna/src/main/java/edu/ucar/unidata/compression/jna/libblosc2/LibBlosc2.java
+++ b/native-compression/libblosc2-jna/src/main/java/edu/ucar/unidata/compression/jna/libblosc2/LibBlosc2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 2025-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -39,13 +39,21 @@ public final class LibBlosc2 {
       File library = Native.extractFromResourcePath(libName);
       Native.register(library.getAbsolutePath());
       log.debug("Using blosc2 library from libblosc2-native.jar");
-    } catch (IOException e) {
+    } catch (IOException | UnsatisfiedLinkError e) {
+      boolean unusableNativeLib = false;
+      // The native jar wasn't found on the classpath, OR the native library
+      // shipped with the jar is not compatible with the current OS toolchain.
+      // Check for the library on the system path.
+      if (e instanceof UnsatisfiedLinkError) {
+        unusableNativeLib = true;
+        log.debug("Error loading libblosc2 from native jar: {}", e.getMessage());
+      }
       try {
         Native.register(libName);
         log.debug("Using libblosc2 library from system");
       } catch (UnsatisfiedLinkError ule) {
-        String message =
-            "libblosc2 C library not present. To read this data, include the libblosc2-native jar in your classpath "
+        String message = unusableNativeLib ? "Usable libblosc2 C library not found. Install libblosc2 on your system."
+            : "libblosc2 C library not found. To read this data, include the libblosc2-native jar in your classpath "
                 + "(edu.ucar:libblosc2-native) or install libblosc2 on your system.";
         log.error(message);
         throw new RuntimeException(message, ule);


### PR DESCRIPTION
## Description of Changes

Handle the case where the native library shipped inside the native jar is not compatible with the current OS's toolchain (e.g., the GLIB_C version associated with the native library is newer than the system supports). In such cases, fall back to searching the system path.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
