### PR TITLE
Add cdm-s3 to ncIdv to enable reading data from object storage

### DIFF
--- a/uber-jars/build.gradle.kts
+++ b/uber-jars/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
   ncIdv(project(":cdm-vis5d"))
   ncIdv(project(":legacy"))
   ncIdv(project(":libaec-native"))
+  ncIdv(project(":cdm-s3"))
 
   // netcdfAll specific
   netcdfAll(project(":netcdf4"))


### PR DESCRIPTION
## Description of Changes


Add cdm-s3 to ncIdv to enable reading data from object storage.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
