### PR TITLE
Fix hdf5 file position bug when handling indirect blocks

### DIFF
--- a/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5IndirectBlocks.java
+++ b/cdm-test/src/test/java/ucar/nc2/iosp/hdf5/TestH5IndirectBlocks.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.iosp.hdf5;
+
+import static com.google.common.truth.Truth.assertThat;
+import static ucar.unidata.util.test.TestDir.cdmUnitTestDir;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import ucar.nc2.Group;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+@Category(NeedsCdmUnitTest.class)
+public class TestH5IndirectBlocks {
+
+  private final String h5FileWithIndirectBlocks = cdmUnitTestDir + "formats/hdf5/bitplane_imaris/indirect_blocks.ims";
+
+  // demonstrated https://github.com/Unidata/netcdf-java/issues/1546 using old api
+  @Test
+  public void testOpenFileWithIndirectBlocksOldApi() throws IOException {
+    NetcdfFile ncf = NetcdfFile.open(h5FileWithIndirectBlocks);
+    assertThat(ncf).isNotNull();
+  }
+
+  // demonstrated https://github.com/Unidata/netcdf-java/issues/1546 using new api
+  @Test
+  public void testOpenFileWithIndirectBlocksNewApi() throws IOException {
+    NetcdfFile ncf = NetcdfFiles.open(h5FileWithIndirectBlocks);
+    assertThat(ncf).isNotNull();
+  }
+
+  @Test
+  public void testReadIndirectBlocksOldApi() throws IOException {
+    NetcdfFile ncf = NetcdfFile.open(h5FileWithIndirectBlocks);
+    assertThat(ncf).isNotNull();
+    readVariableWithIndirectBlocks(ncf);
+  }
+
+  @Test
+  public void testReadIndirectBlocksNewApi() throws IOException {
+    NetcdfFile ncf = NetcdfFiles.open(h5FileWithIndirectBlocks);
+    assertThat(ncf).isNotNull();
+    readVariableWithIndirectBlocks(ncf);
+  }
+
+  private void readVariableWithIndirectBlocks(NetcdfFile ncf) throws IOException {
+    Group groupWithIndirectBlocksVariables = ncf.findGroup("/DataSetInfo/ZeissAttrs");
+    assertThat(groupWithIndirectBlocksVariables).isNotNull();
+    List<Variable> variablesWithIndirectBlocks = groupWithIndirectBlocksVariables.getVariables();
+    assertThat(variablesWithIndirectBlocks).isNotNull();
+    assertThat(variablesWithIndirectBlocks.size()).isEqualTo(3);
+    for (Variable variable : variablesWithIndirectBlocks) {
+      String data = variable.readScalarString();
+      assertThat(data).isNotNull();
+      assertThat(data).isNotEmpty();
+      assertThat(data).startsWith("<?xml");
+      assertThat(data).contains("<ArrayOfRt");
+    }
+  }
+}

--- a/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
+++ b/cdm/core/src/main/java/ucar/nc2/iosp/hdf5/FractalHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2026 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -513,8 +513,11 @@ public class FractalHeap {
         long childIndirectAddress = h5.readOffset();
         if (debugDetail || debugFractalHeap)
           debugOut.println("  InDirectChild " + row + " address= " + childIndirectAddress);
-        if (childIndirectAddress >= 0)
+        if (childIndirectAddress >= 0) {
+          long savePos = raf.getFilePointer();
           readIndirectBlock(iblock2, childIndirectAddress, heapAddress, hasFilter);
+          raf.seek(savePos);
+        }
       }
     }
 


### PR DESCRIPTION
## Description of Changes

Keep track of file position when recursing into readIndirectBlock. Fixes unidata/netcdf-java#1546

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [X] Add labels
- [X] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
