### PR TITLE
Upgrade libaec-native project to use v1.1.7 native libs for libaec

### DIFF
--- a/docs/src/site/_config.yml
+++ b/docs/src/site/_config.yml
@@ -78,5 +78,5 @@ base_docs_url: https://docs.unidata.ucar.edu/netcdf-java/
 # these will appear in various doc pages
 java_version_build: 17
 java_version_runtime: 8
-libaec_version: 1.1.3.0
+libaec_version: 1.1.7.0
 cblosc2_version: 2.23.1.0

--- a/native-compression/libaec-native/build.gradle.kts
+++ b/native-compression/libaec-native/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 
 group = "edu.ucar.unidata"
 
-var aecVersion = "1.1.3"
+var aecVersion = "1.1.7"
 var build = "0"
 
 version = "${aecVersion}.${build}"
@@ -24,10 +24,10 @@ description = "Jar distribution of native libraries for libaec compression."
 project.extra["project.title"] = "Native libraries for libaec."
 
 // zip file produced by GitHub workflow
-val libaecNative = "libaec-native-${aecVersion}-fec016ecd4b8ff1918877e582898d4257c405168.zip"
+val libaecNative = "libaec-native-${aecVersion}-cd42ee111b1aed88c6b4defba428eb7642aee91e.zip"
 
 // sha256 checksum from GitHub workflow output
-val expectedChecksum = "3db1ba7bc95b48eff74501382b90b0c7d0770a98f369d8c376c8ca4b6003487e"
+val expectedChecksum = "43d0d9ca73c3faf6677f65b2ca219812e1e70806e2269bc5bd6b4b6de9f35bee"
 
 val resourceZip = file("$rootDir/project-files/native/libaec/$libaecNative")
 val fetchNativeResources =


### PR DESCRIPTION
## Description of Changes

Upgrade libaec-native project to use v1.1.7 native libs for libaec

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
