### PR TITLE
xpublish DAP2 implementation compatibility

### DIFF
--- a/opendap/src/main/java/ucar/nc2/dods/DODSAttribute.java
+++ b/opendap/src/main/java/ucar/nc2/dods/DODSAttribute.java
@@ -75,7 +75,14 @@ public class DODSAttribute extends ucar.nc2.Attribute {
         data = Array.factory(ncType, new int[] {nvals});
         Index ima = data.getIndex();
         for (int i = 0; i < nvals; i++) {
-          double dval = Double.parseDouble(vals[i]);
+          double dval;
+          try {
+            dval = Double.parseDouble(vals[i]);
+          } catch (NumberFormatException e) {
+            // could be a python, rust (perhaps others) based server, in which case the string representation of NaN is
+            // nan
+            dval = Double.parseDouble(vals[i].replace("nan", "NaN"));
+          }
           data.setDouble(ima.set(i), dval);
         }
       } catch (NumberFormatException e) {


### PR DESCRIPTION
In the xpublish implementation of the DAP2 das response, Not a Number values for attributes are represented by the string nan. However, in Java and other languages, the string representation is NaN, and thus netCDF-Java fails to parse the value.

Fixes unidata/netcdf-java#1581

## Description of Changes

_Erase this and add a general description of changes, heads-up on any tricky parts, etc., here._

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
