### PR TITLE
Fix projection setOriginLon, setOriginLat

### DIFF
--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/AlbersEqualArea.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/AlbersEqualArea.java
@@ -302,7 +302,7 @@ public class AlbersEqualArea extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLon(double lon) {
-    _lon0 = lon0;
+    _lon0 = lon;
     lon0 = Math.toRadians(lon);
     precalculate();
   }
@@ -314,7 +314,7 @@ public class AlbersEqualArea extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLat(double lat) {
-    _lat0 = lat0;
+    _lat0 = lat;
     lat0 = Math.toRadians(lat);
     precalculate();
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertAzimuthalEqualArea.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/LambertAzimuthalEqualArea.java
@@ -200,7 +200,7 @@ public class LambertAzimuthalEqualArea extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLon(double lon) {
-    lon0Degrees = lon0;
+    lon0Degrees = lon;
     lon0 = Math.toRadians(lon);
     precalculate();
   }
@@ -212,7 +212,7 @@ public class LambertAzimuthalEqualArea extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLat(double lat) {
-    _lat0 = lat0;
+    _lat0 = lat;
     lat0 = Math.toRadians(lat);
     precalculate();
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Orthographic.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/Orthographic.java
@@ -157,7 +157,7 @@ public class Orthographic extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLon(double lon) {
-    lon0Degrees = lon0;
+    lon0Degrees = lon;
     lon0 = Math.toRadians(lon);
     precalculate();
   }
@@ -169,7 +169,7 @@ public class Orthographic extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLat(double lat) {
-    _lat0 = lat0;
+    _lat0 = lat;
     lat0 = Math.toRadians(lat);
     precalculate();
   }

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/TransverseMercator.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/TransverseMercator.java
@@ -179,7 +179,7 @@ public class TransverseMercator extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLat(double lat) {
-    _lat0 = lat0;
+    _lat0 = lat;
     lat0 = Math.toRadians(lat);
   }
 
@@ -190,7 +190,7 @@ public class TransverseMercator extends ProjectionImpl {
    */
   @Deprecated
   public void setTangentLon(double lon) {
-    _lon0 = lon0;
+    _lon0 = lon;
     lon0 = Math.toRadians(lon);
   }
 

--- a/cdm/core/src/main/java/ucar/unidata/geoloc/projection/VerticalPerspectiveView.java
+++ b/cdm/core/src/main/java/ucar/unidata/geoloc/projection/VerticalPerspectiveView.java
@@ -225,7 +225,7 @@ public class VerticalPerspectiveView extends ProjectionImpl {
    */
   @Deprecated
   public void setOriginLat(double lat) {
-    _lat0 = lat0;
+    _lat0 = lat;
     lat0 = Math.toRadians(lat);
     precalculate();
   }


### PR DESCRIPTION
## Description of Changes

Thanks to a report from SSEC, fix bugs in various projection setOriginLon, setOriginLat methods. The bug is that the supplied lat/lon values to the functions were not being used, and the values being used (which were in radians), were giving really odd results.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
