### PR TITLE
fallback for truncated ListObjects V1 responses without NextMarker

### DIFF
--- a/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
+++ b/cdm/s3/src/main/java/thredds/filesystem/s3/ControllerS3.java
@@ -331,6 +331,12 @@ public class ControllerS3 implements MController {
             // The response was truncated. Make a new request using the next continuation token to pick up where we
             // left off.
             String continuationToken = useV2 ? responseV2.nextContinuationToken() : responseV1.nextMarker();
+
+            // OpenStack Swift may omit NextMarker for a truncated V1 response.
+            // Continue from the final key returned in the current page.
+            if (!useV2 && continuationToken == null && responseV1.isTruncated() && !objects.isEmpty()) {
+              continuationToken = objects.get(objects.size() - 1).key();
+            }
             updateObjectList(continuationToken);
           }
         }


### PR DESCRIPTION
## Description of Changes

For non-AWS endpoints, netCDF-Java 5.9.1 selected ListObjects V1.

The original pagination logic was:
```
String continuationToken =
    useV2
        ? responseV2.nextContinuationToken()
        : responseV1.nextMarker();
updateObjectList(continuationToken);
```
A direct AWS SDK ListObjects V1 request for Swift returned:
```
count=1000
isTruncated=true
nextMarker=null
```
The page was valid and truncated, but Swift did not return NextMarker, therefore netCDF-Java repeatedly requested the first page.

changed that part to add a fallback for truncated ListObjects V1 responses without NextMarker

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
