### PR TITLE
Use encoded file URI when reading persisted NcML aggregation cache

### DIFF
--- a/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationExisting.java
+++ b/cdm/core/src/main/java/ucar/nc2/internal/ncml/AggregationExisting.java
@@ -321,7 +321,7 @@ class AggregationExisting extends AggregationOuter {
 
     Element aggElem;
     try {
-      aggElem = ucar.nc2.util.xml.Parse.readRootElement("file:" + cacheFile.getPath());
+      aggElem = ucar.nc2.util.xml.Parse.readRootElement(cacheFile.toURI().toString());
     } catch (IOException e) {
       if (debugCache) {
         System.out.println(" No cache for " + cacheName + " - " + e.getMessage());


### PR DESCRIPTION
## Description of Changes

The generated cache filename is:
```
/path/test1.ncml#delimiter
```
This is a valid Linux filename.
`AggregationExisting.persistRead()` parsed the cache using:
```
Parse.readRootElement("file:" + cacheFile.getPath())
```
For a URL such as `file:/path/test1.ncml#delimiter` the #delimiter portion is interpreted as a URI fragment.

The XML parser therefore attempted to open `/path/test1.ncml` instead of `/path/test1.ncml#delimiter`
The resulting IOException was caught and persistRead() returned silently.

replaced that part with `Parse.readRootElement(cacheFile.toURI().toString())`
`File.toURI()` encodes the literal # as %23.

The resulting URI refers to the real file:
`test1.ncml%23delimiter`

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
