### PR TITLE
Add support for template 3.33

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Gds.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2Gds.java
@@ -52,6 +52,9 @@ public abstract class Grib2Gds {
       case 30:
         result = new LambertConformal(data, 30);
         break;
+      case 33:
+        result = new LambertConformalWithModellingSubdomains(data, 33);
+        break;
       case 31:
         result = new AlbersEqualArea(data);
         break;
@@ -1312,6 +1315,27 @@ public abstract class Grib2Gds {
       f.format("    end at latlon= %s%n", endLL);
     }
 
+  }
+
+  /*
+   * Template 3.33 (Grid definition template 3.33 - Lambert Conformal with Modelling Subdomains)
+   * 15-81: Same as grid definition template 3.30
+   * 82–85 (4): Nux – size of model forecast subdomain in x–direction (number of grid points)
+   * 86–89 (4): Ncx – width of coupling area within forecast domain in x–direction (number of grid points)
+   * 90–93 (4): Nuy – size of model forecast subdomain in y–direction (number of grid points)
+   * 94–97 (4): Ncy – width of coupling area within forecast domain in y–direction (number of grid points)
+   */
+  public static class LambertConformalWithModellingSubdomains extends LambertConformal {
+    final int nux, ncx, nuy, ncy;
+
+    LambertConformalWithModellingSubdomains(byte[] data, int template) {
+      super(data, template);
+
+      nux = getOctet4(82);
+      ncx = getOctet4(86);
+      nuy = getOctet4(90);
+      ncy = getOctet4(94);
+    }
   }
 
   /*


### PR DESCRIPTION
## Description of Changes

Add support for grib files using grid definition template 3.33 (https://library.wmo.int/viewer/35625/download?file=WMO-306-v-I-2-2025_en.pdf&type=pdf&navigator=1 page 40.

GDS template 3.33 is the same as 3.30 except 4 additional values (nux, ncx, nuy and ncy).

I know of no public grib files that use 3.33 yet, so testing was done internally - and as I understand it, these 4 values are only used to be able to place the grib file in a larger context (so not used .

But even if those values are not used, parsing still fails with "Unsupported GDS type = 33" - therefore this PR.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [X] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
