### PR TITLE
Expose `Grib2JpegDecoder`

### DIFF
--- a/grib/src/main/java/ucar/nc2/grib/grib2/Grib2JpegDecoder.java
+++ b/grib/src/main/java/ucar/nc2/grib/grib2/Grib2JpegDecoder.java
@@ -69,7 +69,7 @@ public class Grib2JpegDecoder {
    * @throws IllegalArgumentException If 'argv' is empty
    * @see Grib2JpegDecoder#getExitCode
    */
-  Grib2JpegDecoder(int nbits, boolean debug) {
+  public Grib2JpegDecoder(int nbits, boolean debug) {
     this.rate = nbits;
     this.debug = debug;
 


### PR DESCRIPTION
## Description of Changes

- Change `Grib2JpegDecoder` constructor to public access modifier

Exposing `Grib2JpegDecoder` constructor could help applications to extract data section in JPEG-2000 format directly.
Also according to this documentation (https://docs.unidata.ucar.edu/netcdf-java/4.6/javadocAll/index.html?ucar/nc2/grib/grib2/Grib2JpegDecoder.html) it is expected to be a public method.
Please let me know if I'm missing something.
Thank you.

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [ ] Link to any issues that the PR addresses
- [ ] Add labels
- [ ] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [ ] Make sure GitHub tests pass
- [ ] Mark PR as "Ready for Review"
