### PR TITLE
Implement getDataAsByteBuffer(ByteOrder order) for non-integral array classes

### DIFF
--- a/cdm/core/src/main/java/ucar/ma2/ArrayByte.java
+++ b/cdm/core/src/main/java/ucar/ma2/ArrayByte.java
@@ -1,7 +1,8 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
@@ -120,8 +121,11 @@ public class ArrayByte extends Array {
   }
 
   @Override
-  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {// order irrelevant here
-    return ByteBuffer.wrap((byte[]) get1DJavaArray(getDataType()));
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
+    ByteBuffer bb = ByteBuffer.wrap((byte[]) get1DJavaArray(getDataType()));
+    if (order != null)
+      bb.order(order);
+    return bb;
   }
 
   /**

--- a/cdm/core/src/main/java/ucar/ma2/ArrayChar.java
+++ b/cdm/core/src/main/java/ucar/ma2/ArrayChar.java
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Iterator;
 
 /**
@@ -137,10 +139,16 @@ public class ArrayChar extends Array implements Iterable<String> {
    */
   @Override
   public ByteBuffer getDataAsByteBuffer() {
-    ByteBuffer bb = ByteBuffer.allocate((int) getSize());
-    resetLocalIterator();
-    while (hasNext())
-      bb.put(nextByte());
+    return getDataAsByteBuffer(null);
+  }
+
+  @Override
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
+    ByteBuffer bb = super.getDataAsByteBuffer((int) getSize(), order);
+    char[] ja = (char[]) get1DJavaArray(DataType.CHAR);
+    for (char c : ja) {
+      bb.put((byte) c);
+    }
     return bb;
   }
 

--- a/cdm/core/src/main/java/ucar/ma2/ArrayDouble.java
+++ b/cdm/core/src/main/java/ucar/ma2/ArrayDouble.java
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
 
 /**
@@ -115,9 +117,14 @@ public class ArrayDouble extends Array {
 
   @Override
   public ByteBuffer getDataAsByteBuffer() {
-    ByteBuffer bb = ByteBuffer.allocate((int) (8 * getSize()));
+    return getDataAsByteBuffer(null);
+  }
+
+  @Override
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
+    ByteBuffer bb = super.getDataAsByteBuffer((int) (8 * getSize()), order);
     DoubleBuffer ib = bb.asDoubleBuffer();
-    ib.put((double[]) get1DJavaArray(DataType.DOUBLE)); // make sure its in canonical order
+    ib.put((double[]) get1DJavaArray(DataType.DOUBLE));
     return bb;
   }
 

--- a/cdm/core/src/main/java/ucar/ma2/ArrayFloat.java
+++ b/cdm/core/src/main/java/ucar/ma2/ArrayFloat.java
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
 /**
@@ -118,9 +120,14 @@ public class ArrayFloat extends Array {
 
   @Override
   public ByteBuffer getDataAsByteBuffer() {
-    ByteBuffer bb = ByteBuffer.allocate((int) (4 * getSize()));
+    return getDataAsByteBuffer(null);
+  }
+
+  @Override
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
+    ByteBuffer bb = super.getDataAsByteBuffer((int) (4 * getSize()), order);
     FloatBuffer ib = bb.asFloatBuffer();
-    ib.put((float[]) get1DJavaArray(DataType.FLOAT)); // make sure its in canonical order
+    ib.put((float[]) get1DJavaArray(DataType.FLOAT));
     return bb;
   }
 

--- a/cdm/core/src/main/java/ucar/ma2/ArrayString.java
+++ b/cdm/core/src/main/java/ucar/ma2/ArrayString.java
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 1998-2018 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
+
 package ucar.ma2;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 
 /**
@@ -122,15 +124,21 @@ public class ArrayString extends Array {
 
   @Override
   public ByteBuffer getDataAsByteBuffer() {
+    return getDataAsByteBuffer(null);
+  }
+
+  @Override
+  public ByteBuffer getDataAsByteBuffer(ByteOrder order) {
     // Store strings as null terminated character sequences
+    Object[] ja = (Object[]) get1DJavaArray(DataType.STRING);
     int totalsize = 0;
-    for (String aStorage : storage)
-      totalsize += (aStorage.length() + 1); // 1 for null terminator
-    ByteBuffer bb = ByteBuffer.allocate(2 * totalsize);
+    for (Object s : ja)
+      totalsize += (((String) s).length() + 1); // 1 for null terminator
+    ByteBuffer bb = super.getDataAsByteBuffer(2 * totalsize, order);
     CharBuffer cb = bb.asCharBuffer();
     // Concatenate
-    for (String s : storage) {
-      cb.append(s);
+    for (Object s : ja) {
+      cb.append((String) s);
       cb.append('\0');
     }
     return bb;

--- a/cdm/core/src/test/java/ucar/ma2/TestArrayByteOrder.java
+++ b/cdm/core/src/test/java/ucar/ma2/TestArrayByteOrder.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.ma2;
+
+import static com.google.common.truth.Truth.assertThat;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
+import java.nio.CharBuffer;
+import org.junit.Test;
+
+public class TestArrayByteOrder {
+
+  @Test
+  public void testArrayByte() {
+    byte[] data = {1, 2, 3, 4};
+    ArrayByte a = (ArrayByte) Array.factory(DataType.BYTE, new int[] {4}, data);
+
+    // Big Endian
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    for (int i = 0; i < 4; i++) {
+      assertThat(bb.get(i)).isEqualTo(data[i]);
+    }
+
+    // Little Endian
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    for (int i = 0; i < 4; i++) {
+      assertThat(bb.get(i)).isEqualTo(data[i]);
+    }
+  }
+
+  @Test
+  public void testArrayShort() {
+    short[] data = {1, 2, 3, 4};
+    ArrayShort a = (ArrayShort) Array.factory(DataType.SHORT, new int[] {4}, data);
+
+    // Big Endian
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    ShortBuffer sb = bb.asShortBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(sb.get(i)).isEqualTo(data[i]);
+    }
+
+    // Little Endian
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    sb = bb.asShortBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(sb.get(i)).isEqualTo(data[i]);
+    }
+  }
+
+  @Test
+  public void testArrayInt() {
+    int[] data = {1, 2, 3, 4};
+    ArrayInt a = (ArrayInt) Array.factory(DataType.INT, new int[] {4}, data);
+
+    // Big Endian
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    IntBuffer ib = bb.asIntBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(ib.get(i)).isEqualTo(data[i]);
+    }
+
+    // Little Endian
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    ib = bb.asIntBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(ib.get(i)).isEqualTo(data[i]);
+    }
+  }
+
+  @Test
+  public void testArrayLong() {
+    long[] data = {1L, 2L, 3L, 4L};
+    ArrayLong a = (ArrayLong) Array.factory(DataType.LONG, new int[] {4}, data);
+
+    // Big Endian
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    LongBuffer lb = bb.asLongBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(lb.get(i)).isEqualTo(data[i]);
+    }
+
+    // Little Endian
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    lb = bb.asLongBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(lb.get(i)).isEqualTo(data[i]);
+    }
+  }
+
+  @Test
+  public void testArrayDouble() {
+    double[] data = {1.0, 2.0, 3.0, 4.0};
+    ArrayDouble a = (ArrayDouble) Array.factory(DataType.DOUBLE, new int[] {4}, data);
+
+    // Big Endian
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    DoubleBuffer db = bb.asDoubleBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(db.get(i)).isEqualTo(data[i]);
+    }
+
+    // Little Endian
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    db = bb.asDoubleBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(db.get(i)).isEqualTo(data[i]);
+    }
+  }
+
+  @Test
+  public void testArrayFloat() {
+    float[] data = {1.0f, 2.0f, 3.0f, 4.0f};
+    ArrayFloat a = (ArrayFloat) Array.factory(DataType.FLOAT, new int[] {4}, data);
+
+    // Big Endian
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    FloatBuffer fb = bb.asFloatBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(fb.get(i)).isEqualTo(data[i]);
+    }
+
+    // Little Endian
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    fb = bb.asFloatBuffer();
+    for (int i = 0; i < 4; i++) {
+      assertThat(fb.get(i)).isEqualTo(data[i]);
+    }
+  }
+
+  @Test
+  public void testArrayChar() {
+    char[] data = {'a', 'b', 'c', 'd'};
+    ArrayChar a = (ArrayChar) Array.factory(DataType.CHAR, new int[] {4}, data);
+
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    // ByteOrder is irrelevant for single bytes, but we check if it's set
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    for (int i = 0; i < 4; i++) {
+      assertThat(bb.get(i)).isEqualTo((byte) data[i]);
+    }
+
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    for (int i = 0; i < 4; i++) {
+      assertThat(bb.get(i)).isEqualTo((byte) data[i]);
+    }
+  }
+
+  @Test
+  public void testArrayString() {
+    String[] data = {"one", "two", "three"};
+    ArrayString a = ArrayString.factory(Index.factory(new int[] {3}), data);
+
+    ByteBuffer bb = a.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
+    CharBuffer cb = bb.asCharBuffer();
+    StringBuilder sb = new StringBuilder();
+    for (String s : data) {
+      sb.append(s).append('\0');
+    }
+    assertThat(cb.toString()).isEqualTo(sb.toString());
+
+    bb = a.getDataAsByteBuffer(ByteOrder.LITTLE_ENDIAN);
+    assertThat(bb.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+    cb = bb.asCharBuffer();
+    assertThat(cb.toString()).isEqualTo(sb.toString());
+  }
+
+  @Test
+  public void testByteSectionByteBuffer() throws InvalidRangeException {
+    byte[] data = {1, 2, 3, 4};
+    ArrayByte a = (ArrayByte) Array.factory(DataType.BYTE, new int[] {4}, data);
+    ArrayByte section = (ArrayByte) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.limit()).isEqualTo(2 * 1);
+    assertThat(bb.get(0)).isEqualTo((byte) 2);
+    assertThat(bb.get(1)).isEqualTo((byte) 3);
+  }
+
+  @Test
+  public void testShortSectionByteBuffer() throws InvalidRangeException {
+    short[] data = {1, 2, 3, 4};
+    ArrayShort a = (ArrayShort) Array.factory(DataType.SHORT, new int[] {4}, data);
+    ArrayShort section = (ArrayShort) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.limit()).isEqualTo(2 * 2);
+    ShortBuffer sb = bb.asShortBuffer();
+    assertThat(sb.get(0)).isEqualTo((short) 2);
+    assertThat(sb.get(1)).isEqualTo((short) 3);
+  }
+
+  @Test
+  public void testIntSectionByteBuffer() throws InvalidRangeException {
+    int[] data = {1, 2, 3, 4};
+    ArrayInt a = (ArrayInt) Array.factory(DataType.INT, new int[] {4}, data);
+    ArrayInt section = (ArrayInt) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.limit()).isEqualTo(2 * 4);
+    IntBuffer ib = bb.asIntBuffer();
+    assertThat(ib.get(0)).isEqualTo(2);
+    assertThat(ib.get(1)).isEqualTo(3);
+  }
+
+  @Test
+  public void testLongSectionByteBuffer() throws InvalidRangeException {
+    long[] data = {1L, 2L, 3L, 4L};
+    ArrayLong a = (ArrayLong) Array.factory(DataType.LONG, new int[] {4}, data);
+    ArrayLong section = (ArrayLong) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.limit()).isEqualTo(2 * 8);
+    LongBuffer lb = bb.asLongBuffer();
+    assertThat(lb.get(0)).isEqualTo(2L);
+    assertThat(lb.get(1)).isEqualTo(3L);
+  }
+
+  @Test
+  public void testFloatSectionByteBuffer() throws InvalidRangeException {
+    float[] data = {1.0f, 2.0f, 3.0f, 4.0f};
+    ArrayFloat a = (ArrayFloat) Array.factory(DataType.FLOAT, new int[] {4}, data);
+    ArrayFloat section = (ArrayFloat) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.limit()).isEqualTo(2 * 4);
+    FloatBuffer fb = bb.asFloatBuffer();
+    assertThat(fb.get(0)).isEqualTo(2.0f);
+    assertThat(fb.get(1)).isEqualTo(3.0f);
+  }
+
+  @Test
+  public void testDoubleSectionByteBuffer() throws InvalidRangeException {
+    double[] data = {1.0, 2.0, 3.0, 4.0};
+    ArrayDouble a = (ArrayDouble) Array.factory(DataType.DOUBLE, new int[] {4}, data);
+    ArrayDouble section = (ArrayDouble) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.limit()).isEqualTo(2 * 8);
+    DoubleBuffer db = bb.asDoubleBuffer();
+    assertThat(db.get(0)).isEqualTo(2.0);
+    assertThat(db.get(1)).isEqualTo(3.0);
+  }
+
+  @Test
+  public void testCharSectionByteBuffer() throws InvalidRangeException {
+    char[] data = {'a', 'b', 'c', 'd'};
+    ArrayChar a = (ArrayChar) Array.factory(DataType.CHAR, new int[] {4}, data);
+    ArrayChar section = (ArrayChar) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    assertThat(bb.limit()).isEqualTo(2 * 1);
+    assertThat(bb.get(0)).isEqualTo((byte) 'b');
+    assertThat(bb.get(1)).isEqualTo((byte) 'c');
+  }
+
+  @Test
+  public void testStringSectionByteBuffer() throws InvalidRangeException {
+    String[] data = {"one", "two", "three", "four"};
+    ArrayString a = ArrayString.factory(Index.factory(new int[] {4}), data);
+    ArrayString section = (ArrayString) a.section(new int[] {1}, new int[] {2});
+
+    ByteBuffer bb = section.getDataAsByteBuffer(ByteOrder.BIG_ENDIAN);
+    CharBuffer cb = bb.asCharBuffer();
+    assertThat(cb.toString()).isEqualTo("two\0three\0");
+  }
+}


### PR DESCRIPTION
## Description of Changes

Implement getDataAsByteBuffer(ByteOrder order) for non-integral array classes
    
Add tests for getDataAsByteBuffer. Also, fix bug when getting a section of an ArrayString.
    
Fixes Unidata/netcdf-java#1592

## PR Checklist
<!-- This will become an interactive checklist once the PR is opened -->
- [x] Link to any issues that the PR addresses
- [x] Add labels
- [x] Open as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
       until ready for review
- [x] Make sure GitHub tests pass
- [x] Mark PR as "Ready for Review"
